### PR TITLE
feat: Windows port — cross-platform path normalisation and CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,24 +3,66 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
-    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'skills/**'
+      - 'contrib/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
       - uses: Swatinem/rust-cache@v2
-      - name: Install tools
-        run: sudo apt-get install -y ripgrep fd-find
-      - run: cargo fmt --check
-      - run: cargo test
-      - run: cargo clippy -- -D warnings
+
+      - name: Install runtime tools (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep fd-find
+          sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
+
+      - name: Install runtime tools (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ripgrep fd
+
+      - name: Install runtime tools (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install -y --no-progress ripgrep fd
+          Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'
+
+      - name: rustfmt
+        run: cargo fmt --all -- --check
+
+      - name: clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: test
+        run: cargo test --all-features --no-fail-fast
 
   build-sidecar-jar:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,22 @@ jobs:
           npx @vscode/vsce package --no-dependencies --target darwin-arm64 -o ../../kotlin-lsp-darwin-arm64-${GITHUB_REF_NAME}.vsix
           rm -rf server
 
+          # win32-x64 (no bundled sidecar yet — sidecar not yet cross-compiled for Windows)
+          mkdir -p server
+          unzip -j "../../artifacts/kotlin-lsp-windows-x86_64/kotlin-lsp-windows-x86_64.zip" \
+              -d server/
+          mv server/kotlin-lsp-windows-x86_64.exe server/kotlin-lsp.exe
+          npx @vscode/vsce package --no-dependencies --target win32-x64 -o ../../kotlin-lsp-win32-x64-${GITHUB_REF_NAME}.vsix
+          rm -rf server
+
+          # win32-arm64
+          mkdir -p server
+          unzip -j "../../artifacts/kotlin-lsp-windows-aarch64/kotlin-lsp-windows-aarch64.zip" \
+              -d server/
+          mv server/kotlin-lsp-windows-aarch64.exe server/kotlin-lsp.exe
+          npx @vscode/vsce package --no-dependencies --target win32-arm64 -o ../../kotlin-lsp-win32-arm64-${GITHUB_REF_NAME}.vsix
+          rm -rf server
+
       - uses: actions/upload-artifact@v4
         with:
           name: vsix-packages
@@ -254,6 +270,13 @@ jobs:
           done
 
           cp artifacts/vsix-packages/*.vsix release/
+
+          # Windows: copy .zip files directly — no combined tarball since sidecar not yet built for Windows.
+          for win_asset in windows-x86_64 windows-aarch64; do
+            if [ -f "artifacts/kotlin-lsp-${win_asset}/kotlin-lsp-${win_asset}.zip" ]; then
+              cp "artifacts/kotlin-lsp-${win_asset}/kotlin-lsp-${win_asset}.zip" release/
+            fi
+          done
 
           # SHA256 checksums for all release files (required by aqua-registry, mise, etc.)
           cd release && sha256sum * > sha256sums.txt && cd ..

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,14 @@ jobs:
             os: macos-14
             binary: kotlin-lsp
             asset: kotlin-lsp-darwin-aarch64
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            binary: kotlin-lsp.exe
+            asset: kotlin-lsp-windows-x86_64
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+            binary: kotlin-lsp.exe
+            asset: kotlin-lsp-windows-aarch64
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -52,17 +60,29 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Package binary
+      - name: Package binary (Unix)
+        if: runner.os != 'Windows'
         run: |
           mkdir -p dist
           cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/${{ matrix.asset }}
           chmod +x dist/${{ matrix.asset }}
           tar -czf dist/${{ matrix.asset }}.tar.gz -C dist ${{ matrix.asset }}
 
+      - name: Package binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/${{ matrix.binary }}" "dist/${{ matrix.asset }}.exe"
+          Compress-Archive -Path "dist/${{ matrix.asset }}.exe" -DestinationPath "dist/${{ matrix.asset }}.zip"
+
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset }}
-          path: dist/${{ matrix.asset }}.tar.gz
+          path: |
+            dist/${{ matrix.asset }}.tar.gz
+            dist/${{ matrix.asset }}.zip
+          if-no-files-found: ignore
 
   build-sidecar:
     strategy:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ cargo install kotlin-lsp
 **One-liner (Linux / macOS)** — installs both `kotlin-lsp` and the native JAR indexer:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.sh | bash
+```
+
+**One-liner (Windows, PowerShell)** — installs both `kotlin-lsp.exe` and `kotlin-jar-indexer.exe`:
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.ps1 | iex
 ```
 
 **cargo-binstall** — downloads the pre-built binary (no compilation):

--- a/contrib/vscode/extension.js
+++ b/contrib/vscode/extension.js
@@ -11,7 +11,9 @@ function findServerBinary(context) {
   if (configured) return configured;
 
   // 2. Bundled binary in platform-specific .vsix
-  const bundled = path.join(context.extensionPath, "server", "kotlin-lsp");
+  //    On Windows the binary is packaged as kotlin-lsp.exe; on Unix it has no extension.
+  const ext = process.platform === "win32" ? ".exe" : "";
+  const bundled = path.join(context.extensionPath, "server", `kotlin-lsp${ext}`);
   if (fs.existsSync(bundled)) return bundled;
 
   // 3. Fall back to PATH

--- a/install.ps1
+++ b/install.ps1
@@ -135,16 +135,10 @@ try {
 # ---- PATH hint ----
 $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "User")
 if ($machinePath -notlike "*$Prefix*") {
-    Write-Warn "$Prefix is not in your PATH. Add it with:"
+    Write-Warn "$Prefix is not in your PATH."
+    Write-Host "  To add it permanently, run in a new terminal:"
     Write-Host "  [System.Environment]::SetEnvironmentVariable('PATH', `"$Prefix;`$([System.Environment]::GetEnvironmentVariable('PATH','User'))`", 'User')"
     Write-Host ""
-    # Optionally auto-add to User PATH
-    $add = Read-Host "Add '$Prefix' to your User PATH now? [y/N]"
-    if ($add -ieq "y") {
-        $newPath = "$Prefix;$machinePath"
-        [System.Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
-        Write-Ok "PATH updated — restart your terminal for changes to take effect"
-    }
 }
 
 Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,153 @@
+# install.ps1 — download and install kotlin-lsp + kotlin-jar-indexer on Windows
+#
+# Usage (run in PowerShell as Administrator or a user with write access to prefix):
+#   iwr -useb https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.ps1 | iex
+#   iex "& { $(iwr -useb https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.ps1) } --Version v0.19.0"
+#
+# Parameters:
+#   -Version    pin a specific release tag (default: latest)
+#   -Prefix     install directory        (default: $env:KOTLIN_LSP_PREFIX or "$env:LOCALAPPDATA\kotlin-lsp\bin")
+#   -NoSidecar  skip kotlin-jar-indexer installation
+[CmdletBinding()]
+param(
+    [string] $Version  = $env:KOTLIN_LSP_VERSION,
+    [string] $Prefix   = $env:KOTLIN_LSP_PREFIX,
+    [switch] $NoSidecar
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$Repo = "Hessesian/kotlin-lsp"
+
+# ---- helpers ----
+function Write-Info  { param($msg) Write-Host ":: $msg" -ForegroundColor Cyan }
+function Write-Ok    { param($msg) Write-Host "OK $msg" -ForegroundColor Green }
+function Write-Err   { param($msg) Write-Error "error: $msg" }
+function Write-Warn  { param($msg) Write-Host "! $msg"  -ForegroundColor Yellow }
+
+# ---- detect architecture ----
+$arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    "AMD64"   { "x86_64" }
+    "ARM64"   { "aarch64" }
+    default   { Write-Err "unsupported architecture: $env:PROCESSOR_ARCHITECTURE"; exit 1 }
+}
+$Platform = "windows-$arch"
+Write-Info "platform: $Platform"
+
+# ---- resolve version ----
+if (-not $Version) {
+    Write-Info "resolving latest release..."
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -ErrorAction Stop
+    $Version = $release.tag_name
+}
+if (-not $Version) { Write-Err "could not resolve version from GitHub API"; exit 1 }
+Write-Info "version: $Version"
+
+# ---- install prefix ----
+if (-not $Prefix) {
+    $Prefix = Join-Path $env:LOCALAPPDATA "kotlin-lsp\bin"
+}
+New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
+
+# ---- temp dir ----
+$TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "kotlin-lsp-install-$([System.IO.Path]::GetRandomFileName())"
+New-Item -ItemType Directory -Force -Path $TmpDir | Out-Null
+try {
+
+# ---- download sha256sums ----
+$SumsUrl = "https://github.com/$Repo/releases/download/$Version/sha256sums.txt"
+Write-Info "downloading sha256sums..."
+Invoke-WebRequest -Uri $SumsUrl -OutFile "$TmpDir\sha256sums.txt" -UseBasicParsing
+
+function Get-ExpectedHash {
+    param([string] $filename)
+    $lines = Get-Content "$TmpDir\sha256sums.txt"
+    foreach ($line in $lines) {
+        $parts = $line -split '\s+'
+        if ($parts.Count -ge 2 -and $parts[1].TrimStart('.').TrimStart('/') -eq $filename) {
+            return $parts[0].ToUpper()
+        }
+    }
+    return $null
+}
+
+function Install-Asset {
+    param([string] $asset)
+    $zipName = "$asset.zip"
+    $url     = "https://github.com/$Repo/releases/download/$Version/$zipName"
+
+    Write-Info "downloading $zipName..."
+    Invoke-WebRequest -Uri $url -OutFile "$TmpDir\$zipName" -UseBasicParsing
+
+    # Verify checksum
+    $expected = Get-ExpectedHash $zipName
+    if (-not $expected) { Write-Err "$zipName not found in sha256sums.txt"; exit 1 }
+    $actual = (Get-FileHash "$TmpDir\$zipName" -Algorithm SHA256).Hash.ToUpper()
+    if ($actual -ne $expected) {
+        Write-Err "checksum mismatch for $zipName`n  expected: $expected`n  got: $actual"
+        exit 1
+    }
+    Write-Ok "checksum verified"
+
+    Expand-Archive -Path "$TmpDir\$zipName" -DestinationPath "$TmpDir\$asset" -Force
+}
+
+Install-Asset "kotlin-lsp-$Platform"
+if (-not $NoSidecar) {
+    Install-Asset "kotlin-jar-indexer-$Platform"
+}
+
+# ---- copy binaries to prefix ----
+function Copy-Binary {
+    param([string] $name, [string] $assetDir)
+    $src = Join-Path $TmpDir "$assetDir\$name.exe"
+    if (-not (Test-Path $src)) {
+        # some archives place binaries at the root of the zip
+        $src = Join-Path $TmpDir "$assetDir\$name"
+        if (-not (Test-Path $src)) {
+            Write-Err "binary '$name' not found in archive under $assetDir"
+            exit 1
+        }
+    }
+    $dst = Join-Path $Prefix "$name.exe"
+    Copy-Item -Force -Path $src -Destination $dst
+    Write-Ok "$name.exe -> $dst"
+}
+
+Copy-Binary "kotlin-lsp"         "kotlin-lsp-$Platform"
+if (-not $NoSidecar) {
+    Copy-Binary "kotlin-jar-indexer" "kotlin-jar-indexer-$Platform"
+}
+
+} finally {
+    Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
+}
+
+# ---- verify ----
+$binary = Join-Path $Prefix "kotlin-lsp.exe"
+try {
+    $ver = & $binary --version 2>&1
+    Write-Info $ver
+} catch {
+    Write-Warn "installed but could not run --version: $_"
+}
+
+# ---- PATH hint ----
+$machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "User")
+if ($machinePath -notlike "*$Prefix*") {
+    Write-Warn "$Prefix is not in your PATH. Add it with:"
+    Write-Host "  [System.Environment]::SetEnvironmentVariable('PATH', `"$Prefix;`$([System.Environment]::GetEnvironmentVariable('PATH','User'))`", 'User')"
+    Write-Host ""
+    # Optionally auto-add to User PATH
+    $add = Read-Host "Add '$Prefix' to your User PATH now? [y/N]"
+    if ($add -ieq "y") {
+        $newPath = "$Prefix;$machinePath"
+        [System.Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+        Write-Ok "PATH updated — restart your terminal for changes to take effect"
+    }
+}
+
+Write-Host ""
+Write-Host "Next: wire up your editor — see docs at"
+Write-Host "  https://github.com/$Repo#quick-start"
+Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,8 @@
 #
 # Environment variables:
 #   KOTLIN_LSP_VERSION   pin a version (e.g. v0.19.0). Default: latest release.
-#   KOTLIN_LSP_PREFIX    install directory. Default: $HOME/.local/bin
+#   KOTLIN_LSP_PREFIX    install directory. Default: ~/.cargo/bin (if exists), else ~/.local/bin
+#   INSTALL_DIR          alias for KOTLIN_LSP_PREFIX (backward compat)
 #
 # For Windows use install.ps1:
 #   iwr -useb https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.ps1 | iex
@@ -15,7 +16,15 @@
 set -euo pipefail
 
 REPO="Hessesian/kotlin-lsp"
-PREFIX="${KOTLIN_LSP_PREFIX:-$HOME/.local/bin}"
+
+# Resolve prefix: explicit env > INSTALL_DIR alias > cargo/bin if present > local/bin
+_resolve_prefix() {
+  if [ -n "${KOTLIN_LSP_PREFIX:-}" ]; then echo "$KOTLIN_LSP_PREFIX"; return; fi
+  if [ -n "${INSTALL_DIR:-}" ];       then echo "$INSTALL_DIR";        return; fi
+  if [ -d "$HOME/.cargo/bin" ];       then echo "$HOME/.cargo/bin";    return; fi
+  echo "$HOME/.local/bin"
+}
+PREFIX="$(_resolve_prefix)"
 
 err()  { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
 info() { printf '\033[36m::\033[0m %s\n' "$*"; }

--- a/install.sh
+++ b/install.sh
@@ -1,106 +1,158 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # install.sh — download and install kotlin-lsp + kotlin-jar-indexer (native sidecar)
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.sh | sh -s -- --version v0.18.0
-#   INSTALL_DIR=/usr/local/bin sh install.sh
+#   curl -fsSL https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.sh | bash -s -- --version v0.19.0
+#
+# Environment variables:
+#   KOTLIN_LSP_VERSION   pin a version (e.g. v0.19.0). Default: latest release.
+#   KOTLIN_LSP_PREFIX    install directory. Default: $HOME/.local/bin
+#
+# For Windows use install.ps1:
+#   iwr -useb https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.ps1 | iex
 
-set -e
+set -euo pipefail
 
 REPO="Hessesian/kotlin-lsp"
-INSTALL_DIR="${INSTALL_DIR:-$HOME/.cargo/bin}"
+PREFIX="${KOTLIN_LSP_PREFIX:-$HOME/.local/bin}"
 
-# Parse --version flag
-VERSION=""
+err()  { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+info() { printf '\033[36m::\033[0m %s\n' "$*"; }
+ok()   { printf '\033[32m✓\033[0m %s\n' "$*"; }
+
+# Parse --version flag (also honoured via KOTLIN_LSP_VERSION env var).
+VERSION="${KOTLIN_LSP_VERSION:-}"
 while [ $# -gt 0 ]; do
   case "$1" in
     --version)
-      if [ -z "$2" ]; then
-        echo "Error: --version requires a value (e.g. --version v0.18.0)"; exit 1
-      fi
+      [ -n "${2:-}" ] || err "--version requires a value (e.g. --version v0.19.0)"
       VERSION="$2"; shift 2 ;;
-    *) echo "Unknown argument: $1"; exit 1 ;;
+    *) err "unknown argument: $1" ;;
   esac
 done
 
-# Detect platform
-OS="$(uname -s)"
-ARCH="$(uname -m)"
-
-case "$OS" in
-  Linux)  OS_NAME="linux"  ;;
-  Darwin) OS_NAME="darwin" ;;
-  *)      echo "Unsupported OS: $OS"; exit 1 ;;
+# ---- detect platform ----
+uname_s="$(uname -s)"
+uname_m="$(uname -m)"
+case "$uname_s" in
+  Linux)  os="linux" ;;
+  Darwin) os="darwin" ;;
+  *) err "unsupported OS: $uname_s (use install.ps1 on Windows)" ;;
 esac
-
-case "$ARCH" in
-  x86_64 | amd64) ARCH_NAME="x86_64"  ;;
-  aarch64 | arm64) ARCH_NAME="aarch64" ;;
-  *)               echo "Unsupported architecture: $ARCH"; exit 1 ;;
+case "$uname_m" in
+  x86_64|amd64)    arch="x86_64" ;;
+  aarch64|arm64)   arch="aarch64" ;;
+  *) err "unsupported architecture: $uname_m" ;;
 esac
+PLATFORM="${os}-${arch}"
+info "platform: ${PLATFORM}"
 
-PLATFORM="${OS_NAME}-${ARCH_NAME}"
+# ---- http helper ----
+http_get() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL --retry 3 "$@"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO- "$@"
+  else
+    err "need either curl or wget"
+  fi
+}
+http_download() {
+  local url="$1" dest="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fSL --retry 3 -o "$dest" "$url" \
+      || err "download failed: $url"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$dest" "$url" \
+      || err "download failed: $url"
+  else
+    err "need either curl or wget"
+  fi
+}
 
-# Resolve version
+# ---- resolve version ----
 if [ -z "$VERSION" ]; then
-  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+  VERSION="$(http_get "https://api.github.com/repos/${REPO}/releases/latest" \
     | grep '"tag_name"' | sed 's/.*"tag_name": *"\(.*\)".*/\1/')"
+  [ -n "$VERSION" ] || err "could not resolve latest version from GitHub API"
 fi
+info "version: ${VERSION}"
 
-echo "Installing kotlin-lsp ${VERSION} for ${PLATFORM} → ${INSTALL_DIR}"
-
-# Download combined tarball
-TARBALL="kotlin-lsp-${PLATFORM}.tar.gz"
-URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-echo "Downloading ${URL} ..."
-curl -fsSL --progress-bar "$URL" -o "${TMP}/${TARBALL}"
-
-# Verify SHA256 checksum
+# ---- download sha256sums ----
 SUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/sha256sums.txt"
-echo "Verifying checksum ..."
-curl -fsSL "$SUMS_URL" -o "${TMP}/sha256sums.txt"
-EXPECTED="$(grep " ${TARBALL}$" "${TMP}/sha256sums.txt" | awk '{print $1}')"
-if [ -z "$EXPECTED" ]; then
-  echo "Error: ${TARBALL} not found in sha256sums.txt"; exit 1
-fi
-if command -v sha256sum >/dev/null 2>&1; then
-  ACTUAL="$(sha256sum "${TMP}/${TARBALL}" | awk '{print $1}')"
-elif command -v shasum >/dev/null 2>&1; then
-  ACTUAL="$(shasum -a 256 "${TMP}/${TARBALL}" | awk '{print $1}')"
-else
-  echo "Error: neither sha256sum nor shasum is available"; exit 1
-fi
-if [ "$ACTUAL" != "$EXPECTED" ]; then
-  echo "Error: checksum mismatch for ${TARBALL}"; echo "  expected: $EXPECTED"; echo "  got:      $ACTUAL"; exit 1
-fi
-echo "  ✓ checksum OK"
+http_download "$SUMS_URL" "$TMP/sha256sums.txt"
 
-# Extract both binaries (named `kotlin-lsp` and `kotlin-jar-indexer` inside the archive)
-tar -xzf "${TMP}/${TARBALL}" -C "$TMP"
+# ---- download + verify each binary tarball ----
+install_tarball() {
+  local asset="$1"
+  local tarball="${asset}.tar.gz"
+  local url="https://github.com/${REPO}/releases/download/${VERSION}/${tarball}"
 
-# Install — fail fast if an expected binary is missing from the archive
-mkdir -p "$INSTALL_DIR"
-for bin in kotlin-lsp kotlin-jar-indexer; do
-  src="${TMP}/${bin}"
-  if [ ! -f "$src" ]; then
-    echo "Error: expected binary '${bin}' not found in archive"; exit 1
+  info "downloading ${tarball}"
+  http_download "$url" "$TMP/$tarball"
+
+  # Verify checksum
+  expected="$(grep " ${tarball}$" "$TMP/sha256sums.txt" | awk '{print $1}')"
+  [ -n "$expected" ] || err "${tarball} not found in sha256sums.txt"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$TMP/$tarball" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$TMP/$tarball" | awk '{print $1}')"
+  else
+    err "neither sha256sum nor shasum is available"
   fi
+  [ "$actual" = "$expected" ] || \
+    err "checksum mismatch for ${tarball}\n  expected: $expected\n  got: $actual"
+  ok "checksum verified"
+
+  tar -xzf "$TMP/$tarball" -C "$TMP"
+}
+
+install_tarball "kotlin-lsp-${PLATFORM}"
+install_tarball "kotlin-jar-indexer-${PLATFORM}"
+
+# ---- pick install prefix ----
+mkdir -p "$PREFIX" 2>/dev/null || true
+SUDO=""
+if [ ! -w "$PREFIX" ]; then
+  if [ -w /usr/local/bin ]; then
+    PREFIX="/usr/local/bin"
+  elif command -v sudo >/dev/null 2>&1; then
+    info "elevating to write to /usr/local/bin"
+    SUDO="sudo"
+    PREFIX="/usr/local/bin"
+  else
+    err "no writable install prefix; set KOTLIN_LSP_PREFIX or rerun with sudo"
+  fi
+fi
+
+# ---- install binaries ----
+for bin in kotlin-lsp kotlin-jar-indexer; do
+  src="$TMP/$bin"
+  [ -f "$src" ] || err "expected binary '$bin' not found in archive"
   chmod +x "$src"
-  mv "$src" "${INSTALL_DIR}/${bin}"
-  echo "  ✓ ${bin} → ${INSTALL_DIR}/${bin}"
+  ${SUDO} install -m 0755 "$src" "$PREFIX/$bin"
+  ok "${bin} → ${PREFIX}/${bin}"
 done
 
-# Verify
-if command -v kotlin-lsp >/dev/null 2>&1 || [ -x "${INSTALL_DIR}/kotlin-lsp" ]; then
-  echo ""
-  echo "Installation complete."
-  echo "Make sure ${INSTALL_DIR} is on your PATH."
-else
-  echo ""
-  echo "Installation complete. Add ${INSTALL_DIR} to your PATH:"
-  echo "  export PATH=\"\$PATH:${INSTALL_DIR}\""
-fi
+# ---- verify ----
+"$PREFIX/kotlin-lsp" --version >/dev/null 2>&1 \
+  || err "binary at $PREFIX/kotlin-lsp did not run — try \`$PREFIX/kotlin-lsp --version\`"
+info "$("$PREFIX/kotlin-lsp" --version)"
+
+# ---- PATH hint ----
+case ":${PATH:-}:" in
+  *":$PREFIX:"*) ;;
+  *)
+    printf '\n\033[33m!\033[0m %s is not in your PATH. Add it:\n' "$PREFIX"
+    printf '    echo '\''export PATH="%s:$PATH"'\'' >> ~/.zshrc\n' "$PREFIX"
+    printf '    echo '\''export PATH="%s:$PATH"'\'' >> ~/.bashrc\n\n' "$PREFIX"
+    ;;
+esac
+
+printf '\nNext: wire up your editor — see docs at\n  https://github.com/%s#quick-start\n\n' "$REPO"
+

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -973,7 +973,6 @@ class LoginPresenter {
 
     write(root, "IntroContract.kt", intro_src);
     write(root, "LoginContract.kt", login_src);
-    write(root, "IntroContract.kt", intro_src);
     write(root, "IntroPresenter.kt", intro_presenter_src);
     write(root, "LoginPresenter.kt", login_presenter_src);
     std::fs::write(root.join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -973,7 +973,7 @@ class LoginPresenter {
 
     write(root, "IntroContract.kt", intro_src);
     write(root, "LoginContract.kt", login_src);
-    let (_, intro_uri) = write(root, "IntroContract.kt", intro_src);
+    write(root, "IntroContract.kt", intro_src);
     write(root, "IntroPresenter.kt", intro_presenter_src);
     write(root, "LoginPresenter.kt", login_presenter_src);
     std::fs::write(root.join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -22,6 +22,7 @@ pub(crate) mod resolution;
 // Re-export pure helpers from submodules so existing callers within this file
 // and the inline test module (`use super::*`) continue to resolve them by name.
 #[cfg(test)]
+#[allow(unused_imports)]
 pub(crate) use self::infer::deps::TestDeps;
 #[allow(unused_imports)]
 pub(crate) use self::infer::{
@@ -515,6 +516,7 @@ impl Indexer {
     /// indexer.index_content(&uri("/src/Bar.kt"), "class Bar");  // Main
     /// ```
     #[cfg(test)]
+    #[allow(dead_code)] // test helper; not yet used but kept for future subtype tests
     pub(crate) fn for_test_with_library(library_prefix: &str) -> Self {
         let indexer = Self::new();
         if let Ok(mut raw) = indexer.source_paths_raw.write() {

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -33,7 +33,7 @@ use crate::StrExt;
 
 fn classify_source_set(uri: &str, source_paths: &[String]) -> SourceSet {
     for source_path in source_paths {
-        if uri.contains(source_path) || uri.starts_with(&format!("file://{}", source_path)) {
+        if uri.contains(source_path) {
             return SourceSet::Library;
         }
     }
@@ -129,11 +129,7 @@ fn strip_library_private_symbols(
 /// No side effects. Call [`Indexer::apply_contributions`] to commit.
 pub(crate) fn file_contributions(result: &FileIndexResult) -> FileContributions {
     let uri_str = result.uri.to_string();
-    let file_stem: Option<String> = result
-        .uri
-        .to_file_path()
-        .ok()
-        .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().into_owned()));
+    let file_stem = crate::path_util::file_stem_from_uri(&result.uri);
 
     let mut definitions: HashMap<String, Vec<Location>> = HashMap::new();
     let mut qualified: HashMap<String, Location> = HashMap::new();
@@ -206,10 +202,7 @@ pub(crate) fn file_contributions(result: &FileIndexResult) -> FileContributions 
 /// Pure: compute which keys to remove from each index map when `uri` is re-indexed.
 /// Requires the *old* `FileData` to know what the file previously contributed.
 pub(crate) fn stale_keys_for(uri: &Url, old_data: &FileData) -> StaleKeys {
-    let file_stem: Option<String> = uri
-        .to_file_path()
-        .ok()
-        .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().into_owned()));
+    let file_stem = crate::path_util::file_stem_from_uri(uri);
 
     let definition_names: Vec<String> = old_data.symbols.iter().map(|s| s.name.clone()).collect();
 
@@ -318,10 +311,7 @@ impl LibraryBatch {
                 );
             }
         } else {
-            let file_stem: Option<String> = uri
-                .to_file_path()
-                .ok()
-                .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().into_owned()));
+            let file_stem = crate::path_util::file_stem_from_uri(uri);
             for (key, range) in build_qualified_keys(&file_data, file_stem.as_deref()) {
                 self.qualified.insert(
                     key,
@@ -566,7 +556,9 @@ impl Indexer {
         let gen = self.workspace_root.generation();
         // Canonicalize so path.starts_with comparisons against absolute fd output work
         // even when workspace_root was passed as a relative path (e.g. ".").
-        let workspace_root = workspace_root.canonicalize().unwrap_or(workspace_root);
+        let workspace_root = crate::path_util::strip_unc_prefix(
+            workspace_root.canonicalize().unwrap_or(workspace_root),
+        );
         let source_paths = resolve_source_paths(&raw_paths, &workspace_root);
 
         // Load manifest only — cheap (just version + chunk_count, no file data).

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -25,6 +25,7 @@ use super::{FileContributions, Indexer, StaleKeys};
 use crate::indexer::cache::{build_qualified_keys, FileCacheEntry};
 use crate::indexer::discover::find_source_files_unconstrained;
 use crate::parser::parse_by_extension;
+use crate::path_util::to_forward_slash;
 use crate::resolver::symbols_from_uri_as_completions_pub;
 use crate::types::{
     ExtensionEntry, FileData, FileIndexResult, SourceSet, Visibility, WorkspaceIndexResult,
@@ -33,7 +34,8 @@ use crate::StrExt;
 
 fn classify_source_set(uri: &str, source_paths: &[String]) -> SourceSet {
     for source_path in source_paths {
-        if uri.contains(source_path) {
+        let normalized = to_forward_slash(std::path::Path::new(source_path));
+        if uri.contains(&normalized) {
             return SourceSet::Library;
         }
     }

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -230,7 +230,6 @@ pub(crate) fn stale_keys_for(uri: &Url, old_data: &FileData) -> StaleKeys {
 /// Bundles all six HashMap contributions and the library-URI list so that
 /// adding a new index field causes a compile error at `flush_into` rather
 /// than a silent miss at an arbitrary call site.
-
 // Test helper: pure function used only in test assertions.
 #[cfg(test)]
 pub(crate) fn build_bare_names(

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -85,7 +85,9 @@ fn status_cache_path() -> PathBuf {
 /// Uses a SHA-256 hash of the canonicalized root path as the directory name so
 /// equivalent roots always map to the same cache file regardless of symlinks.
 pub(crate) fn workspace_cache_path(root: &Path) -> PathBuf {
-    let canonical = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let canonical = crate::path_util::strip_unc_prefix(
+        std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf()),
+    );
     let root_hash = {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
@@ -245,7 +247,7 @@ pub(super) fn save_cache(
         let hash = content_hashes.get(uri_str).map(|h| *h).unwrap_or(0);
         if let Ok(url) = uri_str.parse::<Url>() {
             if let Ok(path) = url.to_file_path() {
-                let file_stem = path.file_stem().map(|s| s.to_string_lossy().into_owned());
+                let file_stem = crate::path_util::file_stem_from_uri(&url);
                 let meta = std::fs::metadata(&path);
                 let mtime = meta
                     .as_ref()

--- a/src/indexer/discover.rs
+++ b/src/indexer/discover.rs
@@ -108,11 +108,11 @@ fn walkdir_find(root: &Path, matcher: Option<&IgnoreMatcher>) -> Vec<PathBuf> {
             }
             if let Some(gs) = &user_glob_set {
                 let rel = path.strip_prefix(&root_owned).unwrap_or(path);
-                if gs.is_match(rel) {
+                if gs.is_match(crate::path_util::to_forward_slash(rel)) {
                     return false;
                 }
                 if let Some(name) = path.file_name() {
-                    if gs.is_match(Path::new(name)) {
+                    if gs.is_match(crate::path_util::to_forward_slash(Path::new(name))) {
                         return false;
                     }
                 }
@@ -132,7 +132,7 @@ fn walkdir_find(root: &Path, matcher: Option<&IgnoreMatcher>) -> Vec<PathBuf> {
                 if SOURCE_EXTENSIONS.contains(&ext) {
                     if let Some(gs) = &user_glob_set_files {
                         let rel = path.strip_prefix(&root_owned2).unwrap_or(path);
-                        if gs.is_match(rel) {
+                        if gs.is_match(crate::path_util::to_forward_slash(rel)) {
                             continue;
                         }
                     }

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -1981,7 +1981,7 @@ fn regression_jar_symbol_wrong_receiver_falls_back_to_text_path() {
     // propagated the unsubstituted generic param as the `it` type.
     let sig_src = "val users: List<User> = listOf()";
     let code_src = "users.forEach { it }";
-    let (u, idx, lines) = indexed_with_live("/t.kt", &sig_src, code_src);
+    let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
 
     // Insert a JAR forEach with a MISMATCHING receiver (PersistentList, not List).
     insert_fake_jar_symbol(

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -17,6 +17,7 @@ fn indexed(path: &str, src: &str) -> (Url, Indexer) {
 ///
 /// Uses the file base name (without extension) as a proxy for the class name,
 /// which matches the test convention of one class per file.
+#[allow(dead_code)] // test helper; not yet used but kept for subtype assertion tests
 fn sorted_subtype_names(idx: &Indexer, supertype: &str) -> Vec<String> {
     let mut names: Vec<_> = idx
         .subtypes

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -1875,6 +1875,7 @@ fn ignore_matcher_path_pattern_matches_relative() {
     assert!(!m.matches(Path::new("src/third-party-util.kt")));
 }
 
+#[cfg(unix)] // uses Unix absolute paths (/workspace); Windows paths have drive letters
 #[test]
 fn ignore_matcher_absolute_path_normalized() {
     let root = Path::new("/workspace");

--- a/src/inlay_hints_tests.rs
+++ b/src/inlay_hints_tests.rs
@@ -616,7 +616,7 @@ fn named_lambda_param_dotted_type_arg_preserved() {
 
     // Must NOT truncate to bare "DashboardInvestedContract"
     assert!(
-        !labels.iter().any(|l| *l == ": DashboardInvestedContract"),
+        !labels.contains(&": DashboardInvestedContract"),
         "hint must not drop .Effect suffix, got: {labels:?}"
     );
     // If a hint is shown it must be the full qualified name

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod inlay_hints;
 mod language;
 mod lines_ext;
 mod parser;
+mod path_util;
 mod queries;
 mod resolver;
 mod rg;
@@ -195,7 +196,7 @@ async fn async_main() {
             std::process::exit(1);
         }
         let idx = std::sync::Arc::new(indexer::Indexer::new());
-        let root = pb.canonicalize().unwrap_or(pb);
+        let root = crate::path_util::strip_unc_prefix(pb.canonicalize().unwrap_or(pb));
         println!("Indexing workspace: {}", root.display());
         std::sync::Arc::clone(&idx)
             .index_workspace_full(&root, std::sync::Arc::new(indexer::NoopReporter))

--- a/src/path_util.rs
+++ b/src/path_util.rs
@@ -1,0 +1,120 @@
+//! Cross-platform helpers for path/URI handling.
+//!
+//! Several places in the codebase need to match path strings (glob patterns,
+//! substring filters, qualified-key generation) in a way that doesn't depend
+//! on the host OS's separator. These helpers centralise that.
+
+use std::path::{Path, PathBuf};
+
+use tower_lsp::lsp_types::Url;
+
+/// Convert a `Path` to a `String` using `/` as the separator regardless of OS.
+///
+/// On Unix this is essentially `to_string_lossy().into_owned()`; on Windows
+/// it walks the path components and joins with `/`. Used wherever a path is
+/// fed into `globset` (which expects forward slashes) or compared against
+/// embedded forward-slash literals.
+pub(crate) fn to_forward_slash(path: &Path) -> String {
+    if !cfg!(windows) {
+        return path.to_string_lossy().into_owned();
+    }
+    // `Component::as_os_str()` returns `\` for RootDir on Windows, so we
+    // can't just join component strings. Walk the variants explicitly.
+    use std::path::Component;
+    let mut out = String::new();
+    for comp in path.components() {
+        match comp {
+            Component::Prefix(p) => {
+                // e.g. `C:` or `\\?\C:` — keep verbatim, no separator inserted.
+                out.push_str(&p.as_os_str().to_string_lossy());
+            }
+            Component::RootDir => {
+                // Absolute root — always emit a single forward slash.
+                if !out.ends_with('/') {
+                    out.push('/');
+                }
+            }
+            Component::CurDir => {
+                if out.is_empty() {
+                    out.push('.');
+                }
+            }
+            Component::ParentDir => {
+                if !out.is_empty() && !out.ends_with('/') {
+                    out.push('/');
+                }
+                out.push_str("..");
+            }
+            Component::Normal(n) => {
+                if !out.is_empty() && !out.ends_with('/') {
+                    out.push('/');
+                }
+                out.push_str(&n.to_string_lossy());
+            }
+        }
+    }
+    out
+}
+
+/// Strip the Windows long-path prefix (`\\?\`) from a `PathBuf` if present.
+///
+/// `Path::canonicalize` on Windows returns a path with the `\\?\` verbatim
+/// prefix, which `Url::from_file_path` happens to round-trip badly: the
+/// produced URL can't always be round-tripped back through `to_file_path`,
+/// and string comparisons against non-canonicalized paths fail. Strip the
+/// prefix when we know the rest is a valid drive-letter path.
+///
+/// No-op on non-Windows.
+pub(crate) fn strip_unc_prefix(path: PathBuf) -> PathBuf {
+    if cfg!(windows) {
+        let s = path.to_string_lossy();
+        if let Some(rest) = s.strip_prefix(r"\\?\") {
+            // Only strip when the remainder looks like a drive-letter path
+            // (`C:\…`). UNC server paths (`\\server\share\…`) get prefixed as
+            // `\\?\UNC\server\share\…` and need different handling, so we
+            // leave those alone.
+            if rest.len() >= 2
+                && rest.as_bytes()[1] == b':'
+                && rest.as_bytes()[0].is_ascii_alphabetic()
+            {
+                return PathBuf::from(rest);
+            }
+        }
+    }
+    path
+}
+
+/// Extract the file stem (basename without extension) from a `file://` URL.
+///
+/// Prefers `Url::to_file_path()` (which handles percent-decoding correctly)
+/// and falls back to URL-path parsing when that fails. The fallback matters
+/// on Windows: `Url::to_file_path` requires a drive letter, so URIs like
+/// `file:///pkg/Foo.kt` (no drive) return `Err`. The fallback still extracts
+/// the correct stem in that case.
+pub(crate) fn file_stem_from_uri(uri: &Url) -> Option<String> {
+    if let Ok(p) = uri.to_file_path() {
+        if let Some(stem) = p.file_stem() {
+            return Some(stem.to_string_lossy().into_owned());
+        }
+    }
+    let path = uri.path();
+    let last = path.rsplit('/').next()?;
+    if last.is_empty() {
+        return None;
+    }
+    let stem = match last.rfind('.') {
+        // `.gitignore`-style names start with a dot; treat as stem-only.
+        Some(0) => last,
+        Some(dot) => &last[..dot],
+        None => last,
+    };
+    if stem.is_empty() {
+        None
+    } else {
+        Some(stem.to_owned())
+    }
+}
+
+#[cfg(test)]
+#[path = "path_util_tests.rs"]
+mod tests;

--- a/src/path_util_tests.rs
+++ b/src/path_util_tests.rs
@@ -1,0 +1,79 @@
+//! Tests for `path_util`. The helpers are most interesting on Windows but
+//! must also behave correctly on Unix (where most local development happens).
+
+use super::*;
+
+#[test]
+fn forward_slash_unix_path_unchanged() {
+    let p = Path::new("/foo/bar/baz.kt");
+    assert_eq!(to_forward_slash(p), "/foo/bar/baz.kt");
+}
+
+#[test]
+fn forward_slash_relative_path() {
+    let p = Path::new("src/main/Foo.kt");
+    let s = to_forward_slash(p);
+    // On all platforms the result must use `/`.
+    assert!(!s.contains('\\'), "contains backslash: {s}");
+    assert!(s.ends_with("Foo.kt"));
+    assert!(s.contains("src") && s.contains("main"));
+}
+
+#[test]
+fn forward_slash_empty_path() {
+    assert_eq!(to_forward_slash(Path::new("")), "");
+}
+
+#[test]
+fn strip_unc_no_op_on_path_without_prefix() {
+    let p = PathBuf::from("/usr/local/bin");
+    assert_eq!(strip_unc_prefix(p.clone()), p);
+}
+
+#[cfg(windows)]
+#[test]
+fn strip_unc_drive_letter_path() {
+    let p = PathBuf::from(r"\\?\C:\Users\foo\bar.kt");
+    assert_eq!(strip_unc_prefix(p), PathBuf::from(r"C:\Users\foo\bar.kt"));
+}
+
+#[cfg(windows)]
+#[test]
+fn strip_unc_leaves_server_paths_alone() {
+    // \\?\UNC\server\share is structurally different; we don't try to rewrite it.
+    let p = PathBuf::from(r"\\?\UNC\server\share\file.kt");
+    assert_eq!(strip_unc_prefix(p.clone()), p);
+}
+
+#[test]
+fn stem_basic() {
+    let u = Url::parse("file:///pkg/Foo.kt").unwrap();
+    assert_eq!(file_stem_from_uri(&u).as_deref(), Some("Foo"));
+}
+
+#[test]
+fn stem_no_extension() {
+    let u = Url::parse("file:///pkg/README").unwrap();
+    assert_eq!(file_stem_from_uri(&u).as_deref(), Some("README"));
+}
+
+#[test]
+fn stem_dotfile_keeps_full_name() {
+    // `.gitignore` has no "extension" — the whole name is the stem.
+    let u = Url::parse("file:///root/.gitignore").unwrap();
+    assert_eq!(file_stem_from_uri(&u).as_deref(), Some(".gitignore"));
+}
+
+#[test]
+fn stem_windows_style_uri() {
+    // Drive-letter URI — should work on all platforms.
+    let u = Url::parse("file:///C:/pkg/Foo.kt").unwrap();
+    assert_eq!(file_stem_from_uri(&u).as_deref(), Some("Foo"));
+}
+
+#[test]
+fn stem_multiple_dots() {
+    let u = Url::parse("file:///pkg/Foo.bar.kt").unwrap();
+    // `rfind('.')` so only the last extension is stripped.
+    assert_eq!(file_stem_from_uri(&u).as_deref(), Some("Foo.bar"));
+}

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -99,7 +99,7 @@ impl IgnoreMatcher {
             // Normalize absolute paths that fall under the workspace root.
             let normalized = if Path::new(pat.as_str()).is_absolute() {
                 match Path::new(pat.as_str()).strip_prefix(root) {
-                    Ok(rel) => rel.to_string_lossy().into_owned(),
+                    Ok(rel) => crate::path_util::to_forward_slash(rel),
                     Err(_) => {
                         log::warn!("ignorePatterns: absolute path {:?} is not under workspace root, skipping", pat);
                         continue;
@@ -151,7 +151,8 @@ impl IgnoreMatcher {
 
     /// Returns `true` if `rel_path` (relative to workspace root) should be excluded.
     pub(crate) fn matches(&self, rel_path: &Path) -> bool {
-        self.glob_set.is_match(rel_path)
+        self.glob_set
+            .is_match(crate::path_util::to_forward_slash(rel_path))
     }
 
     /// Clone the Arc-wrapped glob set for use in `filter_entry` closures.
@@ -1521,11 +1522,10 @@ pub(crate) fn rg_find_method_overrides(
 /// paths when invoked with a relative root; callers that need relative-path
 /// support should use [`parse_rg_line_with_content_rooted`] instead).
 pub(crate) fn parse_rg_line(line: &str) -> Option<Location> {
-    // format: /abs/path/to/File.kt:line:col:content
-    let mut parts = line.splitn(4, ':');
-    let file = parts.next()?;
-    let line_num: u32 = parts.next()?.trim().parse().ok()?;
-    let col: u32 = parts.next()?.trim().parse().ok()?;
+    // Format: <abs path>:<line>:<col>:<content>
+    // On Windows the path starts with a drive letter (`C:\…`) whose colon
+    // would otherwise be treated as a field separator — splitter handles it.
+    let (file, line_num, col, _content) = split_rg_fields(line)?;
 
     let path = std::path::Path::new(file);
     // Silently skip if rg somehow gave us a relative path.
@@ -1539,6 +1539,34 @@ pub(crate) fn parse_rg_line(line: &str) -> Option<Location> {
         uri,
         range: Range::new(pos, pos),
     })
+}
+
+/// Parse `<path>:<line>:<col>:<content>` from a single rg output line.
+///
+/// Windows-aware: a leading `X:` drive prefix on the path is not treated as
+/// a field separator. Returns `None` if the line is malformed.
+fn split_rg_fields(line: &str) -> Option<(&str, u32, u32, &str)> {
+    // If the line starts with a Windows drive prefix (`X:` followed by `\` or
+    // `/`), advance past the colon so it isn't mistaken for the line-number
+    // separator.
+    let scan_from = if line.len() >= 3
+        && line.as_bytes()[0].is_ascii_alphabetic()
+        && line.as_bytes()[1] == b':'
+        && (line.as_bytes()[2] == b'\\' || line.as_bytes()[2] == b'/')
+    {
+        2 // skip the drive colon when looking for field separators
+    } else {
+        0
+    };
+
+    let rest = &line[scan_from..];
+    let mut parts = rest.splitn(4, ':');
+    let path_after = parts.next()?;
+    let line_num: u32 = parts.next()?.trim().parse().ok()?;
+    let col: u32 = parts.next()?.trim().parse().ok()?;
+    let content = parts.next().unwrap_or("");
+    let file = &line[..scan_from + path_after.len()];
+    Some((file, line_num, col, content))
 }
 
 // ─── Private helpers ─────────────────────────────────────────────────────────
@@ -1607,11 +1635,8 @@ pub(crate) fn rg_word_search(name: &str, root: &Path, source_paths: &[String]) -
 }
 
 fn parse_rg_line_with_content_rooted(line: &str, root: &Path) -> Option<(Location, String)> {
-    let mut parts = line.splitn(4, ':');
-    let file = parts.next()?;
-    let line_num: u32 = parts.next()?.trim().parse().ok()?;
-    let col: u32 = parts.next()?.trim().parse().ok()?;
-    let content = parts.next().unwrap_or("").to_string();
+    let (file, line_num, col, content) = split_rg_fields(line)?;
+    let content = content.to_string();
 
     let path = std::path::Path::new(file);
     let abs_path = if path.is_absolute() {

--- a/src/rg_tests.rs
+++ b/src/rg_tests.rs
@@ -400,7 +400,13 @@ fn rg_find_definition_filters_ignored_dirs() {
     let locs = rg_find_definition("MyClass", Some(root), &[], Some(&matcher));
     let files: Vec<String> = locs
         .iter()
-        .map(|l| l.uri.to_file_path().unwrap().to_string_lossy().into_owned())
+        .map(|l| {
+            l.uri
+                .to_file_path()
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
         .collect();
 
     assert!(
@@ -487,7 +493,13 @@ fn rg_find_definition_scoped_to_source_paths() {
     let locs = rg_find_definition("Foo", Some(root), &source_paths, None);
     let files: Vec<String> = locs
         .iter()
-        .map(|l| l.uri.to_file_path().unwrap().to_string_lossy().into_owned())
+        .map(|l| {
+            l.uri
+                .to_file_path()
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
         .collect();
 
     assert!(

--- a/src/rg_tests.rs
+++ b/src/rg_tests.rs
@@ -17,12 +17,24 @@ use crate::rg::{
 // ─── parse_rg_line ────────────────────────────────────────────────────────────
 
 #[test]
-fn rg_line_absolute_path_parsed() {
+fn parse_rg_line_basic() {
+    // needs a drive prefix on Windows
+    #[cfg(not(windows))]
     let line = "/home/user/project/Foo.kt:10:5:class Foo {";
+    #[cfg(windows)]
+    let line = r"C:\home\user\project\Foo.kt:10:5:class Foo {";
+
     let loc = parse_rg_line(line).unwrap();
     assert_eq!(loc.range.start.line, 9); // 1-indexed → 0-indexed
     assert_eq!(loc.range.start.character, 4);
+    #[cfg(not(windows))]
     assert_eq!(loc.uri.path(), "/home/user/project/Foo.kt");
+    #[cfg(windows)]
+    assert!(
+        loc.uri.path().ends_with("/Foo.kt"),
+        "got: {}",
+        loc.uri.path()
+    );
 }
 
 #[test]

--- a/src/sidecar.rs
+++ b/src/sidecar.rs
@@ -43,6 +43,9 @@ pub(crate) struct SidecarHandle {
 }
 
 impl SidecarHandle {
+    // These functions are called only from `#[cfg(not(test))]` code in indexer.rs,
+    // so test builds flag them as unused. The allow is intentional.
+    #[allow(dead_code)]
     /// Probe for a usable sidecar binary and start it.
     ///
     /// Probe order:
@@ -208,6 +211,7 @@ impl Drop for SidecarHandle {
 }
 
 /// Locate a `java` executable: check `$JAVA_HOME/bin/java` first, then PATH.
+#[allow(dead_code)] // called only from #[cfg(not(test))] launch_jar path
 fn find_java() -> Option<PathBuf> {
     if let Ok(home) = std::env::var("JAVA_HOME") {
         let candidate = PathBuf::from(home).join("bin").join("java");

--- a/src/workspace/config_tests.rs
+++ b/src/workspace/config_tests.rs
@@ -121,9 +121,11 @@ fn workspace_json_paths_are_included() {
     fs::write(dir.path().join("workspace.json"), json).unwrap();
 
     let sources = config(dir.path()).resolve_sources();
-    let src_str = src_dir.to_string_lossy().into_owned();
+    // Normalize separators for cross-platform comparison (workspace.json substitution
+    // may produce mixed slashes on Windows: C:\foo/src).
+    let src_str = src_dir.to_string_lossy().replace('\\', "/");
     assert!(
-        sources.contains(&src_str),
+        sources.iter().any(|s| s.replace('\\', "/") == src_str),
         "Expected workspace.json path in sources, got: {sources:?}"
     );
 }

--- a/tests/lsp_smoke.rs
+++ b/tests/lsp_smoke.rs
@@ -266,7 +266,14 @@ fn write(dir: &Path, rel: &str, content: &str) {
 }
 
 fn file_uri(dir: &Path, rel: &str) -> String {
-    format!("file://{}", dir.join(rel).display())
+    let path = dir.join(rel);
+    // Canonicalize resolves platform symlinks (e.g. /var -> /private/var on macOS)
+    // and produces the same URI format the LSP server emits on all platforms.
+    // All callers write the fixture files before calling file_uri, so the path exists.
+    let canonical = std::fs::canonicalize(&path).unwrap_or(path);
+    tower_lsp::lsp_types::Url::from_file_path(&canonical)
+        .expect("valid absolute file path")
+        .to_string()
 }
 
 /// Build LSP `Position` (0-based) by counting lines and UTF-16 columns.

--- a/tests/lsp_smoke.rs
+++ b/tests/lsp_smoke.rs
@@ -45,10 +45,14 @@ impl LspClient {
     /// `workspace_root` is passed as `KOTLIN_LSP_WORKSPACE_ROOT` so the server
     /// uses the synthetic fixture directory even if a real config file exists.
     fn spawn(workspace_root: &Path) -> Self {
+        // Canonicalize the root so the server uses the same path the OS returns
+        // when walking files (resolves /var -> /private/var on macOS, short
+        // 8.3 names -> long names on Windows).
+        let canonical = canonical_root(workspace_root);
         let mut child = Command::new(BIN)
             .args(["--stdio"])
-            .env("KOTLIN_LSP_WORKSPACE_ROOT", workspace_root)
-            .current_dir(workspace_root)
+            .env("KOTLIN_LSP_WORKSPACE_ROOT", &canonical)
+            .current_dir(&canonical)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             // Inherit stderr so Rust panics/backtraces reach the test output.
@@ -202,7 +206,10 @@ impl LspClient {
     /// Full initialization handshake: send `initialize`, wait for the response,
     /// then send `initialized`.  Does not wait for indexing to finish.
     fn initialize(&mut self, root: &Path) {
-        let root_uri = format!("file://{}", root.display());
+        let canonical = canonical_root(root);
+        let root_uri = tower_lsp::lsp_types::Url::from_file_path(&canonical)
+            .expect("valid absolute path")
+            .to_string();
         let resp = self.request(
             "initialize",
             json!({
@@ -257,6 +264,22 @@ impl Drop for LspClient {
 
 // ── fixture helpers ───────────────────────────────────────────────────────────
 
+/// Returns the canonical form of a path for use as a server workspace root.
+///
+/// On macOS this resolves /var → /private/var symlinks.
+/// On Windows this strips the \\?\ UNC prefix that std::fs::canonicalize adds,
+/// so Url::from_file_path and KOTLIN_LSP_WORKSPACE_ROOT env var work correctly.
+fn canonical_root(path: &Path) -> std::path::PathBuf {
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    // Strip the Windows extended-length prefix (\\?\) if present.
+    let s = canonical.to_string_lossy();
+    if let Some(stripped) = s.strip_prefix("\\\\?\\") {
+        std::path::PathBuf::from(stripped)
+    } else {
+        canonical
+    }
+}
+
 fn write(dir: &Path, rel: &str, content: &str) {
     let full = dir.join(rel);
     if let Some(p) = full.parent() {
@@ -266,11 +289,9 @@ fn write(dir: &Path, rel: &str, content: &str) {
 }
 
 fn file_uri(dir: &Path, rel: &str) -> String {
-    let path = dir.join(rel);
-    // Canonicalize resolves platform symlinks (e.g. /var -> /private/var on macOS)
-    // and produces the same URI format the LSP server emits on all platforms.
-    // All callers write the fixture files before calling file_uri, so the path exists.
-    let canonical = std::fs::canonicalize(&path).unwrap_or(path);
+    // Build from the canonical form of the directory so the URI matches what
+    // the server returns (server is also spawned with the canonical root).
+    let canonical = canonical_root(&dir.join(rel));
     tower_lsp::lsp_types::Url::from_file_path(&canonical)
         .expect("valid absolute file path")
         .to_string()


### PR DESCRIPTION
## Summary

Implements all critical and high-priority items from #127.

## Changes

### New: `src/path_util.rs`
Cross-platform path helpers:
- `to_forward_slash(path)` — converts `Path` to forward-slash string for globset (no-op on Unix)
- `strip_unc_prefix(path)` — strips `\\?\` UNC prefix from `canonicalize()` result (no-op on Unix)
- `file_stem_from_uri(uri)` — URL-based file stem with fallback for driveless URIs

### `src/rg.rs` — `split_rg_fields`
Adds Windows-aware `split_rg_fields()` that detects `C:\` drive-letter prefix and skips that colon before splitting, so `parse_rg_line` and `parse_rg_line_with_content_rooted` work correctly on Windows.

### `src/indexer/discover.rs` — globset forward-slash
Wires `to_forward_slash` into the 3 direct `gs.is_match()` calls in `walkdir_find` that bypassed the `IgnoreMatcher::matches()` wrapper.

### Call sites — `strip_unc_prefix` + URL fix
- `src/main.rs`, `src/indexer/apply.rs`, `src/indexer/cache.rs`: wrap `canonicalize()` with `strip_unc_prefix()`
- `src/indexer/apply.rs`: remove bad `format!(\"file://{}\", source_path)` URI construction

### CI / Release
- `.github/workflows/ci.yml`: add `windows-latest` to test matrix with `choco install ripgrep fd`
- `.github/workflows/release.yml`: add `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` release targets

## Reference
Mechanical fixes modelled on qdsfdhvh/kotlin-lsp Windows branch.

Closes #127