### PR TITLE
fix(perf): move diagnostic computation into spawn_blocking

### DIFF
--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -18,9 +18,13 @@ use crate::queries::{
 };
 
 /// Memoizes `collect_sealed_members` results within a single `when_diagnostics` pass.
-/// Key: `(sealed_name, parent_uri_string)`.
+/// Key: `(sealed_name, parent_uri_string, range)`.
 type SealedMembersCache =
     std::collections::HashMap<(String, String, u32, u32, u32, u32), Vec<WhenMember>>;
+
+/// Memoizes `resolve_type_members` results within a single pass.
+/// Key: subject type name. Safe because the index doesn't change mid-pass.
+type TypeMembersCache = std::collections::HashMap<String, Option<(TypeKind, Vec<WhenMember>)>>;
 
 /// Analysis result for incomplete when expressions — shared by code actions and diagnostics.
 struct WhenAnalysis<'a> {
@@ -37,6 +41,7 @@ fn analyze_when<'a>(
     when_node: tree_sitter::Node<'a>,
     source_bytes: &[u8],
     sealed_cache: &mut SealedMembersCache,
+    type_members_cache: &mut TypeMembersCache,
 ) -> Option<WhenAnalysis<'a>> {
     let subject_node = when_node
         .children(&mut when_node.walk())
@@ -54,8 +59,14 @@ fn analyze_when<'a>(
         .or_else(|| crate::resolver::infer::infer_variable_type(indexer, &subject_var, uri))?;
     let subject_type = strip_nullable(&subject_type).to_string();
 
-    let (type_kind, members) =
-        resolve_type_members(indexer, uri, &subject_type, &existing, sealed_cache)?;
+    let (type_kind, members) = resolve_type_members(
+        indexer,
+        uri,
+        &subject_type,
+        &existing,
+        sealed_cache,
+        type_members_cache,
+    )?;
 
     let missing: Vec<WhenMember> = members
         .into_iter()
@@ -96,6 +107,7 @@ pub(crate) fn build_fill_when_action(
         when_node,
         source_bytes,
         &mut SealedMembersCache::new(),
+        &mut TypeMembersCache::new(),
     )?;
 
     let indent = detect_indent(&analysis.when_node, source_bytes);
@@ -147,8 +159,10 @@ pub(crate) fn when_diagnostics(indexer: &Indexer, uri: &Url) -> Vec<Diagnostic> 
     let source_bytes = &live_doc.bytes;
     let root = live_doc.tree.root_node();
 
+    let t0 = std::time::Instant::now();
     let mut diagnostics = Vec::new();
     let mut sealed_cache = SealedMembersCache::new();
+    let mut type_members_cache = TypeMembersCache::new();
     collect_when_nodes(
         root,
         source_bytes,
@@ -156,7 +170,18 @@ pub(crate) fn when_diagnostics(indexer: &Indexer, uri: &Url) -> Vec<Diagnostic> 
         uri,
         &mut diagnostics,
         &mut sealed_cache,
+        &mut type_members_cache,
     );
+    let elapsed = t0.elapsed();
+    if elapsed.as_millis() > 50 {
+        log::info!(
+            "when_diagnostics: {}ms, {} type-cache entries, {} sealed-cache entries — {}",
+            elapsed.as_millis(),
+            type_members_cache.len(),
+            sealed_cache.len(),
+            uri.path(),
+        );
+    }
     diagnostics
 }
 
@@ -167,6 +192,7 @@ fn collect_when_nodes(
     uri: &Url,
     diagnostics: &mut Vec<Diagnostic>,
     sealed_cache: &mut SealedMembersCache,
+    type_members_cache: &mut TypeMembersCache,
 ) {
     if node.kind() == KIND_WHEN_EXPR {
         // Emit a warning whenever a `when` over a sealed class or enum is missing
@@ -175,7 +201,9 @@ fn collect_when_nodes(
         // have an `else` branch regardless of how the result is used.
         // `analyze_when` returns None if `else` is present, all branches are
         // covered, or the subject type is not a sealed class / enum.
-        if let Some(analysis) = analyze_when(indexer, uri, node, source, sealed_cache) {
+        if let Some(analysis) =
+            analyze_when(indexer, uri, node, source, sealed_cache, type_members_cache)
+        {
             let missing_names: Vec<&str> =
                 analysis.missing.iter().map(|m| m.name.as_str()).collect();
             let message = format!("'when' is missing branches: {}", missing_names.join(", "));
@@ -204,6 +232,7 @@ fn collect_when_nodes(
                 uri,
                 diagnostics,
                 sealed_cache,
+                type_members_cache,
             );
             if !cursor.goto_next_sibling() {
                 break;
@@ -452,6 +481,31 @@ fn strip_nullable(type_name: &str) -> &str {
 
 /// Resolve whether the type is an enum, sealed class, or Boolean, and return its members.
 fn resolve_type_members(
+    indexer: &Indexer,
+    from_uri: &Url,
+    type_name: &str,
+    existing_branches: &[String],
+    sealed_cache: &mut SealedMembersCache,
+    type_members_cache: &mut TypeMembersCache,
+) -> Option<(TypeKind, Vec<WhenMember>)> {
+    // Fast path: same type was already resolved earlier in this pass.
+    // Returns the full member list; `analyze_when` does its own missing-branch
+    // filter after this call, so we must NOT pre-filter here.
+    if let Some(cached) = type_members_cache.get(type_name) {
+        return cached.clone();
+    }
+    let result = resolve_type_members_inner(
+        indexer,
+        from_uri,
+        type_name,
+        existing_branches,
+        sealed_cache,
+    );
+    type_members_cache.insert(type_name.to_string(), result.clone());
+    result
+}
+
+fn resolve_type_members_inner(
     indexer: &Indexer,
     from_uri: &Url,
     type_name: &str,

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -63,7 +63,6 @@ fn analyze_when<'a>(
         indexer,
         uri,
         &subject_type,
-        &existing,
         sealed_cache,
         type_members_cache,
     )?;
@@ -159,7 +158,7 @@ pub(crate) fn when_diagnostics(indexer: &Indexer, uri: &Url) -> Vec<Diagnostic> 
     let source_bytes = &live_doc.bytes;
     let root = live_doc.tree.root_node();
 
-    let t0 = std::time::Instant::now();
+    let diag_start = std::time::Instant::now();
     let mut diagnostics = Vec::new();
     let mut sealed_cache = SealedMembersCache::new();
     let mut type_members_cache = TypeMembersCache::new();
@@ -172,7 +171,7 @@ pub(crate) fn when_diagnostics(indexer: &Indexer, uri: &Url) -> Vec<Diagnostic> 
         &mut sealed_cache,
         &mut type_members_cache,
     );
-    let elapsed = t0.elapsed();
+    let elapsed = diag_start.elapsed();
     if elapsed.as_millis() > 50 {
         log::info!(
             "when_diagnostics: {}ms, {} type-cache entries, {} sealed-cache entries — {}",
@@ -484,23 +483,18 @@ fn resolve_type_members(
     indexer: &Indexer,
     from_uri: &Url,
     type_name: &str,
-    existing_branches: &[String],
     sealed_cache: &mut SealedMembersCache,
     type_members_cache: &mut TypeMembersCache,
 ) -> Option<(TypeKind, Vec<WhenMember>)> {
     // Fast path: same type was already resolved earlier in this pass.
-    // Returns the full member list; `analyze_when` does its own missing-branch
-    // filter after this call, so we must NOT pre-filter here.
+    // We cache with empty existing_branches so the result is independent of
+    // which `when` node queries first — branches_fit_members would otherwise
+    // select different homonymous types depending on call order.
+    // `analyze_when` applies its own missing-branch filter after this call.
     if let Some(cached) = type_members_cache.get(type_name) {
         return cached.clone();
     }
-    let result = resolve_type_members_inner(
-        indexer,
-        from_uri,
-        type_name,
-        existing_branches,
-        sealed_cache,
-    );
+    let result = resolve_type_members_inner(indexer, from_uri, type_name, &[], sealed_cache);
     type_members_cache.insert(type_name.to_string(), result.clone());
     result
 }

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -521,7 +521,9 @@ fn write_sources_jar(
     sources: &[(&str, &str)],
 ) -> std::path::PathBuf {
     let jar_dir = gradle_home
-        .join("caches/modules-2/files-2.1")
+        .join("caches")
+        .join("modules-2")
+        .join("files-2.1")
         .join(group)
         .join(artifact)
         .join(version)

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -1238,7 +1238,13 @@ fn index_sources_jars_serves_fresh_entry_from_cache_without_extraction() {
 
     let jar_dir = gradle_dir
         .path()
-        .join("caches/modules-2/files-2.1/com.example/garbage/1.0.0/abc123");
+        .join("caches")
+        .join("modules-2")
+        .join("files-2.1")
+        .join("com.example")
+        .join("garbage")
+        .join("1.0.0")
+        .join("abc123");
     std::fs::create_dir_all(&jar_dir).expect("mkdir");
     let jar_path = jar_dir.join("garbage-1.0.0-sources.jar");
     std::fs::write(&jar_path, b"definitely not a zip archive").expect("write garbage jar");

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -526,8 +526,12 @@ fn complete_super(indexer: &Indexer, from_uri: &Url, snippets: bool) -> Vec<Comp
     );
     filter_inaccessible_completion_items(&mut items);
     strip_completion_snippets(&mut items, snippets);
-    items.sort_by_key(|item| (kind_sort_rank(item.kind), item.label.clone()));
-    items.dedup_by_key(|item| item.label.clone());
+    items.sort_by(|a, b| {
+        kind_sort_rank(a.kind)
+            .cmp(&kind_sort_rank(b.kind))
+            .then_with(|| a.label.cmp(&b.label))
+    });
+    items.dedup_by(|a, b| a.label == b.label);
     items
 }
 
@@ -808,8 +812,10 @@ fn filter_inaccessible_completion_items(items: &mut Vec<CompletionItem>) {
 }
 
 fn dedup_completion_labels(items: &mut Vec<CompletionItem>) {
-    let mut seen_labels = std::collections::HashSet::new();
-    items.retain(|item| seen_labels.insert(item.label.clone()));
+    let mut seen_labels: std::collections::HashSet<String> = std::collections::HashSet::new();
+    items.retain(|item| {
+        !seen_labels.contains(item.label.as_str()) && seen_labels.insert(item.label.clone())
+    });
 }
 
 fn strip_completion_snippets(items: &mut [CompletionItem], snippets: bool) {
@@ -1396,23 +1402,23 @@ impl<'a> BareCompletionWalk<'a> {
             return;
         }
         for mut item in bare_completions(self.completer.snippets) {
-            let label = item.label.clone();
-            if self.completer.lowercase_mode && label.starts_with_uppercase() {
+            if self.completer.lowercase_mode && item.label.starts_with_uppercase() {
                 continue;
             }
-            if self.completer.uppercase_mode && label.starts_with_lowercase() {
+            if self.completer.uppercase_mode && item.label.starts_with_lowercase() {
                 continue;
             }
-            if self.completer.camel_mode && is_screaming_snake(&label) {
+            if self.completer.camel_mode && is_screaming_snake(&item.label) {
                 continue;
             }
-            let score = match match_score(&label, self.prefix) {
+            let score = match match_score(&item.label, self.prefix) {
                 Some(score) if score <= 2 => score,
                 _ => continue,
             };
-            if self.completer.seen.insert(label.clone()) {
-                item.filter_text = Some(label.clone());
-                item.sort_text = Some(format!("3{}:{}", score, label.to_lowercase()));
+            if !self.completer.seen.contains(item.label.as_str()) {
+                self.completer.seen.insert(item.label.clone());
+                item.sort_text = Some(format!("3{}:{}", score, item.label.to_lowercase()));
+                item.filter_text = Some(item.label.clone());
                 self.completer.items.push(item);
             }
         }
@@ -1560,8 +1566,9 @@ fn symbols_from_uri_as_completions(indexer: &Indexer, file_uri: &str) -> Vec<Com
     }
 
     let items = build_completion_items(indexer, file_uri);
-    let arc = Arc::new(items.clone());
-    indexer.completion_cache.insert(file_uri.to_string(), arc);
+    indexer
+        .completion_cache
+        .insert(file_uri.to_string(), Arc::new(items.clone()));
     items
 }
 

--- a/src/sidecar_ipc_tests.rs
+++ b/src/sidecar_ipc_tests.rs
@@ -6,7 +6,9 @@ mod tests {
     use std::time::{Duration, Instant};
 
     fn gradle_cache_jars() -> Vec<PathBuf> {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/ocel".to_string());
+        let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) else {
+            return Vec::new();
+        };
         let cache = PathBuf::from(&home).join(".gradle/caches/modules-2/files-2.1");
         if !cache.exists() {
             return Vec::new();

--- a/src/sidecar_ipc_tests.rs
+++ b/src/sidecar_ipc_tests.rs
@@ -92,7 +92,10 @@ mod tests {
     /// Send one JAR, read one response, repeat. This identifies which specific JAR hangs.
     #[test]
     fn test_sidecar_sequential_all_jars_ipc() {
-        let (stdin, stdout, child) = launch_sidecar().expect("sidecar not found");
+        let Some((stdin, stdout, child)) = launch_sidecar() else {
+            eprintln!("[test] sidecar not found — skipping");
+            return;
+        };
         let jars = gradle_cache_jars();
         if jars.len() < 10 {
             eprintln!("[test] fewer than 10 JARs found");

--- a/src/sidecar_ipc_tests.rs
+++ b/src/sidecar_ipc_tests.rs
@@ -1,0 +1,186 @@
+#[cfg(test)]
+mod sidecar_ipc_tests {
+    use std::io::{BufRead, BufReader, Write};
+    use std::path::PathBuf;
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    fn gradle_cache_jars() -> Vec<PathBuf> {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/ocel".to_string());
+        let cache = PathBuf::from(&home).join(".gradle/caches/modules-2/files-2.1");
+        if !cache.exists() {
+            return Vec::new();
+        }
+        let output = Command::new("find")
+            .args([
+                cache.to_str().unwrap(),
+                "-name",
+                "*.jar",
+                "!",
+                "-name",
+                "*-sources*.jar",
+                "!",
+                "-name",
+                "*-javadoc*.jar",
+                "-type",
+                "f",
+            ])
+            .output()
+            .expect("find command failed");
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(PathBuf::from)
+            .collect()
+    }
+
+    fn launch_sidecar() -> Option<(
+        std::io::BufWriter<std::process::ChildStdin>,
+        BufReader<std::process::ChildStdout>,
+        std::process::Child,
+    )> {
+        let path = PathBuf::from(std::env::var("HOME").unwrap_or_default())
+            .join(".cargo/bin/kmp-jar-indexer");
+        if !path.exists() {
+            eprintln!("[test] sidecar not found at {:?}", path);
+            return None;
+        }
+        eprintln!("[test] launching sidecar: {:?}", path);
+        let mut child = Command::new(&path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .ok()?;
+        let stdin = std::io::BufWriter::new(child.stdin.take()?);
+        let stdout = BufReader::new(child.stdout.take()?);
+        Some((stdin, stdout, child))
+    }
+
+    fn drain_sidecar(
+        mut child: std::process::Child,
+        mut stdin: std::io::BufWriter<std::process::ChildStdin>,
+        mut stdout: BufReader<std::process::ChildStdout>,
+    ) {
+        let _ = stdin.write_all(b"{\"shutdown\":true}\n");
+        let _ = stdin.flush();
+        let reader = std::thread::spawn(move || {
+            let mut buf = String::new();
+            while let Ok(n) = stdout.read_line(&mut buf) {
+                if n == 0 {
+                    break;
+                }
+                buf.clear();
+            }
+        });
+        let start = Instant::now();
+        loop {
+            if start.elapsed() > Duration::from_secs(10) {
+                eprintln!("[test] sidecar stuck, killing");
+                let _ = child.kill();
+                break;
+            }
+            if let Ok(Some(status)) = child.try_wait() {
+                eprintln!("[test] sidecar exited: {}", status);
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+        let _ = reader.join();
+    }
+
+    /// Send one JAR, read one response, repeat. This identifies which specific JAR hangs.
+    #[test]
+    fn test_sidecar_sequential_all_jars_ipc() {
+        let (stdin, stdout, child) = launch_sidecar().expect("sidecar not found");
+        let jars = gradle_cache_jars();
+        if jars.len() < 10 {
+            eprintln!("[test] fewer than 10 JARs found");
+            drain_sidecar(child, stdin, stdout);
+            return;
+        }
+        let total = jars.len();
+        eprintln!("[test] sequential indexing of ALL {} JARs", total);
+
+        let mut stdin = stdin;
+        let mut stdout = stdout;
+        let start = Instant::now();
+        let timeout_per_jar = Duration::from_secs(30);
+        let mut responses = 0;
+        let mut last_ok_jar = String::new();
+
+        for (i, jar) in jars.iter().enumerate() {
+            let jar_name = jar
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            let jar_path = jar.to_str().unwrap();
+            eprintln!("[test] [{}/{}] {}", i + 1, total, jar_name);
+
+            let req = format!("{{\"jar\":\"{}\"}}\n", jar_path);
+            stdin.write_all(req.as_bytes()).unwrap();
+            stdin.flush().unwrap();
+
+            let jar_start = Instant::now();
+            loop {
+                if jar_start.elapsed() > timeout_per_jar {
+                    eprintln!("[test] TIMEOUT on jar [{}/{}]: {}", i + 1, total, jar_name);
+                    eprintln!("[test] Full path: {}", jar_path);
+                    eprintln!(
+                        "[test] Last successful jar #{} was: {}",
+                        responses, last_ok_jar
+                    );
+                    panic!(
+                        "sidecar hung on jar {} of {} ({})\nlast OK was: {}",
+                        i + 1,
+                        total,
+                        jar_name,
+                        last_ok_jar
+                    );
+                }
+                let mut line = String::new();
+                match stdout.read_line(&mut line) {
+                    Ok(0) => {
+                        eprintln!(
+                            "[test] SIDECAR CLOSED on jar [{}/{}]: {}",
+                            i + 1,
+                            total,
+                            jar_name
+                        );
+                        eprintln!("[test] Last successful was: {}", last_ok_jar);
+                        panic!(
+                            "sidecar closed stdout on jar {} of {} ({})",
+                            i + 1,
+                            total,
+                            jar_name
+                        );
+                    }
+                    Ok(_) if line.trim().is_empty() => continue,
+                    Ok(_) => {
+                        let parsed: Result<Vec<serde_json::Value>, _> = serde_json::from_str(&line);
+                        match parsed {
+                            Ok(_) => {
+                                responses += 1;
+                                last_ok_jar = jar_name.clone();
+                            }
+                            Err(e) => {
+                                eprintln!(
+                                    "[test] PARSE ERROR: {} — {}",
+                                    e,
+                                    &line[..line.len().min(100)]
+                                );
+                            }
+                        }
+                        break;
+                    }
+                    Err(e) => panic!("read error on {}: {}", jar_name, e),
+                }
+            }
+        }
+
+        let elapsed = start.elapsed();
+        eprintln!("[test] PASSED — {} JARs in {:?}", responses, elapsed);
+        drain_sidecar(child, stdin, stdout);
+    }
+}

--- a/src/sidecar_ipc_tests.rs
+++ b/src/sidecar_ipc_tests.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod sidecar_ipc_tests {
+mod tests {
     use std::io::{BufRead, BufReader, Write};
     use std::path::PathBuf;
     use std::process::{Command, Stdio};

--- a/src/workspace/document_handler.rs
+++ b/src/workspace/document_handler.rs
@@ -141,26 +141,31 @@ impl DocumentHandler {
         let semaphore = indexer.parse_sem();
         tokio::task::spawn(async move {
             let diagnostics_uri = uri.clone();
-            let diagnostics_text = content.clone();
             let Ok(permit) = semaphore.acquire_owned().await else {
                 return;
             };
+            // Return `content` from the closure so the second spawn_blocking
+            // can reuse it without an upfront full-file clone.
             let result = tokio::task::spawn_blocking(move || {
                 let _permit = permit;
                 let data = indexer.index_content(&uri, &content);
                 Arc::clone(&indexer).prewarm_completion_cache(&uri);
-                data
+                (data, content)
             })
             .await;
 
-            let mut diagnostics = match result {
+            let (index_result, diagnostics_text) = match result {
+                Ok((data, text)) => (Ok(data), text),
+                Err(_) => (Err(()), String::new()),
+            };
+            let mut diagnostics = match index_result {
                 Ok(Some(indexed_file_data)) => syntax_diagnostics(&indexed_file_data.syntax_errors),
                 Ok(None) => diag_indexer
                     .files
                     .get(diagnostics_uri.as_str())
                     .map(|file_data| syntax_diagnostics(&file_data.syntax_errors))
                     .unwrap_or_default(),
-                Err(_) => Vec::new(),
+                Err(()) => Vec::new(),
             };
 
             // Move all CPU-bound diagnostic work into spawn_blocking so the async

--- a/src/workspace/file_change_handler.rs
+++ b/src/workspace/file_change_handler.rs
@@ -163,8 +163,8 @@ impl FileChangeHandler {
             let semantic_diags = tokio::task::spawn_blocking({
                 let indexer = Arc::clone(&diag_indexer);
                 let uri = diagnostics_uri.clone();
-                let text = diagnostics_text.clone();
                 move || {
+                    let text = diagnostics_text;
                     // Parse tree from the exact same text that was just indexed —
                     // this guarantees CST and indexed data are consistent.
                     let live_doc =

--- a/src/workspace/file_change_handler.rs
+++ b/src/workspace/file_change_handler.rs
@@ -138,11 +138,6 @@ impl FileChangeHandler {
                 return;
             }
 
-            // Parse tree from the exact same text that was just indexed —
-            // this guarantees CST and indexed data are consistent.
-            let live_doc = lang_for_path(diagnostics_uri.path())
-                .and_then(|lang| parse_live(&diagnostics_text, lang));
-
             let index_hit_cache = matches!(result, Ok(None));
             log::debug!(
                 "diag[gen={}]: index_content returned {} for {}",
@@ -154,7 +149,7 @@ impl FileChangeHandler {
                 },
                 diagnostics_uri.path(),
             );
-            let mut diagnostics = match result {
+            let syntax_diags = match result {
                 Ok(Some(data)) => syntax_diagnostics(&data.syntax_errors),
                 Ok(None) => diag_indexer
                     .files
@@ -163,21 +158,40 @@ impl FileChangeHandler {
                     .unwrap_or_default(),
                 Err(_) => Vec::new(),
             };
-            diagnostics.extend(when_diagnostics(&diag_indexer, &diagnostics_uri));
-            if let Some(ref doc) = live_doc {
-                let arg_diags = call_arg_diagnostics(&diag_indexer, &diagnostics_uri, doc);
-                log::debug!(
-                    "diag[gen={}]: call_arg_diagnostics returned {} items",
-                    my_generation,
-                    arg_diags.len(),
-                );
-                diagnostics.extend(arg_diags);
-            } else {
-                log::debug!(
-                    "diag[gen={}]: live_doc is None — no call-arg diagnostics",
-                    my_generation,
-                );
-            }
+
+            // Move all CPU-bound diagnostic work off the async thread.
+            let semantic_diags = tokio::task::spawn_blocking({
+                let indexer = Arc::clone(&diag_indexer);
+                let uri = diagnostics_uri.clone();
+                let text = diagnostics_text.clone();
+                move || {
+                    // Parse tree from the exact same text that was just indexed —
+                    // this guarantees CST and indexed data are consistent.
+                    let live_doc =
+                        lang_for_path(uri.path()).and_then(|lang| parse_live(&text, lang));
+                    let mut d = when_diagnostics(&indexer, &uri);
+                    if let Some(ref doc) = live_doc {
+                        let arg_diags = call_arg_diagnostics(&indexer, &uri, doc);
+                        log::debug!(
+                            "diag[gen={}]: call_arg_diagnostics returned {} items",
+                            my_generation,
+                            arg_diags.len(),
+                        );
+                        d.extend(arg_diags);
+                    } else {
+                        log::debug!(
+                            "diag[gen={}]: live_doc is None — no call-arg diagnostics",
+                            my_generation,
+                        );
+                    }
+                    d
+                }
+            })
+            .await
+            .unwrap_or_default();
+
+            let mut diagnostics = syntax_diags;
+            diagnostics.extend(semantic_diags);
 
             // Final generation check before publishing — prevents stale
             // diagnostics from overwriting a newer clear/publish.

--- a/src/workspace/file_change_handler.rs
+++ b/src/workspace/file_change_handler.rs
@@ -165,12 +165,11 @@ impl FileChangeHandler {
                 let indexer = Arc::clone(&diag_indexer);
                 let uri = diagnostics_uri.clone();
                 move || {
-                    let text = diagnostics_text;
                     // Parse tree from the exact same text that was just indexed —
                     // this guarantees CST and indexed data are consistent.
-                    let live_doc =
-                        lang_for_path(uri.path()).and_then(|lang| parse_live(&text, lang));
-                    let mut d = when_diagnostics(&indexer, &uri);
+                    let live_doc = lang_for_path(uri.path())
+                        .and_then(|lang| parse_live(&diagnostics_text, lang));
+                    let mut diagnostics = when_diagnostics(&indexer, &uri);
                     if let Some(ref doc) = live_doc {
                         let arg_diags = call_arg_diagnostics(&indexer, &uri, doc);
                         log::debug!(
@@ -178,14 +177,14 @@ impl FileChangeHandler {
                             my_generation,
                             arg_diags.len(),
                         );
-                        d.extend(arg_diags);
+                        diagnostics.extend(arg_diags);
                     } else {
                         log::debug!(
                             "diag[gen={}]: live_doc is None — no call-arg diagnostics",
                             my_generation,
                         );
                     }
-                    d
+                    diagnostics
                 }
             })
             .await

--- a/src/workspace/file_change_handler.rs
+++ b/src/workspace/file_change_handler.rs
@@ -106,17 +106,18 @@ impl FileChangeHandler {
                 return;
             };
             let diagnostics_uri = uri.clone();
-            let diagnostics_text = text.clone();
+            // Return `text` from the closure so the diagnostic spawn_blocking
+            // can reuse it without an upfront full-file clone.
             let result = tokio::task::spawn_blocking(move || {
                 // Guard: if the file was closed or deleted before the debounce
                 // fired, skip re-indexing to avoid reinserting stale content.
                 if !indexer.live_lines.contains_key(uri.as_str()) {
                     drop(permit);
-                    return None;
+                    return (None, text);
                 }
                 let data = indexer.index_content(&uri, &text);
                 drop(permit);
-                data
+                (data, text)
             })
             .await;
 
@@ -138,7 +139,8 @@ impl FileChangeHandler {
                 return;
             }
 
-            let index_hit_cache = matches!(result, Ok(None));
+            let (index_result, diagnostics_text) = result.unwrap_or_else(|_| (None, String::new()));
+            let index_hit_cache = index_result.is_none();
             log::debug!(
                 "diag[gen={}]: index_content returned {} for {}",
                 my_generation,
@@ -149,14 +151,13 @@ impl FileChangeHandler {
                 },
                 diagnostics_uri.path(),
             );
-            let syntax_diags = match result {
-                Ok(Some(data)) => syntax_diagnostics(&data.syntax_errors),
-                Ok(None) => diag_indexer
+            let syntax_diags = match index_result {
+                Some(data) => syntax_diagnostics(&data.syntax_errors),
+                None => diag_indexer
                     .files
                     .get(diagnostics_uri.as_str())
                     .map(|file_data| syntax_diagnostics(&file_data.syntax_errors))
                     .unwrap_or_default(),
-                Err(_) => Vec::new(),
             };
 
             // Move all CPU-bound diagnostic work off the async thread.


### PR DESCRIPTION
## Summary

Fixes LSP responsiveness regression where editing a file with large nested sealed-class `when` expressions caused multi-second stalls — not just slow diagnostics, but all LSP operations (completions, go-to-definition) were blocked.

**Root cause**: CPU-bound diagnostic work (`parse_live`, `when_diagnostics`, `call_arg_diagnostics`) was running on Tokio async runtime threads, blocking the executor during debounced file-change handling.

**Changes across files:**

- **`src/workspace/file_change_handler.rs`** — Move all semantic diagnostic computation into `tokio::task::spawn_blocking` in the debounced reindex task. Thread `text` through the first blocking closure to avoid an upfront full-file clone.

- **`src/workspace/document_handler.rs`** — Same `spawn_blocking` pattern for `handle_file_opened` and `republish_open_file_diagnostics`.

- **`src/features/fill_when.rs`** — Add `TypeMembersCache` to memoize `resolve_type_members` results within a single diagnostic pass (avoids repeated `resolve_type_index_only` + `collect_sealed_members` for files with many `when` nodes over the same type). Cache keyed by type name only, always resolved with empty branches so the result is stable regardless of call order. Add timing instrumentation (>50 ms logs).

- **`src/resolver/complete.rs`** — Replace `sort_by_key` (clones label per comparison) with `sort_by` (borrows); deduplicate completion labels with `contains` check to avoid cloning duplicates.

- **`src/sidecar_ipc_tests.rs`** — Add missing test file (declared in `main.rs` but never committed; was breaking CI builds on main).

## Test plan
- [ ] Edit a Kotlin file with deeply nested sealed `when` — completions and go-to-definition should remain responsive during debounce window
- [ ] `cargo test` passes on all platforms
- [ ] No clippy warnings (`cargo clippy --all-targets --all-features -- -D warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)