### PR TITLE
feat(references): precise find-references for JAR/library symbol usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Deprecated & internal completion filtering** — `@Deprecated` library symbols are now hidden from completion (e.g. kotlinx-coroutines' `launch(context: Job)` / `launch(context: NonCancellable)` guidance shims). `@Deprecated` workspace symbols are kept but marked with the LSP `Deprecated` tag and sorted to the bottom. `internal` members of libraries — inaccessible from your module — are also hidden. Deprecation is captured both from sources JARs (tree-sitter) and the compiled-JAR sidecar (reads the `@Deprecated` annotation from bytecode via ASM, matched to declarations by JVM signature).
 - **Completion overload dedup** — overloads of the same extension collapse to a single entry per name (plus its `name { }` trailing-lambda form), matching IDE behaviour. Eliminates duplicate `launch` / `launch { }` rows caused by version skew across cached library versions and by sources-vs-compiled JAR copies of the same function.
+- **Precise find-references for JAR/library symbol usages** — invoking `textDocument/references` on a usage of a JAR-defined symbol (e.g. Compose's `remember`) now scopes the search to workspace files that import the symbol's declaring package/type, instead of an unscoped codebase-wide search. An unrelated workspace `fun remember()` in another package is no longer returned as a false positive.
 
 ### Bug fixes
 

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -38,21 +38,32 @@ pub(crate) async fn find_references_with_qualifier(
     let (parent_class, declared_pkg) =
         resolve_scope_with_qualifier(index, uri, line, name, qualifier);
 
+    // A lowercase usage of a JAR/library symbol now also produces a `declared_pkg`
+    // (the JAR symbol's package), but the request site is a *usage*, not the symbol's
+    // declaration. The `owner_class` / `field_owner` heuristics below assume a
+    // declaration site, so they must not fire for JAR-symbol usages.
+    let is_jar_symbol_usage = !name.starts_with_uppercase()
+        && !index.is_declared_in(uri, name)
+        && index.jar_declaration_scope(name).is_some();
+
     // For lowercase methods at their declaration site, check if they are declared
     // inside a doubly-nested class (e.g. `create` inside `Factory` inside `Reducer`).
     // `declared_pkg.is_some()` is the on_decl proxy for lowercase names: resolve_scope
     // returns (None, Some(pkg)) on_decl and (None, None) off-decl for lowercase names.
-    let owner_class =
-        if !name.starts_with_uppercase() && declared_pkg.is_some() && qualifier.is_none() {
-            outer_class_for_decl_site(index, uri, line)
-        } else {
-            None
-        };
+    let owner_class = if !name.starts_with_uppercase()
+        && declared_pkg.is_some()
+        && qualifier.is_none()
+        && !is_jar_symbol_usage
+    {
+        outer_class_for_decl_site(index, uri, line)
+    } else {
+        None
+    };
 
     // For class members (fields, properties, methods) at their declaration site:
     // scope file discovery to files that mention the declaring class, instead of
     // the whole package.
-    let field_owner = if qualifier.is_none() && declared_pkg.is_some() {
+    let field_owner = if qualifier.is_none() && declared_pkg.is_some() && !is_jar_symbol_usage {
         field_owner_for_decl(index, uri, name, line)
     } else {
         None
@@ -136,12 +147,18 @@ pub(crate) fn resolve_scope_with_qualifier(
                 .definition_locations(name)
                 .iter()
                 .any(|l| l.uri == *uri && l.range.start.line == line);
-        return if on_decl {
+        if on_decl {
             let enclosing_class = index.enclosing_class_at(uri, line);
-            (enclosing_class, index.package_of(uri))
-        } else {
-            (None, None)
-        };
+            return (enclosing_class, index.package_of(uri));
+        }
+        // JAR-symbol usage (not on its own workspace declaration): scope to the
+        // JAR symbol's declaring package/type so file discovery is restricted to
+        // workspace files that import it — instead of an unscoped codebase-wide
+        // bare-word search that also matches unrelated same-named workspace symbols.
+        if let Some((package, container)) = index.jar_declaration_scope(name) {
+            return (container, Some(package));
+        }
+        return (None, None);
     }
 
     // Fast path: an uppercase dot-qualifier (e.g. "ReducerA" in "ReducerA.Factory")
@@ -202,6 +219,28 @@ fn declaration_files_for(
     // When `declared_pkg` is None (unscoped lowercase off-decl-site search), fall
     // back to the source package so that same-named top-level symbols from
     // unrelated packages are not merged into candidates.
+    // JAR/library-defined symbol: no workspace file lives in its package, so the
+    // same-package definition-file scan below would find nothing. Instead, discover
+    // the workspace files that *import* the JAR symbol and use those as candidates.
+    // This drives the import-scoped reference search (reusing the existing
+    // qualifier-precision machinery) and keeps unrelated same-named workspace
+    // symbols out of the result set.
+    if let Some(jar_pkg) = declared_pkg {
+        let no_workspace_decl = index
+            .definition_locations(name)
+            .iter()
+            .all(|loc| index.is_library_uri(&loc.uri));
+        if no_workspace_decl && index.jar_declaration_scope(name).is_some() {
+            let fqn = format!("{jar_pkg}.{name}");
+            return index
+                .workspace_importers_of(&fqn)
+                .into_iter()
+                .filter_map(|url| url.to_file_path().ok())
+                .filter_map(|path| path.to_str().map(|s| s.to_owned()))
+                .collect();
+        }
+    }
+
     let source_pkg = index.package_of(source_uri);
     let pkg_filter = declared_pkg.or(source_pkg.as_deref());
     index

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -155,8 +155,19 @@ pub(crate) fn resolve_scope_with_qualifier(
         // JAR symbol's declaring package/type so file discovery is restricted to
         // workspace files that import it — instead of an unscoped codebase-wide
         // bare-word search that also matches unrelated same-named workspace symbols.
-        if let Some((package, container)) = index.jar_declaration_scope(name) {
-            return (container, Some(package));
+        //
+        // Gate this on the *request file* explicitly importing the symbol.
+        // `resolve_symbol_via_import` reads the file's import statement and returns
+        // its package (also disambiguating same-name symbols that live in different
+        // jars — it uses the package the caller actually imported). Without an
+        // explicit import — e.g. default-import stdlib members like `copy`/`apply` —
+        // it returns `(None, None)` and we keep the prior unscoped search rather than
+        // narrowing to an empty importer set.
+        if index.jar_declaration_scope(name).is_some() {
+            let (import_parent, import_pkg) = index.resolve_symbol_via_import(uri, name);
+            if import_pkg.is_some() {
+                return (import_parent, import_pkg);
+            }
         }
         return (None, None);
     }

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -1662,3 +1662,57 @@ public class Caller {
     assert_refs_contain(&locs, &["Caller.java"]);
     assert_refs_exclude(&locs, &["Other.java"]);
 }
+
+/// **Acceptance (Task 2)**: `find_references` invoked on a *usage* of a JAR-defined
+/// top-level function (`remember`) must return only the workspace files that import
+/// the JAR symbol, and exclude an unrelated workspace `fun remember()` declared in
+/// another package.
+///
+/// Without import-scoping a lowercase JAR-symbol usage falls to an unscoped
+/// codebase-wide bare-word rg search, which also matches `Unrelated.kt`'s
+/// `fun remember()` — a false positive this test guards against.
+#[tokio::test]
+async fn find_references_on_jar_symbol_usage_scopes_to_importers() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Caller imports + calls the JAR `remember`.
+    let caller_src =
+        "package app\nimport androidx.compose.runtime.remember\nfun build() { remember() }\n";
+    // An unrelated workspace function of the same name in a different package,
+    // with no import of the JAR symbol — must NOT appear in the results.
+    let unrelated_src = "package other\nfun remember() {}\nfun use() { remember() }\n";
+
+    let (_, caller_uri) = write(root, "Caller.kt", caller_src);
+    write(root, "Unrelated.kt", unrelated_src);
+
+    let idx = Arc::new(Indexer::new());
+    idx.workspace_root.set(root.to_path_buf());
+
+    // Inject the JAR `remember` as a top-level compose-runtime symbol.
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/compose-runtime.jar"),
+        &[crate::sidecar::SidecarSymbol {
+            name: "remember".into(),
+            kind: "fun".into(),
+            container: "ComposablesKt".into(),
+            detail: "fun remember()".into(),
+            doc: String::new(),
+            type_params: vec![],
+            extension_receiver_type: String::new(),
+            trailing_lambda: false,
+            deprecated: false,
+            pkg: "androidx.compose.runtime".into(),
+            top_level: true,
+        }],
+    );
+
+    idx.index_content(&caller_uri, caller_src);
+
+    // Cursor on the `remember()` call usage in Caller.kt (line 2, 0-indexed).
+    let locs = find_references_with_qualifier("remember", None, &caller_uri, 2, false, &*idx).await;
+
+    assert_refs_contain(&locs, &["Caller.kt"]);
+    assert_refs_exclude(&locs, &["Unrelated.kt"]);
+}

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -1716,3 +1716,64 @@ async fn find_references_on_jar_symbol_usage_scopes_to_importers() {
     assert_refs_contain(&locs, &["Caller.kt"]);
     assert_refs_exclude(&locs, &["Unrelated.kt"]);
 }
+
+/// Two different jars each declare a top-level `remember` in *different* packages.
+/// A caller that imports only the compose one must scope find-references to files
+/// importing *that* package. A second workspace file that imports the competing jar's
+/// same-named symbol must NOT appear.
+///
+/// This guards the import-based disambiguation: `resolve_scope` returns the package the
+/// caller actually imported (`androidx.compose.runtime`), not an arbitrary jar
+/// definition picked by `jar_declaration_scope`'s insertion order. With the old
+/// name-only scoping, an arbitrary pick of `com.other` would have inverted the result —
+/// including `Other.kt` and dropping `Caller.kt`.
+#[tokio::test]
+async fn find_references_on_jar_symbol_disambiguates_competing_jars() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let caller_src =
+        "package app\nimport androidx.compose.runtime.remember\nfun build() { remember() }\n";
+    // Imports the *other* jar's `remember`: same simple name, different package.
+    let other_src = "package feature\nimport com.other.remember\nfun use() { remember() }\n";
+
+    let (_, caller_uri) = write(root, "Caller.kt", caller_src);
+    let (_, other_uri) = write(root, "Other.kt", other_src);
+
+    let idx = Arc::new(Indexer::new());
+    idx.workspace_root.set(root.to_path_buf());
+
+    let jar_symbol = |pkg: &str| crate::sidecar::SidecarSymbol {
+        name: "remember".into(),
+        kind: "fun".into(),
+        container: "ComposablesKt".into(),
+        detail: "fun remember()".into(),
+        doc: String::new(),
+        type_params: vec![],
+        extension_receiver_type: String::new(),
+        trailing_lambda: false,
+        deprecated: false,
+        pkg: pkg.into(),
+        top_level: true,
+    };
+
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/compose-runtime.jar"),
+        &[jar_symbol("androidx.compose.runtime")],
+    );
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/other.jar"),
+        &[jar_symbol("com.other")],
+    );
+
+    idx.index_content(&caller_uri, caller_src);
+    idx.index_content(&other_uri, other_src);
+
+    // Cursor on the `remember()` call usage in Caller.kt (line 2, 0-indexed).
+    let locs = find_references_with_qualifier("remember", None, &caller_uri, 2, false, &*idx).await;
+
+    assert_refs_contain(&locs, &["Caller.kt"]);
+    assert_refs_exclude(&locs, &["Other.kt"]);
+}

--- a/src/features/traits.rs
+++ b/src/features/traits.rs
@@ -126,6 +126,21 @@ pub(crate) trait SymbolIndex {
 
     /// Name of the innermost class/object enclosing `row` in `uri`, if any.
     fn enclosing_class_at(&self, uri: &Url, row: u32) -> Option<String>;
+
+    /// If `name` resolves to a compiled/sources JAR definition, return its
+    /// `(package, container)` — e.g. `("androidx.compose.runtime", None)` for the
+    /// top-level `remember`, `("androidx.compose.ui", Some("Modifier"))` for a
+    /// member. Returns `None` for workspace-only names.
+    ///
+    /// Used by `find_references` to scope a JAR-symbol *usage* to the files that
+    /// import its declaring package/type, rather than a codebase-wide bare search.
+    fn jar_declaration_scope(&self, name: &str) -> Option<(String, Option<String>)>;
+
+    /// Workspace files (`file://` only, non-library) that import `fqn` — either via
+    /// an explicit import of the symbol or a star import of its declaring package.
+    ///
+    /// `fqn` is the fully-qualified name, e.g. `"androidx.compose.runtime.remember"`.
+    fn workspace_importers_of(&self, fqn: &str) -> Vec<Url>;
 }
 
 // ─── DocumentAccess ──────────────────────────────────────────────────────────

--- a/src/features/traits_impl.rs
+++ b/src/features/traits_impl.rs
@@ -51,6 +51,14 @@ impl SymbolIndex for Indexer {
     fn enclosing_class_at(&self, uri: &Url, row: u32) -> Option<String> {
         self.enclosing_class_at(uri, row)
     }
+
+    fn jar_declaration_scope(&self, name: &str) -> Option<(String, Option<String>)> {
+        self.jar_declaration_scope(name)
+    }
+
+    fn workspace_importers_of(&self, fqn: &str) -> Vec<Url> {
+        self.workspace_importers_of(fqn)
+    }
 }
 
 // ─── DocumentAccess ──────────────────────────────────────────────────────────

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -123,6 +123,13 @@ impl Indexer {
             if !uri_str.starts_with("file://") {
                 continue;
             }
+            // Library source files (sources-jars *and* configured `sourcePaths`) are
+            // indexed as `file://` but are not workspace code — they must never count
+            // as importers. `library_uris` only catches the former, so also exclude
+            // anything classified into the Library source set.
+            if entry.value().source_set == crate::types::SourceSet::Library {
+                continue;
+            }
             let imports_symbol = entry
                 .value()
                 .imports

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -54,6 +54,89 @@ impl Indexer {
         self.files.get(uri.as_str())?.package.clone()
     }
 
+    /// If `name` resolves to a compiled/sources JAR definition, return its
+    /// `(package, container)` — e.g. `("androidx.compose.runtime", None)` for the
+    /// top-level `remember`, or `("androidx.compose.ui", Some("Modifier"))` for a
+    /// member declared inside `Modifier`. Returns `None` for workspace-only names.
+    ///
+    /// The package is read from the per-symbol `jar_symbol_packages` side table
+    /// (index-aligned with the symbol's synthetic line number), falling back to the
+    /// per-jar inferred package. The container is read from the JAR symbol entry.
+    pub(crate) fn jar_declaration_scope(&self, name: &str) -> Option<(String, Option<String>)> {
+        let locs = self.jar_definitions.get(name)?;
+        for loc in locs.iter() {
+            let uri_str = loc.uri.as_str();
+            let symbol_index = loc.range.start.line as usize;
+            let package = self
+                .jar_symbol_packages
+                .get(uri_str)
+                .and_then(|packages| {
+                    packages
+                        .get(symbol_index)
+                        .filter(|p| !p.is_empty())
+                        .cloned()
+                })
+                .or_else(|| {
+                    self.jar_files
+                        .get(uri_str)
+                        .and_then(|fd| fd.package.clone())
+                });
+            let Some(package) = package else {
+                continue;
+            };
+            // A top-level Kotlin declaration is registered in `qualified` under
+            // `pkg.name`, while a member is registered under `pkg.Container.name`.
+            // The symbol's stored `container` for a top-level fun/val is its JVM
+            // facade class (e.g. `ComposablesKt`), which is not a usable Kotlin
+            // type qualifier — so report `None` for top-level symbols.
+            let is_top_level = self.qualified.contains_key(&format!("{package}.{name}"));
+            let container = if is_top_level {
+                None
+            } else {
+                self.jar_files.get(uri_str).and_then(|fd| {
+                    fd.symbols
+                        .get(symbol_index)
+                        .and_then(|s| s.container.clone())
+                })
+            };
+            return Some((package, container));
+        }
+        None
+    }
+
+    /// Workspace files (`file://`, non-library) that import `fqn` — either via an
+    /// explicit import of the symbol or a star import of its declaring package.
+    ///
+    /// `fqn` is the fully-qualified name, e.g. `"androidx.compose.runtime.remember"`.
+    /// Reuses [`crate::types::ImportEntry::covers`] for the import-matching rules.
+    /// Library/JAR files are excluded so results are workspace usages only.
+    pub(crate) fn workspace_importers_of(&self, fqn: &str) -> Vec<Url> {
+        let Some((def_pkg, symbol_name)) = fqn.rsplit_once('.') else {
+            return Vec::new();
+        };
+        let mut result = Vec::new();
+        for entry in self.files.iter() {
+            let uri_str = entry.key();
+            if self.library_uris.contains(uri_str) {
+                continue;
+            }
+            if !uri_str.starts_with("file://") {
+                continue;
+            }
+            let imports_symbol = entry
+                .value()
+                .imports
+                .iter()
+                .any(|imp| imp.covers(def_pkg, symbol_name));
+            if imports_symbol {
+                if let Ok(url) = Url::parse(uri_str) {
+                    result.push(url);
+                }
+            }
+        }
+        result
+    }
+
     /// Return the package in which `name` is declared, by looking up its
     /// definition locations and reading the `package` field of those files.
     pub(crate) fn declared_package_of(&self, name: &str, preferred_uri: &Url) -> Option<String> {

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -3061,3 +3061,115 @@ fn jar_symbol_resolved_via_import() {
         locs[0].uri
     );
 }
+
+// ─── jar_declaration_scope / workspace_importers_of accessors ──────────────────
+
+/// Build a sidecar symbol for the JAR accessor tests.
+fn jar_test_symbol(
+    name: &str,
+    container: &str,
+    pkg: &str,
+    top_level: bool,
+) -> crate::sidecar::SidecarSymbol {
+    crate::sidecar::SidecarSymbol {
+        name: name.into(),
+        kind: "fun".into(),
+        container: container.into(),
+        detail: format!("fun {name}()"),
+        doc: String::new(),
+        type_params: vec![],
+        extension_receiver_type: String::new(),
+        trailing_lambda: false,
+        deprecated: false,
+        pkg: pkg.into(),
+        top_level,
+    }
+}
+
+#[test]
+fn jar_declaration_scope_returns_package_for_top_level_symbol() {
+    let idx = Indexer::new();
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/runtime.jar"),
+        &[jar_test_symbol(
+            "remember",
+            "ComposablesKt",
+            "androidx.compose.runtime",
+            true,
+        )],
+    );
+
+    let scope = idx.jar_declaration_scope("remember");
+    assert_eq!(
+        scope,
+        Some(("androidx.compose.runtime".to_string(), None)),
+        "top-level JAR fun must report its package with no container"
+    );
+
+    assert!(
+        idx.jar_declaration_scope("notAJarSymbol").is_none(),
+        "workspace-only / unknown names must return None"
+    );
+}
+
+#[test]
+fn jar_declaration_scope_returns_container_for_member_symbol() {
+    let idx = Indexer::new();
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/ui.jar"),
+        &[jar_test_symbol(
+            "padding",
+            "Modifier",
+            "androidx.compose.ui",
+            false,
+        )],
+    );
+
+    let scope = idx.jar_declaration_scope("padding");
+    assert_eq!(
+        scope,
+        Some((
+            "androidx.compose.ui".to_string(),
+            Some("Modifier".to_string())
+        )),
+        "member JAR fun must report its package and declaring container"
+    );
+}
+
+#[test]
+fn workspace_importers_of_finds_explicit_plus_star_imports_excludes_non_importers() {
+    let idx = Indexer::new();
+
+    let explicit = uri("/Explicit.kt");
+    idx.index_content(
+        &explicit,
+        "package app\nimport androidx.compose.runtime.remember\nfun a() { remember() }\n",
+    );
+
+    let star = uri("/Star.kt");
+    idx.index_content(
+        &star,
+        "package app\nimport androidx.compose.runtime.*\nfun b() { remember() }\n",
+    );
+
+    let unrelated = uri("/Unrelated.kt");
+    idx.index_content(&unrelated, "package other\nfun remember() {}\n");
+
+    let mut importers = idx.workspace_importers_of("androidx.compose.runtime.remember");
+    importers.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+
+    assert!(
+        importers.contains(&explicit),
+        "explicit import must be an importer; got {importers:?}"
+    );
+    assert!(
+        importers.contains(&star),
+        "star import of the package must be an importer; got {importers:?}"
+    );
+    assert!(
+        !importers.contains(&unrelated),
+        "a file that does not import the symbol must be excluded; got {importers:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Makes `textDocument/references` precise when invoked on a *usage* of a JAR/library-defined symbol. Previously a lowercase JAR-symbol usage fell to an unscoped codebase-wide bare-word `rg` search, so a JAR `remember` would also match an unrelated workspace `fun remember()` in another package. The search is now scoped to workspace files that import the JAR symbol's declaring package/type.

Implements **Task 1** and **Task 2** of the plan.

### Task 1 — index accessors (no behaviour change)
- `jar_declaration_scope(name) -> Option<(String, Option<String>)>` — resolves a name to its JAR definition's `(package, container)`. Package comes from the `jar_symbol_packages` side table (falling back to the per-jar package); top-level declarations report `None` container (their JVM facade class, e.g. `ComposablesKt`, is not a usable Kotlin type qualifier).
- `workspace_importers_of(fqn) -> Vec<Url>` — workspace (`file://`, non-library) files importing the FQN, reusing `ImportEntry::covers` for explicit and star imports.

Both are wired through the `SymbolIndex` trait.

### Task 2 — scope a JAR-symbol usage by its importers
- `resolve_scope_with_qualifier` routes a lowercase JAR-symbol *usage* (not on its own workspace declaration) through `(container, Some(package))` scope.
- `declaration_files_for` discovers candidate files via `workspace_importers_of("<pkg>.<name>")` when the package is a JAR package, instead of same-package files.
- The `owner_class` / `field_owner` declaration-site heuristics are guarded so they don't fire for JAR-symbol usages.
- Reuses the existing import-scoped discovery and qualifier-precision machinery (`parent_scoped_reference_locations` / `package_scoped_reference_locations`).

## Tests
- Task 1: `jar_declaration_scope` (top-level + member) and `workspace_importers_of` (explicit + star imports, excludes non-importers) unit tests against a synthetic index built with `populate_from_symbols` + `index_content`.
- Task 2 acceptance: a workspace file imports + calls a JAR `remember`; a second workspace file declares an unrelated `fun remember()`. `find_references` from the first usage returns the import-reachable usage and excludes the unrelated one.

Full suite: 1372 passed, 0 failed. `cargo clippy --bin kmp-lsp` clean.

## Deferred
**Task 3** (references *from* the JAR definition site) is deferred: it depends on the not-yet-landed JAR-source-extraction feature (`2026-06-18-godef-jar-source-extraction.md`) so the cursor can sit on an extracted JAR source. Docs beyond the CHANGELOG line are also deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)