### PR TITLE
feat(backend): slow-path tracing for LSP requests (RUST_LOG-gated)

### DIFF
--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -11,13 +11,21 @@ impl Backend {
         let position = pp.position;
         let workspace = self.indexer.as_ref();
 
+        let t0 = std::time::Instant::now();
         let Some(ctx) = CursorContext::build(&self.indexer, uri, position) else {
             return Ok(None);
         };
-
-        Ok(crate::features::hover::compute_hover(
-            workspace, &ctx, uri, position,
-        ))
+        let ctx_ms = t0.elapsed().as_millis();
+        let t1 = std::time::Instant::now();
+        let result = crate::features::hover::compute_hover(workspace, &ctx, uri, position);
+        let hover_ms = t1.elapsed().as_millis();
+        if ctx_ms + hover_ms > 400 {
+            log::warn!(
+                "SLOW hover: CursorContext::build {ctx_ms}ms + compute_hover {hover_ms}ms (line {})",
+                position.line
+            );
+        }
+        Ok(result)
     }
 
     pub(super) async fn references_impl(
@@ -80,7 +88,17 @@ impl Backend {
     ) -> Result<Option<Vec<InlayHint>>> {
         let uri = &params.text_document.uri;
         let range = params.range;
+        let t = std::time::Instant::now();
         let hints = compute_inlay_hints(&self.indexer, uri, range);
+        let ms = t.elapsed().as_millis();
+        if ms > 400 {
+            log::warn!(
+                "SLOW inlay compute: {ms}ms ({} hints, range {}..{})",
+                hints.len(),
+                range.start.line,
+                range.end.line
+            );
+        }
         Ok(if hints.is_empty() { None } else { Some(hints) })
     }
 

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -11,17 +11,17 @@ impl Backend {
         let position = pp.position;
         let workspace = self.indexer.as_ref();
 
-        let t0 = std::time::Instant::now();
+        let context_started = std::time::Instant::now();
         let Some(ctx) = CursorContext::build(&self.indexer, uri, position) else {
             return Ok(None);
         };
-        let ctx_ms = t0.elapsed().as_millis();
-        let t1 = std::time::Instant::now();
+        let context_build_ms = context_started.elapsed().as_millis();
+        let hover_started = std::time::Instant::now();
         let result = crate::features::hover::compute_hover(workspace, &ctx, uri, position);
-        let hover_ms = t1.elapsed().as_millis();
-        if ctx_ms + hover_ms > 400 {
+        let compute_hover_ms = hover_started.elapsed().as_millis();
+        if context_build_ms + compute_hover_ms > crate::backend::panic_guard::SLOW_THRESHOLD_MS {
             log::warn!(
-                "SLOW hover: CursorContext::build {ctx_ms}ms + compute_hover {hover_ms}ms (line {})",
+                "SLOW hover: CursorContext::build {context_build_ms}ms + compute_hover {compute_hover_ms}ms (line {})",
                 position.line
             );
         }
@@ -88,12 +88,12 @@ impl Backend {
     ) -> Result<Option<Vec<InlayHint>>> {
         let uri = &params.text_document.uri;
         let range = params.range;
-        let t = std::time::Instant::now();
+        let compute_started = std::time::Instant::now();
         let hints = compute_inlay_hints(&self.indexer, uri, range);
-        let ms = t.elapsed().as_millis();
-        if ms > 400 {
+        let compute_ms = compute_started.elapsed().as_millis();
+        if compute_ms > crate::backend::panic_guard::SLOW_THRESHOLD_MS {
             log::warn!(
-                "SLOW inlay compute: {ms}ms ({} hints, range {}..{})",
+                "SLOW inlay compute: {compute_ms}ms ({} hints, range {}..{})",
                 hints.len(),
                 range.start.line,
                 range.end.line

--- a/src/backend/panic_guard.rs
+++ b/src/backend/panic_guard.rs
@@ -1,6 +1,10 @@
 use futures::FutureExt;
 use tower_lsp::jsonrpc::Result;
 
+/// Wall-time threshold (ms) above which a request / inference step is logged as slow.
+/// Shared by the request wrapper and the inlay/hover handlers so the bar is tuned once.
+pub(crate) const SLOW_THRESHOLD_MS: u128 = 400;
+
 /// Wraps an async handler in `catch_unwind` so a panic in one request doesn't
 /// kill the server process. Returns an internal error to the client on panic.
 pub(crate) async fn panic_safe<F, T>(method: &str, future: F) -> Result<T>
@@ -38,7 +42,7 @@ where
     let guarded = PanicGuarded(Box::pin(future));
     let result = std::panic::AssertUnwindSafe(guarded).catch_unwind().await;
     let elapsed_ms = started.elapsed().as_millis();
-    if elapsed_ms > 400 {
+    if elapsed_ms > SLOW_THRESHOLD_MS {
         log::warn!("SLOW request {method}: {elapsed_ms}ms");
     }
 

--- a/src/backend/panic_guard.rs
+++ b/src/backend/panic_guard.rs
@@ -34,8 +34,13 @@ where
         }
     }
 
+    let started = std::time::Instant::now();
     let guarded = PanicGuarded(Box::pin(future));
     let result = std::panic::AssertUnwindSafe(guarded).catch_unwind().await;
+    let elapsed_ms = started.elapsed().as_millis();
+    if elapsed_ms > 400 {
+        log::warn!("SLOW request {method}: {elapsed_ms}ms");
+    }
 
     match result {
         Ok(result) => result,

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -497,7 +497,13 @@ impl<'a> RgSearch<'a> {
 
     fn output(&self) -> Option<std::process::Output> {
         let mut command = self.build_command();
-        match command.output() {
+        let t = std::time::Instant::now();
+        let result = command.output();
+        let ms = t.elapsed().as_millis();
+        if ms > 150 {
+            log::warn!("SLOW rg spawn: {ms}ms");
+        }
+        match result {
             Ok(output) if output.status.success() && !output.stdout.is_empty() => Some(output),
             _ => None,
         }

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -497,11 +497,12 @@ impl<'a> RgSearch<'a> {
 
     fn output(&self) -> Option<std::process::Output> {
         let mut command = self.build_command();
-        let t = std::time::Instant::now();
+        let started = std::time::Instant::now();
         let result = command.output();
-        let ms = t.elapsed().as_millis();
-        if ms > 150 {
-            log::warn!("SLOW rg spawn: {ms}ms");
+        let elapsed_ms = started.elapsed().as_millis();
+        if elapsed_ms > 150 {
+            // Total rg runtime: spawn + execution + wait.
+            log::warn!("SLOW rg query: {elapsed_ms}ms");
         }
         match result {
             Ok(output) if output.status.success() && !output.stdout.is_empty() => Some(output),


### PR DESCRIPTION
## What

Threshold-gated `warn!` tracing so hard-to-reproduce hover/inlay stalls are diagnosable straight from the editor's LSP log — no always-on chatter.

- **`panic_safe`** (wraps every request handler): per-request wall time → `SLOW request {method}: {ms}ms` (>400ms)
- **`inlay_hint` / `hover` handlers**: compute-vs-context breakdown → `SLOW inlay compute: {ms}ms (N hints, range a..b)`, `SLOW hover: CursorContext::build {ms}ms + compute_hover {ms}ms`
- **`rg`**: per-subprocess spawn time → `SLOW rg spawn: {ms}ms` (>150ms)

## Why

This is the instrumentation that localized a multi-second inlay/hover regression to a specific in-process scan (vs. rg / scheduling) purely from the editor log. Useful to keep for future perf triage.

## Risk

Purely additive — timing + gated logging only, no behavior change. First of a layered series (logging → by-name lookup bounding → inference features).

🤖 Generated with [Claude Code](https://claude.com/claude-code)