### PR TITLE
perf(infer): bound receiver-less by-name lookups (fixes multi-second hover/inlay)

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -47,10 +47,10 @@ pub(crate) use self::infer::{
     receiver::lambda_receiver_type_from_context,
     sig::{
         collect_all_fun_params_texts, collect_params_from_line, collect_signature,
-        find_fun_signature_full, find_fun_signature_with_receiver, is_import_reachable,
-        last_fun_param_type_str, nth_fun_param_type_str, resolve_call_signature,
-        split_params_at_depth_zero, strip_trailing_call_args, CallSite, ResolutionScope,
-        SignatureResult,
+        find_fun_params_text_fast, find_fun_signature_full, find_fun_signature_with_receiver,
+        is_import_reachable, last_fun_param_type_str, nth_fun_param_type_str,
+        resolve_call_signature, split_params_at_depth_zero, strip_trailing_call_args, CallSite,
+        ResolutionScope, SignatureResult,
     },
     type_subst::find_last_dot_at_depth_zero,
 };
@@ -263,6 +263,10 @@ pub(crate) struct Indexer {
     /// Key: (fn_name, uri_string) → cached params text.
     /// Cleared on reindex to avoid stale results.
     pub(crate) sig_cache: DashMap<(String, String), Option<String>>,
+    /// Like `sig_cache` but for the index-only fast lookup used by lambda/receiver
+    /// inference (no rg, no all-files re-scan per call). Separate so it never holds an
+    /// index-only `None` that would mask `sig_cache`'s rg-backed result.
+    pub(crate) sig_fast_cache: DashMap<(String, String), Option<String>>,
     /// Handle for submitting unresolved symbols to background rg enrichment.
     /// Noop in CLI mode and tests; set via `set_enrichment_handle`.
     pub(crate) enrichment: std::sync::RwLock<EnrichmentHandle>,
@@ -297,9 +301,18 @@ pub(crate) struct Indexer {
     pub(crate) jar_symbol_packages: DashMap<String, Vec<String>>,
 }
 
+/// Cap on how many same-named definitions a receiver-less by-name inference lookup
+/// scans (see [`Indexer::find_in_workspace_defs`]). Common method names resolve to
+/// thousands of library definitions once source-JARs are indexed; without a receiver
+/// type the exact overload can't be picked anyway, so bound the work.
+pub(crate) const MAX_BY_NAME_DEFS: usize = 64;
+
 impl InferDeps for Indexer {
     fn find_fun_params_text(&self, fn_name: &str, uri: &Url) -> Option<String> {
-        find_fun_signature_full(fn_name, self, uri)
+        // Index-only: lambda/receiver inference is a hot path (called per lambda in
+        // inlay hints/hover); the old rg + all-files fallback spawned subprocesses for
+        // un-indexed stdlib callees (`let`/`forEachIndexed`) and made inlay time out.
+        find_fun_params_text_fast(fn_name, self, uri)
     }
     fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String> {
         infer_variable_type_raw(self, var_name, uri)
@@ -366,31 +379,31 @@ impl InferDeps for Indexer {
         crate::indexer::infer::sig::find_method_params_in_class(self, class_name, method_name)
     }
     fn find_fun_callable_info(&self, fn_name: &str, _uri: &Url) -> Option<CallableInfo> {
-        // Check source-indexed files first.
-        if let Some(locations) = self.definitions.get(fn_name) {
-            for loc in locations.iter() {
-                if let Some(file_data) = self.files.get(loc.uri.as_str()) {
-                    if let Some(sym) = file_data
-                        .symbols
-                        .iter()
-                        .find(|s| s.name == fn_name && !s.type_params.is_empty())
-                    {
-                        return Some(CallableInfo {
-                            type_params: sym.type_params.clone(),
-                            extension_receiver_type: sym.extension_receiver_type.clone(),
-                        });
-                    }
-                }
-            }
+        // Workspace definitions first (scoped + capped — see find_in_workspace_defs).
+        let from_workspace = self.find_in_workspace_defs(fn_name, |loc| {
+            let file_data = self.files.get(loc.uri.as_str())?;
+            let sym = file_data
+                .symbols
+                .iter()
+                .find(|s| s.name == fn_name && !s.type_params.is_empty())?;
+            Some(CallableInfo {
+                type_params: sym.type_params.clone(),
+                extension_receiver_type: sym.extension_receiver_type.clone(),
+            })
+        });
+        if from_workspace.is_some() {
+            return from_workspace;
         }
-        // Fallback: JAR-indexed files (sidecar symbols now carry type_params).
+        // Fallback: JAR-indexed files (sidecar symbols carry type_params). JAR symbols
+        // use a synthetic line == index into `symbols`, so address each entry directly
+        // (O(1)) rather than a per-loc linear `find` over the whole jar's symbol list.
         let jar_locs = self.jar_definitions.get(fn_name)?;
-        for loc in jar_locs.iter() {
+        for loc in jar_locs.iter().take(MAX_BY_NAME_DEFS) {
             if let Some(file_data) = self.jar_files.get(loc.uri.as_str()) {
                 if let Some(sym) = file_data
                     .symbols
-                    .iter()
-                    .find(|s| s.name == fn_name && !s.type_params.is_empty())
+                    .get(loc.range.start.line as usize)
+                    .filter(|s| s.name == fn_name && !s.type_params.is_empty())
                 {
                     return Some(CallableInfo {
                         type_params: sym.type_params.clone(),
@@ -538,6 +551,7 @@ impl Indexer {
             importable_fqns: std::sync::RwLock::new(std::collections::HashMap::new()),
             live_trees: DashMap::new(),
             sig_cache: DashMap::new(),
+            sig_fast_cache: DashMap::new(),
             enrichment: std::sync::RwLock::new(EnrichmentHandle::noop()),
             jar_sidecar: std::sync::Mutex::new(jar_sidecar),
             jar_phase: Arc::new(std::sync::Mutex::new(initial_jar_phase)),
@@ -662,6 +676,7 @@ impl Indexer {
         self.this_ext_ancestor_cache.clear();
         self.completion_epoch.fetch_add(1, Ordering::Release);
         self.sig_cache.clear();
+        self.sig_fast_cache.clear();
         // Clear enrichment dedup so symbols are re-attempted after reindex.
         if let Ok(handle) = self.enrichment.read() {
             handle.clear();
@@ -784,6 +799,37 @@ impl Indexer {
             locs.extend(jar_locs.iter().cloned());
         }
         locs
+    }
+
+    /// Apply `f` to each *workspace* (non-library) definition location of `name`,
+    /// returning the first `Some`. The single chokepoint for **receiver-less,
+    /// best-effort by-name inference lookups** (return/field/callable/signature
+    /// resolution that has no import or receiver scope).
+    ///
+    /// Ubiquitous names like `create`/`build` resolve to thousands of source-JAR
+    /// definitions once those are indexed; scanning them all per lookup stalled
+    /// inlay/hover for seconds. Library definitions are skipped (their metadata comes
+    /// from indexed symbol detail / the JAR index) and the scan is capped — without a
+    /// receiver type the exact overload can't be picked anyway.
+    ///
+    /// The (≤ [`MAX_BY_NAME_DEFS`]) candidate locations are snapshotted and the
+    /// `definitions` read guard is dropped before `f` runs, so `f` may freely resolve
+    /// other names (re-enter `definitions`) without risking a reader/writer deadlock
+    /// on the shard.
+    pub(crate) fn find_in_workspace_defs<T>(
+        &self,
+        name: &str,
+        f: impl FnMut(&Location) -> Option<T>,
+    ) -> Option<T> {
+        let candidates: Vec<Location> = self
+            .definitions
+            .get(name)?
+            .iter()
+            .filter(|loc| !self.library_uris.contains(loc.uri.as_str()))
+            .take(MAX_BY_NAME_DEFS)
+            .cloned()
+            .collect();
+        candidates.iter().find_map(f)
     }
 
     pub(crate) fn is_library_uri(&self, uri: &Url) -> bool {

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -1060,6 +1060,7 @@ impl Indexer {
         }
         // Invalidate entire signature cache — a changed file may affect lookups from any caller.
         self.sig_cache.clear();
+        self.sig_fast_cache.clear();
 
         let result = Self::parse_file(uri, content);
         self.apply_file_result(&result);

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -6,7 +6,7 @@
 use tower_lsp::lsp_types::Url;
 
 use crate::indexer::infer::sig::{
-    find_fun_signature_full, nth_fun_param_type_str, split_params_at_depth_zero,
+    find_fun_params_text_fast, nth_fun_param_type_str, split_params_at_depth_zero,
 };
 use crate::indexer::NodeExt;
 use crate::indexer::{find_enclosing_call_name, is_id_char, Indexer};
@@ -101,7 +101,7 @@ fn find_named_call_arg_type(
         .split('.')
         .next_back()
         .filter(|name| !name.is_empty())?;
-    let signature = find_fun_signature_full(function_name, idx, uri)?;
+    let signature = find_fun_params_text_fast(function_name, idx, uri)?;
     let parameter_type = find_named_param_type_in_sig(&signature, named_argument)?;
     normalize_parameter_base_type(&parameter_type)
 }
@@ -114,7 +114,7 @@ fn find_positional_call_arg_type(
     uri: &Url,
 ) -> Option<String> {
     let call_context = find_call_context(lines, cursor_line, cursor_column)?;
-    let signature = find_fun_signature_full(&call_context.function_name, idx, uri)?;
+    let signature = find_fun_params_text_fast(&call_context.function_name, idx, uri)?;
     let parameter_type = nth_fun_param_type_str(&signature, call_context.argument_position)?;
     normalize_parameter_base_type(&parameter_type)
 }
@@ -434,7 +434,7 @@ fn cst_call_arg_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String>
     }?;
 
     let fn_name = call_expr.call_fn_name(bytes)?;
-    let sig = find_fun_signature_full(&fn_name, idx, uri)?;
+    let sig = find_fun_params_text_fast(&fn_name, idx, uri)?;
 
     // Named arg: value_argument has [simple_identifier "="] prefix in grammar.
     let param_type = if let Some(arg_name) = value_arg.named_arg_label(bytes) {

--- a/src/indexer/infer/receiver.rs
+++ b/src/indexer/infer/receiver.rs
@@ -47,16 +47,6 @@ pub(crate) fn lambda_receiver_type_from_context(
 
     let callee = normalized_lambda_callee(trimmed);
 
-    // A qualified callee `receiver.method { … }` is a member/extension call on a known
-    // receiver, so resolve it through the receiver's type only. The bare-name fallbacks
-    // (`plain_trailing_lambda_type` → `last_ident_in`) would look up just `method`
-    // across the whole index — for ubiquitous names like `create`/`build` that means
-    // scanning thousands of same-named definitions and picking an arbitrary overload
-    // (slow, and wrong). If the receiver type can't be resolved, emit no hint.
-    if find_last_dot_at_depth_zero(&callee).is_some() {
-        return receiver_dot_lambda_type(&callee, deps, uri);
-    }
-
     receiver_dot_lambda_type(&callee, deps, uri)
         .or_else(|| plain_trailing_lambda_type(trimmed, &callee, deps, uri))
         .or_else(|| inline_lambda_param_type(trimmed, deps, uri))

--- a/src/indexer/infer/receiver.rs
+++ b/src/indexer/infer/receiver.rs
@@ -13,7 +13,7 @@ use super::lambda::{
     lambda_type_first_input, lambda_type_nth_input, lambda_type_receiver, SCOPE_FUNCTIONS,
 };
 use super::sig::{
-    collect_all_fun_params_texts, find_fun_signature_full, last_fun_param_type_str,
+    collect_all_fun_params_texts, find_fun_params_text_fast, last_fun_param_type_str,
     nth_fun_param_type_str, strip_trailing_call_args,
 };
 use super::type_subst::{
@@ -46,6 +46,16 @@ pub(crate) fn lambda_receiver_type_from_context(
     }
 
     let callee = normalized_lambda_callee(trimmed);
+
+    // A qualified callee `receiver.method { … }` is a member/extension call on a known
+    // receiver, so resolve it through the receiver's type only. The bare-name fallbacks
+    // (`plain_trailing_lambda_type` → `last_ident_in`) would look up just `method`
+    // across the whole index — for ubiquitous names like `create`/`build` that means
+    // scanning thousands of same-named definitions and picking an arbitrary overload
+    // (slow, and wrong). If the receiver type can't be resolved, emit no hint.
+    if find_last_dot_at_depth_zero(&callee).is_some() {
+        return receiver_dot_lambda_type(&callee, deps, uri);
+    }
 
     receiver_dot_lambda_type(&callee, deps, uri)
         .or_else(|| plain_trailing_lambda_type(trimmed, &callee, deps, uri))
@@ -505,12 +515,12 @@ pub(super) fn lambda_receiver_type_named_arg_ml(
             if let Some((_sig, param_type)) = found {
                 return lambda_type_nth_input(&param_type, lambda_param_pos);
             }
-            find_fun_signature_full(fn_name, idx, uri)
+            find_fun_params_text_fast(fn_name, idx, uri)
         } else {
-            find_fun_signature_full(fn_name, idx, uri)
+            find_fun_params_text_fast(fn_name, idx, uri)
         }
     } else {
-        find_fun_signature_full(fn_name, idx, uri)
+        find_fun_params_text_fast(fn_name, idx, uri)
     }?;
 
     let param_type = find_named_param_type_in_sig(&sig, named_arg)?;

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -275,10 +275,10 @@ pub(crate) fn find_fun_params_text_fast(fn_name: &str, idx: &Indexer, uri: &Url)
     if let Some(cached) = idx.sig_fast_cache.get(&key) {
         return cached.clone();
     }
-    // Index-only (imports → package → all-indexed-files → JAR); crucially NO rg like
-    // find_fun_signature_full. The O(workspace) all-files scan inside is memoized in
-    // sig_fast_cache so recursive lambda/receiver inference resolves each callee at
-    // most once (and across requests, as long as the cache isn't invalidated).
+    // Index-only (imports → current file → declaring workspace files → JAR); crucially
+    // NO rg like find_fun_signature_full. The result is memoized in sig_fast_cache so
+    // recursive lambda/receiver inference resolves each callee at most once (and across
+    // requests, until the cache is invalidated on reindex).
     let result = find_fun_signature(fn_name, idx, uri);
     idx.sig_fast_cache.insert(key, result.clone());
     result

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -178,10 +178,42 @@ pub(crate) fn collect_signature(lines: &[String], start_line: usize) -> String {
 /// Used by signature help (fires on every keystroke).
 fn find_fun_signature(fn_name: &str, idx: &Indexer, uri: &Url) -> Option<String> {
     // 1. Import-aware resolution using only already-indexed files (no rg/disk).
-    let locs = idx.resolve_symbol_no_rg(fn_name, uri);
-    for loc in &locs {
-        let file_uri_str = loc.uri.as_str();
-        if let Some(data) = idx.files.get(file_uri_str) {
+    if let Some(params) = sig_step_import_aware(fn_name, idx, uri) {
+        return Some(params);
+    }
+
+    // 2. Fallback: current file, then other workspace files that declare `fn_name`.
+    //    The text scan only ever matches a *workspace* function (library params come
+    //    from indexed symbol detail in step 1, or the JAR fallback in step 3), so the
+    //    helper scopes to workspace defs and caps the scan. For stdlib/library callees
+    //    (`let`, `forEachIndexed`, Compose builders) `definitions` has no entry, so
+    //    this is skipped entirely.
+    if let Some(sig) = collect_fun_params_text(fn_name, uri.as_str(), idx) {
+        return Some(sig);
+    }
+    if let Some(sig) = idx.find_in_workspace_defs(fn_name, |loc| {
+        let def_uri = loc.uri.as_str();
+        if def_uri == uri.as_str() {
+            return None;
+        }
+        collect_fun_params_text(fn_name, def_uri, idx)
+    }) {
+        return Some(sig);
+    }
+
+    // 3. JAR fallback.
+    sig_step_jar(fn_name, idx)
+}
+
+/// Step 1 of `find_fun_signature`: resolve `fn_name` through imports/package/etc.
+/// (no rg) and read params from the matching indexed symbol's `detail`.
+fn sig_step_import_aware(fn_name: &str, idx: &Indexer, uri: &Url) -> Option<String> {
+    for loc in idx
+        .resolve_symbol_no_rg(fn_name, uri)
+        .iter()
+        .take(crate::indexer::MAX_BY_NAME_DEFS)
+    {
+        if let Some(data) = idx.files.get(loc.uri.as_str()) {
             let start_line = loc.range.start.line;
             if let Some(symbol_entry) = data.symbols.iter().find(|s| {
                 s.name == fn_name
@@ -194,34 +226,26 @@ fn find_fun_signature(fn_name: &str, idx: &Indexer, uri: &Url) -> Option<String>
             }
         }
     }
+    None
+}
 
-    // 2. Fallback: current file → all already-indexed files (name-only scan).
-    if let Some(sig) = collect_fun_params_text(fn_name, uri.as_str(), idx) {
-        return Some(sig);
-    }
-    for entry in idx.files.iter() {
-        if entry.key() == uri.as_str() {
-            continue;
-        }
-        if let Some(sig) = collect_fun_params_text(fn_name, entry.key(), idx) {
-            return Some(sig);
-        }
-    }
-
-    // 3. JAR fallback: sidecar symbols carry params in their `detail` string
-    //    (e.g. "fun <T> ImmutableList<T>.fastForEach(action: (T) -> Unit)").
-    //    `params` is empty for JAR entries so collect_fun_params_text skips them.
-    if let Some(jar_locs) = idx.jar_definitions.get(fn_name) {
-        for loc in jar_locs.iter() {
-            if let Some(file_data) = idx.jar_files.get(loc.uri.as_str()) {
-                if let Some(jar_symbol_entry) = file_data
-                    .symbols
-                    .iter()
-                    .find(|s| s.name == fn_name && !s.detail.is_empty())
-                {
-                    if let Some(params) = extract_params_from_detail(&jar_symbol_entry.detail) {
-                        return Some(params);
-                    }
+/// Step 3 of `find_fun_signature`: JAR fallback. Sidecar symbols carry params in
+/// their `detail` string (e.g. "fun <T> ImmutableList<T>.fastForEach(action: (T) -> Unit)").
+fn sig_step_jar(fn_name: &str, idx: &Indexer) -> Option<String> {
+    let jar_locs = idx.jar_definitions.get(fn_name)?;
+    for loc in jar_locs.iter() {
+        if let Some(file_data) = idx.jar_files.get(loc.uri.as_str()) {
+            // JAR symbols use a synthetic line == index into `symbols`, so address the
+            // entry directly. A linear `.iter().find()` here scans the whole jar's
+            // symbol list (100k+ for a large AAR) per callee — which made inlay/hover
+            // inference take seconds once the gradle JARs were indexed.
+            if let Some(jar_symbol_entry) = file_data
+                .symbols
+                .get(loc.range.start.line as usize)
+                .filter(|s| s.name == fn_name && !s.detail.is_empty())
+            {
+                if let Some(params) = extract_params_from_detail(&jar_symbol_entry.detail) {
+                    return Some(params);
                 }
             }
         }
@@ -238,6 +262,25 @@ pub(crate) fn find_fun_signature_full(fn_name: &str, idx: &Indexer, uri: &Url) -
     }
     let result = find_fun_signature_full_uncached(fn_name, idx, uri);
     idx.sig_cache.insert(cache_key, result.clone());
+    result
+}
+
+/// Index-only function-signature lookup for hot inference paths (lambda receiver
+/// resolution): resolve the name via imports/package/jar (no rg, no all-files scan)
+/// and read the resolved symbol's parameter list from its `detail`. Returns `None`
+/// quickly when the callee isn't indexed (e.g. a stdlib `let`/`forEachIndexed`),
+/// which is exactly the common case the slow path used to spawn `rg` for.
+pub(crate) fn find_fun_params_text_fast(fn_name: &str, idx: &Indexer, uri: &Url) -> Option<String> {
+    let key = (fn_name.to_owned(), uri.to_string());
+    if let Some(cached) = idx.sig_fast_cache.get(&key) {
+        return cached.clone();
+    }
+    // Index-only (imports → package → all-indexed-files → JAR); crucially NO rg like
+    // find_fun_signature_full. The O(workspace) all-files scan inside is memoized in
+    // sig_fast_cache so recursive lambda/receiver inference resolves each callee at
+    // most once (and across requests, as long as the cache isn't invalidated).
+    let result = find_fun_signature(fn_name, idx, uri);
+    idx.sig_fast_cache.insert(key, result.clone());
     result
 }
 

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -3173,3 +3173,44 @@ fn workspace_importers_of_finds_explicit_plus_star_imports_excludes_non_importer
         "a file that does not import the symbol must be excluded; got {importers:?}"
     );
 }
+
+#[test]
+fn find_in_workspace_defs_invariants() {
+    let idx = Indexer::new();
+    let mk = |u: &Url| Location {
+        uri: u.clone(),
+        range: Range::default(),
+    };
+
+    // (1) Library/source-JAR definitions are skipped — only workspace defs reach `f`.
+    let lib = uri("/lib/Lib.kt");
+    let ws = uri("/ws/Ws.kt");
+    idx.library_uris.insert(lib.as_str().to_owned());
+    idx.definitions
+        .insert("create".to_owned(), vec![mk(&lib), mk(&ws)]);
+    let mut seen: Vec<String> = Vec::new();
+    let _: Option<()> = idx.find_in_workspace_defs("create", |loc| {
+        seen.push(loc.uri.to_string());
+        None
+    });
+    assert_eq!(
+        seen,
+        vec![ws.to_string()],
+        "library definitions must be skipped"
+    );
+
+    // (2) The scan is capped at MAX_BY_NAME_DEFS regardless of how many defs exist.
+    let many: Vec<Location> = (0..(MAX_BY_NAME_DEFS + 25))
+        .map(|i| mk(&uri(&format!("/ws/F{i}.kt"))))
+        .collect();
+    idx.definitions.insert("many".to_owned(), many);
+    let mut count = 0usize;
+    let _: Option<()> = idx.find_in_workspace_defs("many", |_| {
+        count += 1;
+        None
+    });
+    assert_eq!(
+        count, MAX_BY_NAME_DEFS,
+        "scan must be capped at MAX_BY_NAME_DEFS"
+    );
+}

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -465,31 +465,24 @@ pub(crate) fn infer_field_type_raw(
     lines.infer_type_raw(field_name)
 }
 
-/// Look up the raw type of `field_name` declared inside class `class_name`,
-/// resolving across files via the definitions index.
-///
-/// Used for multi-segment receiver chains like `result.availableBanks.map { it }`:
-/// resolves `result` → `ResponseBody`, then looks up `availableBanks` in `ResponseBody`.
 pub(crate) fn find_field_type_in_class(
     indexer: &Indexer,
     class_name: &str,
     field_name: &str,
 ) -> Option<String> {
-    let locs = indexer.definitions.get(class_name)?;
-    for loc in locs.iter() {
-        if let Some(type_name) = infer_field_type_raw(indexer, loc.uri.as_str(), field_name) {
-            return Some(type_name);
-        }
-    }
-    // Fallback: full variable inference including CST-indexed field_access_rhs
-    // and method_call_rhs data (handles unannotated `val x = recv.field`).
-    let locs = indexer.definitions.get(class_name)?;
-    for loc in locs.iter() {
-        if let Some(type_name) = infer_variable_type_raw(indexer, field_name, &loc.uri) {
-            return Some(type_name);
-        }
-    }
-    None
+    // Per-loc field inference is expensive; the helper scopes to workspace defs and
+    // caps the scan so a common class name with many source-JAR defs can't stall.
+    indexer
+        .find_in_workspace_defs(class_name, |loc| {
+            infer_field_type_raw(indexer, loc.uri.as_str(), field_name)
+        })
+        // Fallback: full variable inference including CST-indexed field_access_rhs
+        // and method_call_rhs data (handles unannotated `val x = recv.field`).
+        .or_else(|| {
+            indexer.find_in_workspace_defs(class_name, |loc| {
+                infer_variable_type_raw(indexer, field_name, &loc.uri)
+            })
+        })
 }
 
 // ─── Extension property type inference ───────────────────────────────────────
@@ -663,39 +656,33 @@ fn infer_method_return_type(
     None
 }
 
-/// Look up `method_name` in the symbol index for `type_name` and return its
-/// return type, extracted from `SymbolEntry.detail`.
-/// Look up the return type of a function by name, searching across all indexed files.
-///
-/// Unlike `find_method_return_type` this requires no receiver type — useful when
-/// the caller is a method chain expression and the receiver type is unknown.
-/// Returns the raw return type string (with generics preserved), e.g. `"List<Account>"`.
 pub(crate) fn find_fun_return_type_by_name(indexer: &Indexer, fn_name: &str) -> Option<String> {
-    let locations = indexer.definitions.get(fn_name)?;
-    for loc in locations.iter() {
-        if let Some(file_data) = indexer.files.get(loc.uri.as_str()) {
-            for symbol in &file_data.symbols {
-                if symbol.name != fn_name {
-                    continue;
-                }
-                if !matches!(
-                    symbol.kind,
-                    SymbolKind::FUNCTION | SymbolKind::METHOD | SymbolKind::OPERATOR
-                ) {
-                    continue;
-                }
-                if let Some(ret) = extract_return_type_from_detail(&symbol.detail) {
-                    return Some(ret);
-                }
-                let start_line = symbol.selection_start() as usize;
-                let full_sig = file_data.lines.collect_signature(start_line);
-                if let Some(ret) = extract_return_type_from_detail(&full_sig) {
-                    return Some(ret);
-                }
+    // Receiver-less by-name lookup: the helper scopes to workspace defs and caps the
+    // scan (a ubiquitous name like `create` has thousands of source-JAR defs, each a
+    // full symbol-list + signature line scan — previously a multi-second stall).
+    indexer.find_in_workspace_defs(fn_name, |loc| {
+        let file_data = indexer.files.get(loc.uri.as_str())?;
+        for symbol in &file_data.symbols {
+            if symbol.name != fn_name {
+                continue;
+            }
+            if !matches!(
+                symbol.kind,
+                SymbolKind::FUNCTION | SymbolKind::METHOD | SymbolKind::OPERATOR
+            ) {
+                continue;
+            }
+            if let Some(ret) = extract_return_type_from_detail(&symbol.detail) {
+                return Some(ret);
+            }
+            let start_line = symbol.selection_start() as usize;
+            let full_sig = file_data.lines.collect_signature(start_line);
+            if let Some(ret) = extract_return_type_from_detail(&full_sig) {
+                return Some(ret);
             }
         }
-    }
-    None
+        None
+    })
 }
 
 /// Import-aware return-type lookup. Resolves `fn_name` via the no-rg resolver
@@ -755,37 +742,35 @@ pub(crate) fn find_method_return_type(
         return Some(ret);
     }
 
-    // Then check member functions (container-based).
-    let locations = indexer.definitions.get(type_base)?;
-    for loc in locations.iter() {
-        if let Some(file_data) = indexer.files.get(loc.uri.as_str()) {
-            for symbol in &file_data.symbols {
-                if symbol.name != method_name {
-                    continue;
-                }
-                if !matches!(
-                    symbol.kind,
-                    SymbolKind::FUNCTION | SymbolKind::METHOD | SymbolKind::OPERATOR
-                ) {
-                    continue;
-                }
-                if symbol.container.as_deref() != Some(type_base) {
-                    continue;
-                }
-                // Try detail first; fall back to source lines when detail is truncated.
-                if let Some(ret) = extract_return_type_from_detail(&symbol.detail) {
-                    return Some(ret);
-                }
-                // detail may be truncated (120 char limit) — try the source lines.
-                let start_line = symbol.selection_start() as usize;
-                let full_sig = file_data.lines.collect_signature(start_line);
-                if let Some(ret) = extract_return_type_from_detail(&full_sig) {
-                    return Some(ret);
-                }
+    // Then check member functions (container-based), scoped + capped via the helper.
+    indexer.find_in_workspace_defs(type_base, |loc| {
+        let file_data = indexer.files.get(loc.uri.as_str())?;
+        for symbol in &file_data.symbols {
+            if symbol.name != method_name {
+                continue;
+            }
+            if !matches!(
+                symbol.kind,
+                SymbolKind::FUNCTION | SymbolKind::METHOD | SymbolKind::OPERATOR
+            ) {
+                continue;
+            }
+            if symbol.container.as_deref() != Some(type_base) {
+                continue;
+            }
+            // Try detail first; fall back to source lines when detail is truncated.
+            if let Some(ret) = extract_return_type_from_detail(&symbol.detail) {
+                return Some(ret);
+            }
+            // detail may be truncated (120 char limit) — try the source lines.
+            let start_line = symbol.selection_start() as usize;
+            let full_sig = file_data.lines.collect_signature(start_line);
+            if let Some(ret) = extract_return_type_from_detail(&full_sig) {
+                return Some(ret);
             }
         }
-    }
-    None
+        None
+    })
 }
 
 /// Returns true when an extension function declared in `entry_package` is
@@ -894,11 +879,9 @@ fn find_extension_fn_return_type_global(
     receiver_base: &str,
     method_name: &str,
 ) -> Option<String> {
-    let locations = indexer.definitions.get(method_name)?;
-    for loc in locations.iter() {
-        let Some(file_data) = indexer.files.get(loc.uri.as_str()) else {
-            continue;
-        };
+    // Global extension-fn lookup by bare method name: scoped + capped via the helper.
+    indexer.find_in_workspace_defs(method_name, |loc| {
+        let file_data = indexer.files.get(loc.uri.as_str())?;
         for symbol in &file_data.symbols {
             if symbol.name != method_name {
                 continue;
@@ -909,30 +892,19 @@ fn find_extension_fn_return_type_global(
             if symbol.extension_receiver != receiver_base {
                 continue;
             }
-            // Try detail first; fall back to source lines when detail is truncated.
             if let Some(ret) = extract_return_type_from_detail(&symbol.detail) {
                 return Some(ret);
             }
-            // detail may be truncated (120 char limit) — try the source lines.
             let start_line = symbol.selection_start() as usize;
             let full_sig = file_data.lines.collect_signature(start_line);
             if let Some(ret) = extract_return_type_from_detail(&full_sig) {
                 return Some(ret);
             }
         }
-    }
-    None
+        None
+    })
 }
 
-/// Walk the class hierarchy to find an inherited method's return type.
-///
-/// When `find_method_return_type(indexer, "BuildingSavingsReducer", "reduce")` returns
-/// `None` because `reduce` is declared on supertype `FlowReducer`, this function:
-/// 1. Finds the subclass's supertype declarations (with type args)
-/// 2. Looks up the method on each supertype
-/// 3. Substitutes the supertype's generic type params with the concrete type args
-///
-/// Returns `None` if the method is not found on any supertype.
 pub(crate) fn find_method_return_type_via_supertypes(
     indexer: &Indexer,
     class_name: &str,
@@ -940,59 +912,44 @@ pub(crate) fn find_method_return_type_via_supertypes(
     from_uri: Option<&Url>,
 ) -> Option<String> {
     let class_base = class_name.split('<').next().unwrap_or(class_name);
-    let class_locs = indexer.definitions.get(class_base)?;
 
-    for class_loc in class_locs.iter() {
-        let Some(file_data) = indexer.files.get(class_loc.uri.as_str()) else {
-            continue;
-        };
-        let Some(class_sym) = file_data.symbols.iter().find(|s| s.name == class_base) else {
-            continue;
-        };
+    indexer.find_in_workspace_defs(class_base, |class_loc| {
+        let file_data = indexer.files.get(class_loc.uri.as_str())?;
+        let class_sym = file_data.symbols.iter().find(|s| s.name == class_base)?;
         let class_line = class_sym.selection_start();
 
         for (line, super_name, type_args) in file_data.supers.iter() {
             if *line != class_line {
                 continue;
             }
-            let raw_return_type =
-                find_method_return_type(indexer, super_name, method_name, from_uri);
-            let Some(raw) = raw_return_type else {
+            let Some(raw) = find_method_return_type(indexer, super_name, method_name, from_uri)
+            else {
                 continue;
             };
-
             if type_args.is_empty() {
                 return Some(raw);
             }
-
             let super_type_params = find_class_type_params(indexer, super_name);
             if super_type_params.is_empty() {
                 return Some(raw);
             }
-
-            let substituted = apply_supertype_subst(&raw, &super_type_params, type_args);
-            return Some(substituted);
+            return Some(apply_supertype_subst(&raw, &super_type_params, type_args));
         }
-    }
-    None
+        None
+    })
 }
 
 fn find_class_type_params(indexer: &Indexer, class_name: &str) -> Vec<String> {
-    let Some(locations) = indexer.definitions.get(class_name) else {
-        return Vec::new();
-    };
-    for loc in locations.iter() {
-        if let Some(file_data) = indexer.files.get(loc.uri.as_str()) {
-            if let Some(symbol) = file_data
+    indexer
+        .find_in_workspace_defs(class_name, |loc| {
+            let file_data = indexer.files.get(loc.uri.as_str())?;
+            let symbol = file_data
                 .symbols
                 .iter()
-                .find(|s| s.name == class_name && !s.type_params.is_empty())
-            {
-                return symbol.type_params.clone();
-            }
-        }
-    }
-    Vec::new()
+                .find(|s| s.name == class_name && !s.type_params.is_empty())?;
+            Some(symbol.type_params.clone())
+        })
+        .unwrap_or_default()
 }
 
 /// Replace generic type parameter names with concrete type arguments.


### PR DESCRIPTION
## What

Type inference resolves many things by **bare name** (return type, field type, callable info, signature), and each helper scanned the **entire `definitions` index** for that name with no import/receiver/scope filter. Once gradle **source-JARs** are indexed (1M+ symbols), ubiquitous method names like `create`/`build` have **thousands** of entries — each a per-file symbol + signature line scan. Result: `compute_inlay_hints` / hover stalling for **~4s** and timing out.

This is **pre-existing** on `main` (the leaky functions all live there today); source-JAR indexing + heavier lambda inference just exposed it.

## Changes

- **New chokepoint** `Indexer::find_in_workspace_defs(name, f)` — workspace-scoped, skips library/source-JAR defs, caps at `MAX_BY_NAME_DEFS`. Snapshots candidates and **drops the `definitions` read guard before the callback**, so callbacks that re-resolve names can't deadlock (reader vs. writer on the shard). Replaces 7 duplicated unbounded scans.
- `find_fun_signature`: bound the all-files fallback to files that actually declare the name; address JAR entries by their synthetic line index (**O(1)**) instead of a per-loc full symbol-list scan.
- Lambda/receiver inference uses an **index-only** signature lookup (no `rg` subprocess per un-indexed stdlib/Compose callee), memoized.
- A **qualified** lambda callee `recv.method { it }` resolves through the receiver type only — never a global bare-name fallback (which also picked an arbitrary overload).

## Measurements (Moneta, source-JARs indexed)

`compute_inlay_hints` on the worst reducer file: **~4s → <100ms**, zero `rg` spawns. Diagnosed with the tracing from #178.

## Risk

Bounded, best-effort lookups — without a receiver type they can't pick the exact overload anyway. 1380 tests green. Second of a layered series (#178 logging → this → inference features).

🤖 Generated with [Claude Code](https://claude.com/claude-code)