### PR TITLE
feat(jar): emit + walk JAR class supertypes (inherited-member resolution)

### DIFF
--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
@@ -307,7 +307,12 @@ private fun entriesFromClass(klass: KmClass, dep: DeprecationInfo, pkg: String):
         val tps = klass.typeParameters.joinToString(", ") { it.name }
         "$classKind $simpleName<$tps>"
     }
-    entries += SymbolEntry(simpleName, classKind, "", classDetail, pkg = pkg, topLevel = true)
+    // Direct super types (super class + interfaces) as simple names, for inheritance
+    // walking on the Rust side. `Any` is implicit and dropped as noise.
+    val supers = klass.supertypes.mapNotNull { st ->
+        (st.classifier as? KmClassifier.Class)?.name?.substringAfterLast('/')
+    }.filter { it != "Any" }
+    entries += SymbolEntry(simpleName, classKind, "", classDetail, pkg = pkg, topLevel = true, supers = supers)
 
     for (fn in klass.functions) {
         if (!fn.visibility.isPublicLike()) continue
@@ -391,7 +396,13 @@ private class JavaClassVisitor(private val entries: MutableList<SymbolEntry>, pr
         className = name.substringAfterLast('/')
         isPublicClass = (access and Opcodes.ACC_PUBLIC) != 0
         if (isPublicClass && !className.contains('$')) {
-            entries += SymbolEntry(className, "class", "", "class $className", pkg = pkg, topLevel = true)
+            // Direct super types (super class + interfaces) as simple names; `Object`
+            // is implicit and dropped as noise.
+            val supers = buildList {
+                superName?.takeIf { it != "java/lang/Object" }?.let { add(it.substringAfterLast('/')) }
+                interfaces?.forEach { add(it.substringAfterLast('/')) }
+            }
+            entries += SymbolEntry(className, "class", "", "class $className", pkg = pkg, topLevel = true, supers = supers)
         }
     }
 

--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/model/SymbolEntry.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/model/SymbolEntry.kt
@@ -34,4 +34,11 @@ data class SymbolEntry(
     /** True for top-level declarations (a top-level fun/val, or a class/interface/object itself). */
     @SerialName("top_level")
     val topLevel: Boolean = false,
+    /**
+     * Simple names of this class's direct super types (super class + interfaces),
+     * e.g. `["DialogFragment", "AppCompatDialogFragment"]`. Empty for non-class
+     * symbols and for classes that only extend `Any`/`Object`. Lets the Rust indexer
+     * walk inheritance through library types.
+     */
+    val supers: List<String> = emptyList(),
 )

--- a/src/features/call_arg_diagnostics_tests.rs
+++ b/src/features/call_arg_diagnostics_tests.rs
@@ -1162,6 +1162,7 @@ fn jar_symbol(name: &str, detail: &str, container: &str) -> crate::sidecar::Side
         deprecated: false,
         pkg: String::new(),
         top_level: container.is_empty(),
+        supers: vec![],
     }
 }
 

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -1705,6 +1705,7 @@ async fn find_references_on_jar_symbol_usage_scopes_to_importers() {
             deprecated: false,
             pkg: "androidx.compose.runtime".into(),
             top_level: true,
+            supers: vec![],
         }],
     );
 
@@ -1755,6 +1756,7 @@ async fn find_references_on_jar_symbol_disambiguates_competing_jars() {
         deprecated: false,
         pkg: pkg.into(),
         top_level: true,
+        supers: vec![],
     };
 
     crate::indexer::jar::populate_from_symbols(
@@ -1815,6 +1817,7 @@ async fn find_references_from_jar_definition_site_returns_workspace_callers() {
         deprecated: false,
         pkg: pkg.into(),
         top_level: true,
+        supers: vec![],
     };
     // Populate the competing jar first: a name-only scope lookup would pick `com.other`.
     crate::indexer::jar::populate_from_symbols(

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -675,6 +675,9 @@ fn build_jar_file_data(
 ) -> usize {
     let mut symbols: Vec<SymbolEntry> = Vec::with_capacity(sidecar_symbols.len());
     let mut jar_names: Vec<String> = Vec::with_capacity(sidecar_symbols.len());
+    // (class_synthetic_line, supertype_simple_name, type_args) — lets the hierarchy
+    // walker traverse inheritance through library types.
+    let mut supers: Vec<(u32, String, Vec<String>)> = Vec::new();
 
     for (line_idx, sym) in sidecar_symbols.iter().enumerate() {
         let synthetic_range = tower_lsp::lsp_types::Range {
@@ -728,6 +731,9 @@ fn build_jar_file_data(
                 range: synthetic_range,
             });
         jar_names.push(sym.name.clone());
+        for super_name in &sym.supers {
+            supers.push((line_idx as u32, super_name.clone(), Vec::new()));
+        }
     }
 
     // Populate reverse index so removal can be O(symbols_in_jar).
@@ -846,6 +852,7 @@ fn build_jar_file_data(
             source_set: SourceSet::Library,
             lines: Arc::new(lines),
             package,
+            supers,
             ..Default::default()
         }),
     );

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -34,7 +34,9 @@ use crate::sidecar::SidecarSymbol;
 ///            `annotation class Composable`) — re-scan.
 /// v11 → v12: sidecar strips non-KDoc comments before matching, so comments containing `)`
 ///            inside a multi-line annotation no longer hide the declaration (`@Composable`).
-const JAR_CACHE_VERSION: u32 = 12;
+/// v12 → v13: sidecar now emits each class's direct super types (`supers`), populating
+///            jar `FileData.supers` so inheritance can be walked through library types.
+const JAR_CACHE_VERSION: u32 = 13;
 
 #[derive(Serialize, Deserialize)]
 struct JarCache {

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -32,6 +32,7 @@ fn make_sidecar_symbol(name: &str, kind: &str, detail: &str, container: &str) ->
         deprecated: false,
         pkg: String::new(),
         top_level: container.is_empty(),
+        supers: vec![],
     }
 }
 
@@ -48,6 +49,7 @@ fn make_sidecar_extension(name: &str, receiver_type: &str, detail: &str) -> Side
         deprecated: false,
         pkg: String::new(),
         top_level: true,
+        supers: vec![],
     }
 }
 
@@ -1475,6 +1477,7 @@ fn jar_symbol_gets_real_param_counts() {
             deprecated: false,
             pkg: String::new(),
             top_level: true,
+            supers: vec![],
         }],
     );
     let found = indexer
@@ -1499,6 +1502,7 @@ fn sym_with_pkg(name: &str, container: &str, pkg: &str, top_level: bool) -> Side
         deprecated: false,
         pkg: pkg.to_owned(),
         top_level,
+        supers: vec![],
     }
 }
 

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -3083,6 +3083,7 @@ fn jar_test_symbol(
         deprecated: false,
         pkg: pkg.into(),
         top_level,
+        supers: vec![],
     }
 }
 

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -332,6 +332,7 @@ fn return_type_reachable_prefers_imported_symbol() {
             deprecated: false,
             pkg: "androidx.compose.ui.res".into(),
             top_level: true,
+            supers: vec![],
         }],
     );
     // Workspace decoy with the same name but a different return type.

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -969,12 +969,16 @@ fn resolve_star_imports(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Locatio
 /// 3. Search the resolved file's symbol table for `name`.
 /// 4. Recurse into that file's own supertypes (depth-limited, cycle-safe).
 fn resolve_from_class_hierarchy(indexer: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
+    // Deep enough for real Android/Kotlin hierarchies: app base classes often stack
+    // several levels (`…Fragment → BaseFragment → … → androidx Fragment`) before the
+    // library super that declares an inherited member like `requireActivity`. The
+    // visited-set bounds total work regardless of depth.
     let results = walk_hierarchy(
         indexer,
         "",
         from_uri.as_str(),
         CallerContext::default(),
-        4,
+        12,
         |index, _, class_uri, _| find_name_in_uri(index, name, class_uri),
     );
     // Stable dedup via HashSet — diamond inheritance can produce the same location

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -3393,6 +3393,7 @@ fn import_resolves_jar_symbol_to_correct_package() {
         deprecated: false,
         pkg: pkg.into(),
         top_level,
+        supers: vec![],
     };
 
     let idx = Indexer::new();

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -3503,3 +3503,52 @@ fn import_disambiguates_deeply_nested_member_by_full_chain() {
     // State.Sub.Idle is the object on line 4 (0-indexed); Event.Sub.Idle is line 9.
     assert_eq!(locs[0].range.start.line, 4);
 }
+
+#[test]
+fn jar_to_jar_supertype_walk_resolves_inherited_member() {
+    // Base + its member live in one JAR; Child (which extends Base via `supers`)
+    // lives in a *different* JAR. A member inherited Child→Base is only reachable
+    // by following the JAR class's recorded supertypes across the JAR boundary.
+    let sym = |name: &str, kind: &str, container: &str, supers: Vec<String>| {
+        crate::sidecar::SidecarSymbol {
+            name: name.into(),
+            kind: kind.into(),
+            container: container.into(),
+            detail: format!("{kind} {name}"),
+            doc: String::new(),
+            type_params: vec![],
+            extension_receiver_type: String::new(),
+            trailing_lambda: false,
+            deprecated: false,
+            pkg: "lib".into(),
+            top_level: container.is_empty(),
+            supers,
+        }
+    };
+    let idx = Indexer::new();
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/base.jar"),
+        &[
+            sym("Base", "class", "", vec![]),
+            sym("baseMethod", "fun", "Base", vec![]),
+        ],
+    );
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/child.jar"),
+        &[sym("Child", "class", "", vec!["Base".to_owned()])],
+    );
+
+    let file = uri("/ws/Widget.kt");
+    idx.index_content(
+        &file,
+        "package ws\nclass Widget : Child {\n  fun use() { baseMethod() }\n}",
+    );
+
+    let locs = resolve_symbol(&idx, "baseMethod", None, &file);
+    assert!(
+        locs.iter().any(|l| l.uri.as_str().contains("base.jar")),
+        "baseMethod must resolve via the JAR→JAR supertype walk (Widget → Child → Base); got {locs:?}"
+    );
+}

--- a/src/sidecar.rs
+++ b/src/sidecar.rs
@@ -65,6 +65,10 @@ pub(crate) struct SidecarSymbol {
     /// True for top-level declarations (a top-level fun/val, or a class/interface/object itself).
     #[serde(default)]
     pub top_level: bool,
+    /// Simple names of a class's direct super types (super class + interfaces).
+    /// Empty for non-class symbols and for older sidecars.
+    #[serde(default)]
+    pub supers: Vec<String>,
 }
 
 pub(crate) struct SidecarHandle {


### PR DESCRIPTION
Re-opened (#180 auto-closed when its stacked base branch was deleted on merge). Rebased onto `main` after #178/#179 landed; diff is now jar-supertypes only.

## What

Records each compiled-JAR class's **supertypes** (via the sidecar) and lets the class-hierarchy walk traverse *through* library types — so members inherited from a library base class/interface resolve (previously dead-ended at the JAR boundary).

- Sidecar (`KotlinClassIndexer`, `SymbolEntry`): emit supertype simple-names per class (drop `Any`/`Object`).
- `SidecarSymbol.supers` + `build_jar_file_data` populates `FileData.supers`.
- `hierarchy.rs` follows JAR supertypes; `JAR_CACHE_VERSION` bumped.
- Regression test: JAR→JAR walk (Base + member in one JAR, Child extends Base in another, workspace class extends Child).

## Notes

- Review follow-up: supertypes are emitted as *simple* names, so JAR→JAR resolution is by-name (can collide with a same-named type). Making it deterministic means moving the whole `supers` pipeline (workspace `supers` from `parser.rs` are also simple names; consumers in `hierarchy.rs`/`infer.rs`/`resolution.rs` resolve by name) to FQN + qualified resolution — a separate focused PR. This PR is strictly additive (dead-end → resolves).
- Sidecar JAR must be rebuilt (`./gradlew shadowJar`) to pick up supertype emission.

1382 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)