### PR TITLE
fix: recover annotation-mis-parsed interfaces + strip suspend before receiver type

### DIFF
--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -22,7 +22,9 @@ use crate::types::{FileData, FileIndexResult, Visibility};
 
 /// Bump when the serialized format changes; invalidates any older cache files.
 /// v28: added `SymbolEntry.deprecated` (forces reparse so it populates).
-pub(crate) const CACHE_VERSION: u32 = 28;
+/// v29: recover interface symbols mis-parsed via qualified/array annotations
+///      (forces reparse so the recovered symbols populate).
+pub(crate) const CACHE_VERSION: u32 = 29;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/src/indexer/infer/lambda.rs
+++ b/src/indexer/infer/lambda.rs
@@ -215,18 +215,17 @@ pub(crate) fn lambda_type_first_input(type_name: &str) -> Option<String> {
 }
 
 /// Strip a leading `suspend` keyword from a Kotlin function type string.
-/// `"suspend (T) -> Unit"` → `"(T) -> Unit"`;  anything else unchanged.
-/// Only strips when followed by `(` or `.` (receiver lambdas like `suspend T.() -> R`).
+/// `"suspend (T) -> Unit"` → `"(T) -> Unit"`;
+/// `"suspend ProducerScope<E>.() -> Unit"` → `"ProducerScope<E>.() -> Unit"`.
+/// Requires `suspend` to be a whole word (followed by whitespace) so identifiers like
+/// `suspendable` are untouched. In a function-type string the only word `suspend` can
+/// be is the modifier, so the following token (`(`, a receiver type, …) is the type.
 #[inline]
 fn strip_suspend(type_name: &str) -> &str {
-    let rest = type_name.strip_prefix("suspend").unwrap_or(type_name);
-    if rest.len() == type_name.len() {
-        return type_name;
-    } // no prefix stripped
-    let rest = rest.trim_start();
-    if rest.starts_with('(') || rest.starts_with('.') {
-        rest
-    } else {
-        type_name
+    if let Some(rest) = type_name.strip_prefix("suspend") {
+        if rest.starts_with(char::is_whitespace) {
+            return rest.trim_start();
+        }
     }
+    type_name
 }

--- a/src/indexer/infer/lambda_tests.rs
+++ b/src/indexer/infer/lambda_tests.rs
@@ -83,3 +83,23 @@ fn lambda_type_input_preserves_qualified_type_names() {
         Some("Contract.Effect".into())
     );
 }
+
+#[test]
+fn lambda_type_receiver_strips_suspend_before_receiver_type() {
+    // `suspend` modifier directly before the receiver type (coroutine builders like
+    // `callbackFlow { … }` whose block is `suspend ProducerScope<E>.() -> Unit`).
+    assert_eq!(
+        lambda_type_receiver("suspend ProducerScope<E>.() -> Unit").as_deref(),
+        Some("ProducerScope")
+    );
+    // Plain receiver lambda still resolves.
+    assert_eq!(
+        lambda_type_receiver("LazyListScope.() -> Unit").as_deref(),
+        Some("LazyListScope")
+    );
+    // `suspend` as a prefix of a longer identifier must NOT be stripped.
+    assert_eq!(
+        lambda_type_receiver("suspendableScope.() -> Unit").as_deref(),
+        Some("suspendableScope")
+    );
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,14 +12,15 @@ use crate::queries::{
     KIND_ENUM_CONSTANT, KIND_ENUM_DECL, KIND_EQ, KIND_EXTENDS_INTERFACES, KIND_FIELD_DECL,
     KIND_FORMAL_PARAM, KIND_FORMAL_PARAMS, KIND_FUN, KIND_FUNCTION_TYPE, KIND_FUN_BODY,
     KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS, KIND_IDENTIFIER, KIND_IMPORT_ALIAS, KIND_IMPORT_DECL,
-    KIND_IMPORT_HEADER, KIND_IMPORT_LIST, KIND_INHERITANCE_SPEC, KIND_INHERITANCE_SPECS,
-    KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MOD_FINAL,
-    KIND_MOD_STATIC, KIND_NAV_EXPR, KIND_NULLABLE_TYPE, KIND_OBJECT_DECL, KIND_PACKAGE_DECL,
-    KIND_PACKAGE_HEADER, KIND_PARAMETER, KIND_PRIMARY_CTOR, KIND_PROP_DECL, KIND_PROP_DELEGATE,
-    KIND_PROTOCOL_DECL, KIND_RECORD_DECL, KIND_SCOPED_IDENT, KIND_SECONDARY_CTOR,
-    KIND_SIMPLE_IDENT, KIND_SOURCE_FILE, KIND_STATEMENTS, KIND_SUPERCLASS, KIND_SUPER_INTERFACES,
-    KIND_TYPE_IDENT, KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VALUE_ARGS, KIND_VAR_DECL,
-    KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
+    KIND_IMPORT_HEADER, KIND_IMPORT_LIST, KIND_INFIX_EXPR, KIND_INHERITANCE_SPEC,
+    KIND_INHERITANCE_SPECS, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_METHOD_DECL, KIND_MODIFIERS,
+    KIND_MOD_FINAL, KIND_MOD_STATIC, KIND_NAV_EXPR, KIND_NULLABLE_TYPE, KIND_OBJECT_DECL,
+    KIND_PACKAGE_DECL, KIND_PACKAGE_HEADER, KIND_PARAMETER, KIND_PREFIX_EXPR, KIND_PRIMARY_CTOR,
+    KIND_PROP_DECL, KIND_PROP_DELEGATE, KIND_PROTOCOL_DECL, KIND_RECORD_DECL, KIND_SCOPED_IDENT,
+    KIND_SECONDARY_CTOR, KIND_SIMPLE_IDENT, KIND_SOURCE_FILE, KIND_STATEMENTS, KIND_SUPERCLASS,
+    KIND_SUPER_INTERFACES, KIND_TYPE_IDENT, KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VALUE_ARGS,
+    KIND_VAR_DECL, KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT, KOTLIN_DEFINITIONS,
+    SWIFT_DEFINITIONS,
 };
 use crate::StrExt;
 
@@ -923,28 +924,29 @@ fn extract_misparsed_annotated_interfaces(root: Node, bytes: &[u8], data: &mut F
     // declarations, so a top-level expression node is the (cheap) signal that this
     // recovery is needed. Note: a qualified annotation can trigger the mis-parse with
     // NO ERROR node, so we cannot gate on `has_error()`.
-    let mut top = root.walk();
+    let mut cursor = root.walk();
     let needs_recovery = root
-        .children(&mut top)
-        .any(|c| matches!(c.kind(), "prefix_expression" | "infix_expression"));
-    drop(top);
+        .children(&mut cursor)
+        .any(|child| matches!(child.kind(), KIND_PREFIX_EXPR | KIND_INFIX_EXPR));
+    drop(cursor);
     if !needs_recovery {
         return;
     }
 
     let mut stack = vec![root];
     while let Some(node) = stack.pop() {
-        if node.kind() == "infix_expression" {
+        if node.kind() == KIND_INFIX_EXPR {
             if let Some(name_node) = misparsed_interface_name_node(&node, bytes) {
                 if let Ok(name) = name_node.utf8_text(bytes) {
-                    if !name.is_empty() && !data.symbols.iter().any(|s| s.name == name) {
+                    let already_extracted = data.symbols.iter().any(|symbol| symbol.name == name);
+                    if !name.is_empty() && !already_extracted {
                         push_interface_symbol(name, &node, name_node.range(), bytes, data);
                     }
                 }
             }
         }
-        let mut cur = node.walk();
-        for child in node.children(&mut cur) {
+        let mut child_cursor = node.walk();
+        for child in node.children(&mut child_cursor) {
             stack.push(child);
         }
     }
@@ -955,16 +957,16 @@ fn extract_misparsed_annotated_interfaces(root: Node, bytes: &[u8], data: &mut F
 /// bare `simple_identifier`; the name follows as a `call_expression` callee (with a
 /// body) or a trailing `simple_identifier` (no body).
 fn misparsed_interface_name_node<'a>(infix: &Node<'a>, bytes: &[u8]) -> Option<Node<'a>> {
-    let mut cur = infix.walk();
-    let children: Vec<Node<'a>> = infix.children(&mut cur).collect();
-    drop(cur);
-    let kw_idx = children.iter().position(|c| {
-        c.kind() == KIND_SIMPLE_IDENT && c.utf8_text(bytes).ok() == Some("interface")
+    let mut cursor = infix.walk();
+    let children: Vec<Node<'a>> = infix.children(&mut cursor).collect();
+    drop(cursor);
+    let interface_keyword_index = children.iter().position(|child| {
+        child.kind() == KIND_SIMPLE_IDENT && child.utf8_text(bytes).ok() == Some("interface")
     })?;
-    let after = children.get(kw_idx + 1)?;
-    match after.kind() {
-        KIND_CALL_EXPR => after.first_child_of_kind(KIND_SIMPLE_IDENT),
-        KIND_SIMPLE_IDENT => Some(*after),
+    let name_node = children.get(interface_keyword_index + 1)?;
+    match name_node.kind() {
+        KIND_CALL_EXPR => name_node.first_child_of_kind(KIND_SIMPLE_IDENT),
+        KIND_SIMPLE_IDENT => Some(*name_node),
         _ => None,
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -175,7 +175,7 @@ pub(crate) fn parse_kotlin(content: &str) -> FileData {
         // ── fun interface (tree-sitter parses these as ERROR + lambda_literal) ─
         data.extract_fun_interfaces(root, bytes);
 
-        // ── interfaces mis-parsed via a trailing comma in an annotation array arg ─
+        // ── interfaces mis-parsed because of a qualified / array-arg annotation ─
         extract_misparsed_annotated_interfaces(root, bytes, data);
 
         // ── secondary constructors (no @name in tree-sitter patterns) ────────
@@ -911,13 +911,17 @@ fn extract_fun_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
     }
 }
 
-/// Recover an interface symbol that tree-sitter mis-parsed because a trailing comma
-/// in an annotation array argument (`@Subcomponent(modules = [X::class,])`) created an
-/// ERROR that cascades: `internal interface Foo { … }` then parses as
+/// Recover an interface symbol that tree-sitter-kotlin mis-parsed because of its
+/// annotations. A *qualified* annotation (`@A.B.C`) and/or a multi-line array-arg
+/// annotation (`@Subcomponent(modules = [X::class])`) before an interface can make
+/// `internal interface Foo { … }` parse as expression soup —
 /// `infix_expression(simple_identifier "internal", simple_identifier "interface",
-/// call_expression(simple_identifier "Foo", …))` instead of a `class_declaration`,
-/// so `Foo` is never emitted as a symbol (breaks go-to-def, resolution, and flags it
-/// as a missing import). Gated on `has_error()` and the precise mis-parse shape.
+/// call_expression(simple_identifier "Foo", …))` instead of a `class_declaration` — so
+/// `Foo` is never emitted as a symbol (breaks go-to-def, hover, resolution).
+///
+/// The mis-parse can occur with **no** `ERROR` node (a qualified annotation alone
+/// triggers it), so this cannot gate on `has_error()`; it instead gates on a top-level
+/// expression node, since normal Kotlin top level holds only declarations (see body).
 fn extract_misparsed_annotated_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
     // The mis-parse surfaces the whole declaration as a top-level `prefix_expression`
     // (annotations) wrapping an `infix_expression` — normal Kotlin top level only has

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -174,6 +174,9 @@ pub(crate) fn parse_kotlin(content: &str) -> FileData {
         // ── fun interface (tree-sitter parses these as ERROR + lambda_literal) ─
         data.extract_fun_interfaces(root, bytes);
 
+        // ── interfaces mis-parsed via a trailing comma in an annotation array arg ─
+        extract_misparsed_annotated_interfaces(root, bytes, data);
+
         // ── secondary constructors (no @name in tree-sitter patterns) ────────
         data.extract_secondary_constructors(root, bytes);
 
@@ -904,6 +907,65 @@ fn extract_fun_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
                 stack.push(child);
             }
         }
+    }
+}
+
+/// Recover an interface symbol that tree-sitter mis-parsed because a trailing comma
+/// in an annotation array argument (`@Subcomponent(modules = [X::class,])`) created an
+/// ERROR that cascades: `internal interface Foo { … }` then parses as
+/// `infix_expression(simple_identifier "internal", simple_identifier "interface",
+/// call_expression(simple_identifier "Foo", …))` instead of a `class_declaration`,
+/// so `Foo` is never emitted as a symbol (breaks go-to-def, resolution, and flags it
+/// as a missing import). Gated on `has_error()` and the precise mis-parse shape.
+fn extract_misparsed_annotated_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
+    // The mis-parse surfaces the whole declaration as a top-level `prefix_expression`
+    // (annotations) wrapping an `infix_expression` — normal Kotlin top level only has
+    // declarations, so a top-level expression node is the (cheap) signal that this
+    // recovery is needed. Note: a qualified annotation can trigger the mis-parse with
+    // NO ERROR node, so we cannot gate on `has_error()`.
+    let mut top = root.walk();
+    let needs_recovery = root
+        .children(&mut top)
+        .any(|c| matches!(c.kind(), "prefix_expression" | "infix_expression"));
+    drop(top);
+    if !needs_recovery {
+        return;
+    }
+
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "infix_expression" {
+            if let Some(name_node) = misparsed_interface_name_node(&node, bytes) {
+                if let Ok(name) = name_node.utf8_text(bytes) {
+                    if !name.is_empty() && !data.symbols.iter().any(|s| s.name == name) {
+                        push_interface_symbol(name, &node, name_node.range(), bytes, data);
+                    }
+                }
+            }
+        }
+        let mut cur = node.walk();
+        for child in node.children(&mut cur) {
+            stack.push(child);
+        }
+    }
+}
+
+/// If `infix` is the mis-parse of `[modifiers] interface Name { … }`, return the
+/// `simple_identifier` node holding `Name`. The `interface` keyword appears as a
+/// bare `simple_identifier`; the name follows as a `call_expression` callee (with a
+/// body) or a trailing `simple_identifier` (no body).
+fn misparsed_interface_name_node<'a>(infix: &Node<'a>, bytes: &[u8]) -> Option<Node<'a>> {
+    let mut cur = infix.walk();
+    let children: Vec<Node<'a>> = infix.children(&mut cur).collect();
+    drop(cur);
+    let kw_idx = children.iter().position(|c| {
+        c.kind() == KIND_SIMPLE_IDENT && c.utf8_text(bytes).ok() == Some("interface")
+    })?;
+    let after = children.get(kw_idx + 1)?;
+    match after.kind() {
+        KIND_CALL_EXPR => after.first_child_of_kind(KIND_SIMPLE_IDENT),
+        KIND_SIMPLE_IDENT => Some(*after),
+        _ => None,
     }
 }
 

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -1765,3 +1765,27 @@ fn extension_property_with_public_modifier_receiver() {
         .expect("viewModelScope should be indexed");
     assert_eq!(sym.extension_receiver, "ViewModel");
 }
+
+#[test]
+fn interface_misparsed_by_annotation_is_recovered() {
+    // A qualified annotation (`@A.B.C`) plus an array-arg annotation make
+    // tree-sitter-kotlin mis-parse `interface Foo { … }` as expression soup
+    // (`infix_expression(… "interface" call_expression(Foo …))`), so the symbol is
+    // never emitted — breaking go-to-def/hover/resolution. It must be recovered.
+    let data = parse_kotlin(
+        "package p\n\
+         @Scope.Nested.Marker\n\
+         @Subcomponent(modules = [Mod::class])\n\
+         internal interface NeedsRecovery {\n\
+           fun create(): NeedsRecovery\n\
+         }\n\
+         interface CleanlyParsed\n",
+    );
+    let recovered = sym(&data, "NeedsRecovery").expect("mis-parsed interface must be recovered");
+    assert_eq!(recovered.kind, SymbolKind::INTERFACE);
+    // A normally-parsed sibling is unaffected (recovery doesn't disturb it).
+    assert_eq!(
+        sym(&data, "CleanlyParsed").map(|symbol| symbol.kind),
+        Some(SymbolKind::INTERFACE)
+    );
+}

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -470,6 +470,7 @@ pub(crate) const KIND_KW_ENUM: &str = "enum";
 pub(crate) const KIND_KW_VAL: &str = "val";
 pub(crate) const KIND_BINDING_PATTERN_KIND: &str = "binding_pattern_kind";
 pub(crate) const KIND_PREFIX_EXPR: &str = "prefix_expression";
+pub(crate) const KIND_INFIX_EXPR: &str = "infix_expression";
 pub(crate) const KIND_IF_EXPR: &str = "if_expression";
 pub(crate) const KIND_CHECK_EXPR: &str = "check_expression";
 pub(crate) const KIND_COMPARISON_EXPR: &str = "comparison_expression";


### PR DESCRIPTION
Two independent symbol/type-inference correctness fixes (extracted from missing-import-diagnostic work; both benefit go-to-def / hover / inlay / completion).

## 1. Recover interface symbols mis-parsed by annotations

A qualified annotation (`@A.B.C`) and/or a multi-line array-arg annotation (`@Subcomponent(modules = [X::class])`) before a Kotlin `interface` makes tree-sitter-kotlin mis-parse `interface Foo { … }` as expression soup — `infix_expression(… "interface" call_expression(Foo …))` instead of a `class_declaration`. The result: **`Foo` is never emitted as a symbol**, so go-to-def, hover, completion, and resolution all silently fail for it. This hit essentially every Dagger `@Subcomponent`/`@Component` in a real project.

Recovery mirrors the existing `extract_fun_interfaces` pattern: when `source_file` has a top-level expression node (the mis-parse signal — normal top level is only declarations; note the mis-parse can occur with **no** ERROR node), walk for the `infix_expression` shape and emit the interface symbol. `CACHE_VERSION` bumped (forces a reparse so recovered symbols populate).

## 2. Strip `suspend` before a receiver type

`strip_suspend` only removed `suspend` when followed by `(` or `.`, so a suspend *receiver* lambda type like `suspend ProducerScope<E>.() -> Unit` kept the keyword and `lambda_type_receiver` returned `"suspend"` as the receiver. That broke `this`/implicit-receiver resolution inside coroutine builders (`callbackFlow { … }`). Now strips `suspend` whenever it's a whole word (so `suspendableScope` is untouched).

## Tests
- `interface_misparsed_by_annotation_is_recovered` (+ a cleanly-parsed sibling as a regression guard)
- `lambda_type_receiver_strips_suspend_before_receiver_type` (+ a misleading `suspendableScope` case)

1384 tests green; `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)