### PR TITLE
fix(resolve): companion-object member wins over same-named instance member

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,11 +8,11 @@ use tree_sitter::{Node, Parser, Query, QueryCursor};
 use crate::indexer::NodeExt;
 use crate::queries::{
     self, KIND_ANNOTATION_TYPE_DECL, KIND_CALLABLE_REF, KIND_CALL_EXPR, KIND_CALL_SUFFIX,
-    KIND_CLASS_BODY, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_CTOR_DECL, KIND_DELEGATION_SPEC,
-    KIND_ENUM_CONSTANT, KIND_ENUM_DECL, KIND_EQ, KIND_EXTENDS_INTERFACES, KIND_FIELD_DECL,
-    KIND_FORMAL_PARAM, KIND_FORMAL_PARAMS, KIND_FUN, KIND_FUNCTION_TYPE, KIND_FUN_BODY,
-    KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS, KIND_IDENTIFIER, KIND_IMPORT_ALIAS, KIND_IMPORT_DECL,
-    KIND_IMPORT_HEADER, KIND_IMPORT_LIST, KIND_INFIX_EXPR, KIND_INHERITANCE_SPEC,
+    KIND_CLASS_BODY, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ, KIND_CTOR_DECL,
+    KIND_DELEGATION_SPEC, KIND_ENUM_CONSTANT, KIND_ENUM_DECL, KIND_EQ, KIND_EXTENDS_INTERFACES,
+    KIND_FIELD_DECL, KIND_FORMAL_PARAM, KIND_FORMAL_PARAMS, KIND_FUN, KIND_FUNCTION_TYPE,
+    KIND_FUN_BODY, KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS, KIND_IDENTIFIER, KIND_IMPORT_ALIAS,
+    KIND_IMPORT_DECL, KIND_IMPORT_HEADER, KIND_IMPORT_LIST, KIND_INFIX_EXPR, KIND_INHERITANCE_SPEC,
     KIND_INHERITANCE_SPECS, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_METHOD_DECL, KIND_MODIFIERS,
     KIND_MOD_FINAL, KIND_MOD_STATIC, KIND_NAV_EXPR, KIND_NULLABLE_TYPE, KIND_OBJECT_DECL,
     KIND_PACKAGE_DECL, KIND_PACKAGE_HEADER, KIND_PARAMETER, KIND_PREFIX_EXPR, KIND_PRIMARY_CTOR,
@@ -180,6 +180,9 @@ pub(crate) fn parse_kotlin(content: &str) -> FileData {
 
         // ── secondary constructors (no @name in tree-sitter patterns) ────────
         data.extract_secondary_constructors(root, bytes);
+
+        // ── anonymous companion objects (no @name in tree-sitter patterns) ────
+        extract_anonymous_companion_objects(root, bytes, data);
 
         // ── supertype relationships (delegation specifiers) ────────────────────
         data.extract_supers_kotlin(root, bytes);
@@ -1027,6 +1030,56 @@ fn extract_secondary_constructors(root: Node, bytes: &[u8], data: &mut FileData)
                     deprecated,
                 });
             }
+        }
+        let mut cursor = node.walk();
+        stack.extend(node.children(&mut cursor));
+    }
+}
+
+/// The implicit name Kotlin gives an unnamed `companion object { ... }`.
+pub(crate) const COMPANION_OBJECT_NAME: &str = "Companion";
+
+/// Anonymous `companion object { ... }` has no `type_identifier` child, so the
+/// tree-sitter query (which requires a `@name` capture) never matches it — only
+/// the named form `companion object Factory { ... }` does. Without a symbol entry
+/// for the anonymous case, `assign_containers` can't tell a companion member apart
+/// from a regular instance member of the same enclosing class (both get `container
+/// == "Foo"`), which is what let `Foo.fooFunc()` resolve to the wrong overload when
+/// both a member and a companion member share the name. Synthesize the missing
+/// entry with Kotlin's implicit name "Companion" so container assignment nests
+/// companion members under it instead.
+fn extract_anonymous_companion_objects(root: Node, bytes: &[u8], data: &mut FileData) {
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if node.kind() == KIND_COMPANION_OBJ && node.extract_type_name(bytes).is_none() {
+            let range = ts_to_lsp(node.range());
+            let sel = Range::new(
+                range.start,
+                Position::new(
+                    range.start.line,
+                    range.start.character + "companion object".len() as u32,
+                ),
+            );
+            let detail = extract_detail(&data.lines, range.start.line, range.end.line);
+            let visibility = visibility_at_line(&data.lines, range.start.line as usize);
+            let deprecated = deprecated_at_line(&data.lines, range.start.line as usize);
+            data.symbols.push(SymbolEntry {
+                name: COMPANION_OBJECT_NAME.to_owned(),
+                kind: SymbolKind::OBJECT,
+                visibility,
+                range,
+                selection_range: sel,
+                detail,
+                type_params: Vec::new(),
+                extension_receiver: String::new(),
+                extension_receiver_type: String::new(),
+                container: None,
+                params: String::new(),
+                param_counts: (0, 0),
+                doc: String::new(),
+                trailing_lambda: false,
+                deprecated,
+            });
         }
         let mut cursor = node.walk();
         stack.extend(node.children(&mut cursor));

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -1594,9 +1594,12 @@ fn container_companion_object() {
     let src = "class Host {\n    companion object {\n        fun factory() {}\n    }\n}";
     let data = parse_kotlin(src);
     let factory = sym(&data, "factory").unwrap();
-    // Unnamed companion objects aren't extracted as separate symbols,
-    // so factory's container is the enclosing class.
-    assert_eq!(factory.container.as_deref(), Some("Host"));
+    // An anonymous `companion object { ... }` is synthesized as a "Companion"
+    // symbol (Kotlin's implicit name) so its members nest under it, distinct
+    // from the enclosing class's own members. Without this, a same-named
+    // member and companion member resolve to the same container and `Foo.member()`
+    // would pick whichever appears first in the file instead of the companion.
+    assert_eq!(factory.container.as_deref(), Some("Companion"));
 }
 
 #[test]

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -564,10 +564,18 @@ fn resolve_qualified(
             // companion-object member in Kotlin — never an instance member of `Foo`,
             // even if one shares the name. Try the companion first so a same-named
             // instance member declared earlier in the file can't shadow it.
-            let companion_locs =
-                resolve_companion_member(indexer, name, root, qual_loc.uri.as_str());
-            if !companion_locs.is_empty() {
-                return companion_locs;
+            //
+            // Only the single-segment `Foo.member` form names `root` as the
+            // qualifying class. For a multi-segment qualifier like
+            // `Outer.Inner.member`, `root` is `Outer` — not the class the member
+            // is accessed on — so probing `Outer`'s companion would mis-resolve;
+            // fall through to the nested-segment handling instead.
+            if segments.len() == 1 {
+                let companion_locs =
+                    resolve_companion_member(indexer, name, root, qual_loc.uri.as_str());
+                if !companion_locs.is_empty() {
+                    return companion_locs;
+                }
             }
 
             let after_line = qual_loc.range.start.line;
@@ -794,8 +802,16 @@ fn resolve_companion_member(
         return vec![];
     };
     let Some(companion) = file_data.symbols.iter().find(|symbol| {
+        // `kind == OBJECT` already restricts this to object declarations; among
+        // those, the companion is the one carrying the `companion` soft-keyword.
+        // Match it as a token rather than a prefix so leading modifiers or an
+        // annotation line (`private companion object`, `@JvmStatic\ncompanion
+        // object`) don't hide it.
         symbol.kind == SymbolKind::OBJECT
-            && symbol.detail.starts_with("companion object")
+            && symbol
+                .detail
+                .split_whitespace()
+                .any(|token| token == "companion")
             && range_encloses(class_range, symbol.range)
     }) else {
         return vec![];

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
 
-use tower_lsp::lsp_types::{Location, Url};
+use tower_lsp::lsp_types::{Location, SymbolKind, Url};
 
 use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
@@ -560,6 +560,16 @@ fn resolve_qualified(
         // Then check member functions (same-file).
         let qual_locs = resolve_symbol(indexer, root, None, from_uri);
         for qual_loc in &qual_locs {
+            // `Foo.member` with `Foo` a class name (not a variable) can only reach a
+            // companion-object member in Kotlin — never an instance member of `Foo`,
+            // even if one shares the name. Try the companion first so a same-named
+            // instance member declared earlier in the file can't shadow it.
+            let companion_locs =
+                resolve_companion_member(indexer, name, root, qual_loc.uri.as_str());
+            if !companion_locs.is_empty() {
+                return companion_locs;
+            }
+
             let after_line = qual_loc.range.start.line;
             let locs =
                 find_name_in_uri_after_line(indexer, name, qual_loc.uri.as_str(), after_line);
@@ -750,6 +760,59 @@ fn pos_tuple(p: tower_lsp::lsp_types::Position) -> (u32, u32) {
 /// Whether `outer` fully contains `inner` (start ≤ start and end ≥ end).
 fn range_encloses(outer: tower_lsp::lsp_types::Range, inner: tower_lsp::lsp_types::Range) -> bool {
     pos_tuple(outer.start) <= pos_tuple(inner.start) && pos_tuple(inner.end) <= pos_tuple(outer.end)
+}
+
+/// Find `name` inside the companion object nested in `class_name`.
+///
+/// `Foo.member` with `Foo` a class name (not a variable) can only ever reach a
+/// companion-object member in Kotlin — never an instance member of `Foo`, even
+/// when one happens to share the name. The companion is identified by its
+/// `detail`, which always starts with the literal `"companion object"` keywords
+/// (set by [`crate::parser::extract_detail`] for both the named and the
+/// synthesized-anonymous form — see [`crate::parser::extract_anonymous_companion_objects`]).
+fn resolve_companion_member(
+    indexer: &Indexer,
+    name: &str,
+    class_name: &str,
+    file_uri: &str,
+) -> Vec<Location> {
+    let Ok(uri) = Url::parse(file_uri) else {
+        return vec![];
+    };
+    let Some(file_data) = indexer.file_data_for(file_uri) else {
+        return vec![];
+    };
+    // The class's full declaration range (not just its name's selection range) is
+    // needed to tell which companion object belongs to it when a file has more
+    // than one class.
+    let Some(class_range) = file_data
+        .symbols
+        .iter()
+        .find(|symbol| symbol.name == class_name && crate::parser::is_container_kind(symbol.kind))
+        .map(|symbol| symbol.range)
+    else {
+        return vec![];
+    };
+    let Some(companion) = file_data.symbols.iter().find(|symbol| {
+        symbol.kind == SymbolKind::OBJECT
+            && symbol.detail.starts_with("companion object")
+            && range_encloses(class_range, symbol.range)
+    }) else {
+        return vec![];
+    };
+    file_data
+        .symbols
+        .iter()
+        .filter(|symbol| {
+            symbol.name == name
+                && symbol.range != companion.range
+                && range_encloses(companion.range, symbol.range)
+        })
+        .map(|symbol| Location {
+            uri: uri.clone(),
+            range: symbol.selection_range,
+        })
+        .collect()
 }
 
 /// Step 2 — explicit single-symbol imports.

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -240,6 +240,40 @@ fn resolve_qualified_class_name_prefers_companion_member_over_instance_member() 
 }
 
 #[test]
+fn resolve_qualified_class_name_prefers_private_companion_member() {
+    // The companion-object detection must not assume the declaration starts with
+    // `companion object` — a `private` (or otherwise modified) companion is still
+    // a companion. Regression for a detail-prefix check that missed modifiers.
+    let host_uri = uri("/Host.kt");
+    let foo_uri = uri("/Foo.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &foo_uri,
+        concat!(
+            "package com.pkg\n",
+            "class Foo {\n",
+            "  fun fooFunc() {}\n",
+            "  private companion object {\n",
+            "    fun fooFunc() {}\n",
+            "  }\n",
+            "}\n",
+        ),
+    );
+    idx.index_content(&host_uri, "package com.pkg\nfun caller() { Foo.fooFunc() }");
+
+    let locs = resolve_symbol(&idx, "fooFunc", Some("Foo"), &host_uri);
+    assert!(
+        !locs.is_empty(),
+        "fooFunc not found via class-name qualifier"
+    );
+    assert_eq!(
+        locs[0].range.start.line, 4,
+        "expected the private companion's fooFunc (line 4), got line {}",
+        locs[0].range.start.line
+    );
+}
+
+#[test]
 fn resolve_qualified_class_name_prefers_named_companion_member() {
     // Same as above but with an explicitly named companion (`companion object
     // Factory`), which the tree-sitter query already captures as a `@name`d

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -204,6 +204,76 @@ fn resolve_qualifier_dot_access() {
 }
 
 #[test]
+fn resolve_qualified_class_name_prefers_companion_member_over_instance_member() {
+    // `Foo.fooFunc()` where `Foo` is a class name (not a variable) can only ever
+    // call a companion-object member in Kotlin — an instance member of the same
+    // name is not reachable through the class name. When a class has both, the
+    // companion member must win, not whichever member happens to appear first
+    // (by line) in the file.
+    let host_uri = uri("/Host.kt");
+    let foo_uri = uri("/Foo.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &foo_uri,
+        concat!(
+            "package com.pkg\n",
+            "class Foo {\n",
+            "  fun fooFunc() {}\n",
+            "  companion object {\n",
+            "    fun fooFunc() {}\n",
+            "  }\n",
+            "}\n",
+        ),
+    );
+    idx.index_content(&host_uri, "package com.pkg\nfun caller() { Foo.fooFunc() }");
+
+    let locs = resolve_symbol(&idx, "fooFunc", Some("Foo"), &host_uri);
+    assert!(
+        !locs.is_empty(),
+        "fooFunc not found via class-name qualifier"
+    );
+    assert_eq!(
+        locs[0].range.start.line, 4,
+        "expected the companion's fooFunc (line 4), got line {}",
+        locs[0].range.start.line
+    );
+}
+
+#[test]
+fn resolve_qualified_class_name_prefers_named_companion_member() {
+    // Same as above but with an explicitly named companion (`companion object
+    // Factory`), which the tree-sitter query already captures as a `@name`d
+    // symbol — confirm the fix covers both the named and anonymous forms.
+    let host_uri = uri("/Host.kt");
+    let foo_uri = uri("/Foo.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &foo_uri,
+        concat!(
+            "package com.pkg\n",
+            "class Foo {\n",
+            "  fun fooFunc() {}\n",
+            "  companion object Factory {\n",
+            "    fun fooFunc() {}\n",
+            "  }\n",
+            "}\n",
+        ),
+    );
+    idx.index_content(&host_uri, "package com.pkg\nfun caller() { Foo.fooFunc() }");
+
+    let locs = resolve_symbol(&idx, "fooFunc", Some("Foo"), &host_uri);
+    assert!(
+        !locs.is_empty(),
+        "fooFunc not found via class-name qualifier"
+    );
+    assert_eq!(
+        locs[0].range.start.line, 4,
+        "expected the named companion's fooFunc (line 4), got line {}",
+        locs[0].range.start.line
+    );
+}
+
+#[test]
 fn resolve_deep_qualifier_chain() {
     // A.B.C.D cursor on D → qualifier = "A.B.C"
     // resolve_qualified should resolve root "A", find its file, locate "D" in it.


### PR DESCRIPTION
## Problem

`Foo.fooFunc()` where `Foo` is a class name (not a variable) can only ever reach a companion-object member in Kotlin — never an instance member, even when one shares the name. `resolve_qualified`'s uppercase-root branch instead searched the whole file for any symbol named `fooFunc` and returned whichever appeared first by line, so a same-named instance member declared earlier in the file silently won over the companion's member.

## Fix

Two parts:

1. **Parser**: an anonymous `companion object { ... }` has no `type_identifier` child, so the existing tree-sitter query (which requires a `@name` capture) never matched it — only the named form (`companion object Factory { ... }`) did. Without a symbol entry for the anonymous case, container assignment couldn't distinguish a companion member from a regular instance member of the same class (both got `container == "Foo"`). Synthesizes the missing entry with Kotlin's implicit name `"Companion"`, mirroring the existing secondary-constructor synthesis pattern (`extract_secondary_constructors`).

2. **Resolver**: `resolve_qualified` now tries the companion object first when the qualifier is a class name, falling back to the existing any-member search only when no companion member matches.

## Test plan

- [x] `cargo test` — 1391 passed
- [x] `cargo clippy -- -D warnings` — clean
- [x] Added regression tests for both the anonymous and explicitly-named companion-object forms
- [x] Updated the parser test that documented the old (buggy) container-assignment behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)