### PR TITLE
fix(completion): restore autocomplete after Kotlin's safe-call `?.`

### DIFF
--- a/src/features/completion_tests.rs
+++ b/src/features/completion_tests.rs
@@ -126,6 +126,47 @@ fn dot_receiver_none() {
     assert_eq!(ReceiverExpr::parse("foo"), None);
 }
 
+#[test]
+fn dot_receiver_safe_call() {
+    // `nullable?.` (Kotlin's safe-call operator) must resolve the same receiver
+    // chain as a plain `.` — the `?` only affects null-handling, not which type's
+    // members should be suggested.
+    assert_eq!(
+        ReceiverExpr::parse("nullable?."),
+        recv("nullable", false),
+        "safe-call `?.` on a simple variable should still yield a receiver"
+    );
+}
+
+#[test]
+fn dot_receiver_safe_call_chained() {
+    assert_eq!(
+        ReceiverExpr::parse("outer.nullable?."),
+        recv("outer.nullable", false),
+        "safe-call after a dotted chain should keep the full chain"
+    );
+}
+
+#[test]
+fn dot_receiver_safe_call_after_call_expression() {
+    assert_eq!(
+        ReceiverExpr::parse("getNullable()?."),
+        recv("getNullable", true),
+        "safe-call after a call expression should still strip the call args"
+    );
+}
+
+#[test]
+fn dot_receiver_safe_call_double_chain() {
+    // `a?.b?.` — each `?.` is independent; only the immediate receiver `b`
+    // matters for the completion currently being triggered.
+    assert_eq!(
+        ReceiverExpr::parse("a?.b?."),
+        recv("a.b", false),
+        "chained safe-calls should resolve the full chain, not bail out"
+    );
+}
+
 // ── param_names_from_sig ──────────────────────────────────────────────────────
 
 #[test]

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -146,8 +146,15 @@ impl ReceiverExpr {
     ///
     /// `"productFlow(trigger.isRefresh())."` → `Some(ReceiverExpr { chain: "productFlow", is_call: true })`
     /// `"foo.bar."` → `Some(ReceiverExpr { chain: "foo.bar", is_call: false })`
+    /// `"nullable?."` → `Some(ReceiverExpr { chain: "nullable", is_call: false })`
     pub(crate) fn parse(before_prefix: &str) -> Option<Self> {
-        let before_dot = before_prefix.strip_suffix('.')?;
+        // Kotlin's safe-call `?.` only affects null-handling at runtime — for
+        // finding which type's members to suggest it's equivalent to a plain `.`.
+        // Normalize before scanning so the rest of this function (and the
+        // backward identifier scan, which doesn't otherwise allow `?`) doesn't
+        // need its own safe-call handling.
+        let normalized = before_prefix.replace("?.", ".");
+        let before_dot = normalized.strip_suffix('.')?;
         let (before_call, is_call) = if before_dot.trim_end().ends_with(')') {
             (Self::strip_call_args(before_dot.trim_end()), true)
         } else {

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, CompletionItemTag, InsertTextFormat, Position, SymbolKind,
@@ -152,8 +153,13 @@ impl ReceiverExpr {
         // finding which type's members to suggest it's equivalent to a plain `.`.
         // Normalize before scanning so the rest of this function (and the
         // backward identifier scan, which doesn't otherwise allow `?`) doesn't
-        // need its own safe-call handling.
-        let normalized = before_prefix.replace("?.", ".");
+        // need its own safe-call handling. Only allocate when a `?.` is actually
+        // present — the common (plain `.`) case borrows the input unchanged.
+        let normalized: Cow<str> = if before_prefix.contains("?.") {
+            Cow::Owned(before_prefix.replace("?.", "."))
+        } else {
+            Cow::Borrowed(before_prefix)
+        };
         let before_dot = normalized.strip_suffix('.')?;
         let (before_call, is_call) = if before_dot.trim_end().ends_with(')') {
             (Self::strip_call_args(before_dot.trim_end()), true)


### PR DESCRIPTION
## Problem

`nullable?.<cursor>` returned no completions at all.

`ReceiverExpr::parse` strips a trailing `.` and then backward-scans for identifier characters (alphanumeric, `_`, `.`, and non-ASCII) to find the receiver chain — `?` isn't in that allowed set, so the scan stopped immediately on the `?` left behind by `?.`, producing an empty (or, for chained safe-calls, a leading-dot) chain that gets rejected outright.

## Fix

Kotlin's `?.` only affects null-handling at runtime — for finding which type's members to suggest, it's equivalent to a plain `.`. Normalize `?.` to `.` before parsing so the rest of the function (call-arg stripping, the identifier scan) doesn't need its own safe-call handling.

## Test plan

- [x] `cargo test` — 1395 passed
- [x] `cargo clippy -- -D warnings` — clean
- [x] Added regression tests: simple safe-call, safe-call after a dotted chain, safe-call after a call expression, chained double safe-call

🤖 Generated with [Claude Code](https://claude.com/claude-code)