### PR TITLE
refactor(resolution): introduce Resolver trait catalog (slice 1)

### DIFF
--- a/src/features/nullable_call_diagnostics.rs
+++ b/src/features/nullable_call_diagnostics.rs
@@ -22,7 +22,7 @@ use tower_lsp::lsp_types::*;
 
 use crate::indexer::{live_tree::LiveDoc, Indexer, NodeExt};
 use crate::queries::{KIND_NAV_EXPR, KIND_SIMPLE_IDENT};
-use crate::resolver::{infer_field_chain_type, infer_receiver_type, ReceiverKind, ReceiverType};
+use crate::resolver::{ReceiverKind, ReceiverType, Resolver};
 
 /// Scan a file for plain-`.` member access on nullable receivers.
 ///
@@ -119,7 +119,7 @@ fn check_nullable_dot_call(
     //    container-scoped, so verify the resolved symbol is actually nested
     //    inside the receiver's class — otherwise a same-named top-level
     //    extension declared in the same file would be mistaken for a member.
-    let member_locs = indexer.resolve_member_only(&member_name, &qualifier, uri);
+    let member_locs = indexer.resolve_member(&member_name, &qualifier, uri);
     if member_locs
         .iter()
         .any(|location| is_member_of(indexer, location, &receiver_type.leaf))
@@ -187,7 +187,7 @@ fn resolve_receiver(
             if name == "this" || name == "super" {
                 return None;
             }
-            let receiver_type = infer_receiver_type(indexer, ReceiverKind::Variable(&name), uri)?;
+            let receiver_type = indexer.infer_receiver_type(ReceiverKind::Variable(&name), uri)?;
             Some((name, receiver_type))
         }
         KIND_NAV_EXPR => {
@@ -196,7 +196,7 @@ fn resolve_receiver(
             if chain.len() < 2 || chain[0] == "this" || chain[0] == "super" {
                 return None;
             }
-            let receiver_type = infer_field_chain_type(indexer, &chain, uri)?;
+            let receiver_type = indexer.infer_field_chain_type(&chain, uri)?;
             Some((chain.join("."), receiver_type))
         }
         _ => None,

--- a/src/features/nullable_call_diagnostics.rs
+++ b/src/features/nullable_call_diagnostics.rs
@@ -39,8 +39,8 @@ pub(crate) fn nullable_dot_call_diagnostics(
     // whole window (the symptom that surfaced this: "no diagnostics on live
     // lines"). It is safe to run during loading because:
     //   * Every true positive resolves to a workspace-local symbol (a project
-    //     class member via `resolve_member_only`, or a project extension via
-    //     `extension_by_receiver`), all of which are populated by the fast
+    //     class member via `Resolver::resolve_member`, or a project extension
+    //     via `extension_by_receiver`), all of which are populated by the fast
     //     source scan — none depend on JAR symbols.
     //   * The diagnostic only fires when it *positively* resolves a member or a
     //     non-nullable extension; a partial index that simply lacks a symbol
@@ -106,7 +106,7 @@ fn check_nullable_dot_call(
 
     // The receiver is either a simple variable (`repo.load()`) or a pure
     // field-access chain (`holder.repo.load()`, where `repo` is a nullable
-    // field). `qualifier` is the text we hand to `resolve_member_only` to
+    // field). `qualifier` is the text we hand to `Resolver::resolve_member` to
     // locate the member; `receiver_type` carries the inferred nullability.
     let (qualifier, receiver_type) = resolve_receiver(indexer, &receiver_node, bytes, uri)?;
     if !receiver_type.nullable {
@@ -115,7 +115,7 @@ fn check_nullable_dot_call(
 
     // 1. A real class member (declared in the body or inherited) is always an
     //    error on a nullable receiver, regardless of any extension with the
-    //    same name. `resolve_member_only`'s underlying file search isn't
+    //    same name. `resolve_member`'s underlying file search isn't
     //    container-scoped, so verify the resolved symbol is actually nested
     //    inside the receiver's class — otherwise a same-named top-level
     //    extension declared in the same file would be mistaken for a member.

--- a/src/features/nullable_call_diagnostics_tests.rs
+++ b/src/features/nullable_call_diagnostics_tests.rs
@@ -484,3 +484,59 @@ fn deeply_nested_member_resolves_in_owner_file_despite_same_named_decoy() {
     assert_eq!(diags.len(), 1, "expected one diagnostic: {diags:?}");
     assert!(diags[0].message.contains("tabCzech"));
 }
+
+#[test]
+fn direct_nested_field_chain_member_resolves_despite_same_named_decoy() {
+    // Sibling to `deeply_nested_member_resolves_in_owner_file_despite_same_named_decoy`,
+    // but for the *direct* field-chain shape `arg.texts.tabCzech` (no intermediate
+    // `val texts = arg.texts`). The two shapes take different paths through
+    // `resolve_qualified`:
+    //   * local-val: `infer_variable_type("texts")` yields the dotted nested type,
+    //     handled by the per-level `find_name_in_uri` loop (the path fixed by the
+    //     `inner_type.split('.')` change).
+    //   * direct:    `qualifier == "arg.texts"`; the loop hits the `texts` *field*
+    //     branch and hands the dotted field type straight to `resolve_symbol`,
+    //     relying on its dotted handler to stay anchored to the imported owner
+    //     file rather than the same-named decoy.
+    // The decoy is a different `Scenes.Confirmation` (no `tabCzech`) in the access
+    // file's own package; the real type is reached via an explicit import.
+    let real_src = concat!(
+        "package real\n",
+        "class TextsResponseBody {\n",
+        "    class Scenes {\n",
+        "        class Confirmation {\n",
+        "            val tabCzech: String? = null\n",
+        "        }\n",
+        "    }\n",
+        "}\n",
+    );
+    let decoy_src = concat!(
+        "package demo\n",
+        "class Scenes {\n",
+        "    class Confirmation {\n",
+        "        val somethingElse: String? = null\n",
+        "    }\n",
+        "}\n",
+    );
+    let mapper_src = concat!(
+        "package demo\n",
+        "import real.TextsResponseBody\n",
+        "data class Arg(val texts: TextsResponseBody.Scenes.Confirmation?)\n",
+        "fun map(arg: Arg) {\n",
+        "    arg.texts.tabCzech\n",
+        "}\n",
+    );
+    let real_uri = uri("/real.kt");
+    let decoy_uri = uri("/decoy.kt");
+    let mapper_uri = uri("/mapper.kt");
+    let idx = Indexer::new();
+    idx.index_content(&real_uri, real_src);
+    idx.index_content(&decoy_uri, decoy_src);
+    idx.index_content(&mapper_uri, mapper_src);
+    idx.store_live_tree(&mapper_uri, mapper_src);
+    idx.set_live_lines(&mapper_uri, mapper_src);
+
+    let diags = run_diagnostics(&idx, &mapper_uri, mapper_src);
+    assert_eq!(diags.len(), 1, "expected one diagnostic: {diags:?}");
+    assert!(diags[0].message.contains("tabCzech"));
+}

--- a/src/features/nullable_call_diagnostics_tests.rs
+++ b/src/features/nullable_call_diagnostics_tests.rs
@@ -529,14 +529,18 @@ fn direct_nested_field_chain_member_resolves_despite_same_named_decoy() {
     let real_uri = uri("/real.kt");
     let decoy_uri = uri("/decoy.kt");
     let mapper_uri = uri("/mapper.kt");
-    let idx = Indexer::new();
-    idx.index_content(&real_uri, real_src);
-    idx.index_content(&decoy_uri, decoy_src);
-    idx.index_content(&mapper_uri, mapper_src);
-    idx.store_live_tree(&mapper_uri, mapper_src);
-    idx.set_live_lines(&mapper_uri, mapper_src);
+    let indexer = Indexer::new();
+    indexer.index_content(&real_uri, real_src);
+    indexer.index_content(&decoy_uri, decoy_src);
+    indexer.index_content(&mapper_uri, mapper_src);
+    indexer.store_live_tree(&mapper_uri, mapper_src);
+    indexer.set_live_lines(&mapper_uri, mapper_src);
 
-    let diags = run_diagnostics(&idx, &mapper_uri, mapper_src);
-    assert_eq!(diags.len(), 1, "expected one diagnostic: {diags:?}");
-    assert!(diags[0].message.contains("tabCzech"));
+    let diagnostics = run_diagnostics(&indexer, &mapper_uri, mapper_src);
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected one diagnostic: {diagnostics:?}"
+    );
+    assert!(diagnostics[0].message.contains("tabCzech"));
 }

--- a/src/resolver/api.rs
+++ b/src/resolver/api.rs
@@ -1,0 +1,96 @@
+//! The resolution capability **catalog** for the `resolver` subsystem.
+//!
+//! This module exposes [`Resolver`] — the single, intent-named, documented
+//! surface for resolving Kotlin/KMP receivers and members against the workspace
+//! index. It exists to stop the *reinvention* that fragmented resolution in the
+//! first place: consumers (diagnostics, hover, completion, semantic
+//! highlighting, go-to-definition) kept hand-rolling slightly-divergent copies
+//! of the same lookups because the existing capability wasn't discoverable.
+//!
+//! **The contract:** a consumer that needs to resolve something looks here
+//! first. If the capability exists, call it — do not re-derive it inline. If it
+//! is *missing*, add a method to [`Resolver`] (and implement it by delegating to
+//! the canonical function), so the next consumer finds it instead of reinventing
+//! it. A trait that is missing a capability is worse than none, because it sends
+//! implementors back to hand-rolling.
+//!
+//! Return types are deliberately self-documenting so a caller knows what to
+//! expect from the signature alone: a [`ReceiverType`] always carries the
+//! `raw`/`qualified`/`outer`/`leaf`/`nullable` breakdown of an inferred
+//! receiver; [`Definitions`] is an ordered (best-first) list of *definition*
+//! sites — never references, never an error channel.
+//!
+//! The trait is implemented for [`Indexer`], which owns the file/symbol/
+//! extension maps these methods read.
+
+use tower_lsp::lsp_types::{Location, Url};
+
+use crate::indexer::Indexer;
+
+use super::infer::{infer_field_chain_type, infer_receiver_type};
+use super::{ReceiverKind, ReceiverType};
+
+/// An ordered list of **definition** sites (where a symbol is *declared*), best
+/// match first — never references, never an error signal.
+///
+/// An empty `Definitions` means "no definition resolved": callers treat that as
+/// *skip, don't guess*, not as a failure. Dereferences to `[Location]`, so
+/// `iter()`, `first()`, `is_empty()`, and slice indexing work directly.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Definitions(pub Vec<Location>);
+
+impl std::ops::Deref for Definitions {
+    type Target = [Location];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// The resolution capability catalog. See the module docs for the contract.
+///
+/// Implemented for [`Indexer`]; each method delegates to the canonical
+/// resolution function so there is exactly one implementation of each
+/// capability behind a discoverable name.
+pub(crate) trait Resolver {
+    /// Infer the [`ReceiverType`] of a receiver expression — a bare variable
+    /// (`repo` in `repo.load()`) or a lambda/implicit-receiver
+    /// ([`ReceiverKind::Contextual`]) — at `uri`.
+    ///
+    /// Returns `None` when the type cannot be inferred (no annotation, unindexed
+    /// file, unresolvable lambda scope). Never performs a global ripgrep scan;
+    /// the caller decides whether to skip or fall back.
+    fn infer_receiver_type(&self, receiver: ReceiverKind<'_>, uri: &Url) -> Option<ReceiverType>;
+
+    /// Infer the [`ReceiverType`] reached by walking a *pure field-access chain*
+    /// (`["holder", "repo"]` for `holder.repo`) from the root variable through
+    /// each declared field type. The leaf field's trailing `?` is preserved in
+    /// [`ReceiverType::nullable`].
+    ///
+    /// Returns `None` if the chain has fewer than two segments or any segment's
+    /// type cannot be resolved.
+    fn infer_field_chain_type(&self, chain: &[String], uri: &Url) -> Option<ReceiverType>;
+
+    /// Resolve `member` accessed through `qualifier` — a variable name
+    /// (`"repo"`) or a pure field chain (`"arg.texts"`) — to its declaration
+    /// site(s), searching the receiver type's owner file and its
+    /// superclass/interface hierarchy.
+    ///
+    /// Returns [`Definitions`] (best-first, possibly empty). This is the
+    /// import-aware member lookup; prefer it over reaching into the raw
+    /// `definition_locations` map, which is not scope-aware.
+    fn resolve_member(&self, member: &str, qualifier: &str, uri: &Url) -> Definitions;
+}
+
+impl Resolver for Indexer {
+    fn infer_receiver_type(&self, receiver: ReceiverKind<'_>, uri: &Url) -> Option<ReceiverType> {
+        infer_receiver_type(self, receiver, uri)
+    }
+
+    fn infer_field_chain_type(&self, chain: &[String], uri: &Url) -> Option<ReceiverType> {
+        infer_field_chain_type(self, chain, uri)
+    }
+
+    fn resolve_member(&self, member: &str, qualifier: &str, uri: &Url) -> Definitions {
+        Definitions(self.resolve_member_only(member, qualifier, uri))
+    }
+}

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! See [`resolve`] for the resolution chain and strategy documentation.
 
+mod api;
 pub(crate) mod complete;
 mod fd;
 pub(crate) mod find;
@@ -15,14 +16,15 @@ mod tests;
 
 // ─── re-exports ───────────────────────────────────────────────────────────────
 
+pub(crate) use api::Resolver;
 pub(crate) use complete::symbols_from_uri_as_completions_pub;
 #[cfg(test)]
 pub(crate) use complete::{complete_symbol, complete_symbol_with_context, is_annotation_context};
 pub(crate) use hierarchy::walk_hierarchy;
 pub(crate) use import_edit::{already_imported, import_insertion_line, make_import_edit};
 pub(crate) use infer::{
-    infer_field_chain_type, infer_receiver_type, infer_receiver_type_at, infer_variable_type_raw,
-    InferenceChain, ReceiverKind, ReceiverType,
+    infer_receiver_type, infer_receiver_type_at, infer_variable_type_raw, InferenceChain,
+    ReceiverKind, ReceiverType,
 };
 pub(crate) use infer_lines::extract_collection_element_type;
 pub(crate) use resolve::{ensure_file_data, fqns_for_name, resolve_symbol_no_rg};

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! See [`resolve`] for the resolution chain and strategy documentation.
 
-mod api;
+pub(crate) mod api;
 pub(crate) mod complete;
 mod fd;
 pub(crate) mod find;


### PR DESCRIPTION
First slice of the **unified-resolution** migration. Goal: replace the fragmented, hand-rolled resolution call sites with one discoverable, documented capability **catalog** per module, so consumers (diagnostics, hover, completion, semantic highlighting, go-to-def) stop reinventing slightly-divergent copies of the same lookups.

This slice is intentionally small and **behaviour-preserving**.

## What's here
- **`resolver/api.rs` (new)** — the `Resolver` trait: the single intent-named, documented surface for the resolution subsystem, implemented for `Indexer`. Each method delegates to the one canonical resolution function, so there's exactly one implementation behind a discoverable name. Module rustdoc states the contract: *look here first; if a capability is missing, add a method — don't hand-roll inline.*
- **Self-documenting return types** — receiver inference returns `ReceiverType` (raw/qualified/outer/leaf/nullable); member resolution returns the new `Definitions` newtype: an ordered, best-first list of *definition* sites that `Deref`s to `[Location]` (empty = skip-don't-guess, never an error channel).
- **Nullable-dot-call diagnostic routed through the trait** (`infer_receiver_type` / `infer_field_chain_type` / `resolve_member`) instead of the free functions.
- **New regression test** — `direct_nested_field_chain_member_resolves_despite_same_named_decoy` closes a previously-uncovered shape (`arg.texts.member` direct chain + a same-named decoy). It's green: the behaviour is already correct, also verified at full Moneta scale (12,624 files / 19 same-named `TextsResponseBody`).

## Scope notes
- The trait holds only the methods actually routed today; it grows as each later slice migrates a consumer (a dead method in the catalog would just push implementors back to hand-rolling).
- No consumer collapses yet (the three `resolve_qualified` copies, receiver-inference duplicates, etc. land in later slices).

## Verification
- Full suite green: **1410 passed / 0 failed**, clean build, zero warnings (`cargo fmt` + `clippy` via pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)