### PR TITLE
refactor(semantic-tokens): make symbol-kind classification import-aware

### DIFF
--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -2,9 +2,8 @@
 // Phase 2: Core `resolve_symbol_info` pipeline implementation.
 
 use std::collections::HashMap;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use tower_lsp::lsp_types::{CompletionItem, Position, SymbolKind, Url};
+use tower_lsp::lsp_types::{SymbolKind, Url};
 
 use crate::indexer::doc::extract_doc_comment;
 use crate::indexer::Location;
@@ -135,8 +134,9 @@ pub(crate) trait IndexRead {
 /// does not provide.
 ///
 /// The trait grows only as backend handlers migrate away from direct `Indexer`
-/// access. Current callers use `enclosing_class_at`, `mem_lines_for`,
-/// `completions`, and `is_indexing_in_progress` in addition to definition lookup.
+/// access; until then, capabilities like `enclosing_class_at`, `mem_lines_for`,
+/// `completions`, and `is_indexing_in_progress` are still reached through the
+/// inherent `Indexer` (via `as_indexer`), not this trait.
 pub(crate) trait WorkspaceRead: IndexRead {
     fn as_indexer(&self) -> Option<&super::Indexer> {
         None
@@ -149,35 +149,6 @@ pub(crate) trait WorkspaceRead: IndexRead {
         from_uri: &Url,
     ) -> Vec<Location> {
         self.resolve_locations(name, qualifier, from_uri, true)
-    }
-
-    #[allow(dead_code)]
-    fn enclosing_class_at(&self, uri: &Url, row: u32) -> Option<String> {
-        self.as_indexer()?.enclosing_class_at(uri, row)
-    }
-
-    #[allow(dead_code)]
-    fn mem_lines_for(&self, uri: &str) -> Option<Arc<Vec<String>>> {
-        self.as_indexer()?.mem_lines_for(uri)
-    }
-
-    #[allow(dead_code)]
-    fn completions(
-        &self,
-        uri: &Url,
-        position: Position,
-        snippets: bool,
-    ) -> (Vec<CompletionItem>, bool) {
-        let Some(indexer) = self.as_indexer() else {
-            return (vec![], false);
-        };
-        indexer.completions(uri, position, snippets)
-    }
-
-    #[allow(dead_code)]
-    fn is_indexing_in_progress(&self) -> bool {
-        self.as_indexer()
-            .is_some_and(|indexer| indexer.indexing_in_progress.load(Ordering::Acquire))
     }
 }
 

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -597,6 +597,10 @@ fn complete_super(indexer: &Indexer, from_uri: &Url, snippets: bool) -> Vec<Comp
 
 /// Dot-completion: return all members of the receiver's inferred type,
 /// sorted: methods first, then fields/vars, then class-level names last.
+///
+/// Test-only thin wrapper over [`complete_dot_expr`]; production callers build
+/// the [`ReceiverExpr`] directly.
+#[cfg(test)]
 pub(crate) fn complete_dot(
     indexer: &Indexer,
     receiver: &str,
@@ -1868,44 +1872,6 @@ fn trigger_parameter_hints() -> tower_lsp::lsp_types::Command {
         title: "triggerParameterHints".into(),
         command: "editor.action.triggerParameterHints".into(),
         arguments: None,
-    }
-}
-
-// ─── impl Indexer wrappers ────────────────────────────────────────────────────
-
-#[allow(dead_code)]
-impl crate::indexer::Indexer {
-    pub(crate) fn complete_dot(
-        &self,
-        receiver: &str,
-        from_uri: &Url,
-        snippets: bool,
-    ) -> Vec<CompletionItem> {
-        complete_dot(self, receiver, from_uri, snippets, None)
-    }
-    pub(crate) fn complete_bare(
-        &self,
-        prefix: &str,
-        from_uri: &Url,
-        snippets: bool,
-        annotation_only: bool,
-    ) -> (Vec<CompletionItem>, bool) {
-        complete_bare(self, prefix, from_uri, snippets, annotation_only, None)
-    }
-    pub(super) fn complete_super_w(&self, from_uri: &Url, snippets: bool) -> Vec<CompletionItem> {
-        complete_super(self, from_uri, snippets)
-    }
-    pub(super) fn symbols_from_uri_as_completions_w(&self, file_uri: &str) -> Vec<CompletionItem> {
-        symbols_from_uri_as_completions(self, file_uri)
-    }
-    pub(super) fn build_completion_items_w(&self, file_uri: &str) -> Vec<CompletionItem> {
-        build_completion_items(self, file_uri)
-    }
-    pub(crate) fn symbols_from_uri_as_completions_pub(
-        &self,
-        file_uri: &str,
-    ) -> Vec<CompletionItem> {
-        symbols_from_uri_as_completions_pub(self, file_uri)
     }
 }
 

--- a/src/resolver/find.rs
+++ b/src/resolver/find.rs
@@ -139,20 +139,8 @@ pub(crate) fn find_local_declaration(idx: &Indexer, name: &str, uri: &Url) -> Ve
 
 // ─── impl Indexer wrappers ────────────────────────────────────────────────────
 
-#[allow(dead_code)]
 impl crate::indexer::Indexer {
     pub(crate) fn find_name_in_uri(&self, name: &str, file_uri: &str) -> Vec<Location> {
         find_name_in_uri(self, name, file_uri)
-    }
-    pub(crate) fn find_name_in_uri_after_line(
-        &self,
-        name: &str,
-        file_uri: &str,
-        after_line: u32,
-    ) -> Vec<Location> {
-        find_name_in_uri_after_line(self, name, file_uri, after_line)
-    }
-    pub(crate) fn find_local_declaration(&self, name: &str, uri: &Url) -> Vec<Location> {
-        find_local_declaration(self, name, uri)
     }
 }

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -1264,46 +1264,6 @@ pub(crate) fn is_stdlib(pkg: &str) -> bool {
     )
 }
 
-// ─── ResolutionChain trait ────────────────────────────────────────────────────
-
-/// The five ordered resolution steps used by [`resolve_symbol_inner`].
-///
-/// Implementing this trait on a type allows the resolution chain to be driven
-/// generically — e.g. in tests a lightweight stub can replace the full
-/// [`Indexer`] without bringing up a real index.
-///
-/// Step order mirrors the chain in [`resolve_symbol_inner`]:
-/// `local → via_imports → same_package → star_imports → qualified`.
-///
-/// TODO(G4): make `resolve_symbol_inner` generic over `ResolutionChain +
-/// SymbolIndex + ScopeQuery` and migrate call-sites away from `&Indexer`.
-#[allow(dead_code)]
-pub(crate) trait ResolutionChain {
-    fn resolve_local(&self, name: &str, uri: &Url) -> Vec<Location>;
-    fn resolve_via_imports(&self, name: &str, uri: &Url) -> Vec<Location>;
-    fn resolve_same_package(&self, name: &str, uri: &Url) -> Vec<Location>;
-    fn resolve_star_imports(&self, name: &str, uri: &Url) -> Vec<Location>;
-    fn resolve_qualified(&self, name: &str, qualifier: &str, uri: &Url) -> Vec<Location>;
-}
-
-impl ResolutionChain for Indexer {
-    fn resolve_local(&self, name: &str, uri: &Url) -> Vec<Location> {
-        resolve_local(self, name, uri)
-    }
-    fn resolve_via_imports(&self, name: &str, uri: &Url) -> Vec<Location> {
-        resolve_via_imports(self, name, uri)
-    }
-    fn resolve_same_package(&self, name: &str, uri: &Url) -> Vec<Location> {
-        resolve_same_package(self, name, uri)
-    }
-    fn resolve_star_imports(&self, name: &str, uri: &Url) -> Vec<Location> {
-        resolve_star_imports(self, name, uri)
-    }
-    fn resolve_qualified(&self, name: &str, qualifier: &str, uri: &Url) -> Vec<Location> {
-        resolve_qualified(self, name, qualifier, uri)
-    }
-}
-
 // ─── impl Indexer wrappers ────────────────────────────────────────────────────
 
 impl crate::indexer::Indexer {

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -41,7 +41,7 @@ pub(super) fn walk_references(
     }
     // Tier 1: direct index lookups (type refs, top-level calls, annotations)
     let mut resolved = Vec::new();
-    walk_kotlin_references(doc.tree.root_node(), src, indexer, &mut resolved);
+    walk_kotlin_references(doc.tree.root_node(), src, indexer, uri, &mut resolved);
     raw.extend(resolved);
 
     // Tier 2: receiver-inferred member coloring
@@ -55,17 +55,18 @@ fn walk_kotlin_references(
     node: Node<'_>,
     src: &Source<'_>,
     indexer: &Indexer,
+    uri: &Url,
     out: &mut Vec<RawToken>,
 ) {
     if is_kotlin_keyword_node(node) {
         push_token(node, type_index(&SemanticTokenType::KEYWORD), 0, src, out);
-    } else if let Some(token_type) = classify_kotlin_reference(node, src.bytes, indexer) {
+    } else if let Some(token_type) = classify_kotlin_reference(node, src.bytes, indexer, uri) {
         push_token(node, token_type, 0, src, out);
     }
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
         loop {
-            walk_kotlin_references(cursor.node(), src, indexer, out);
+            walk_kotlin_references(cursor.node(), src, indexer, uri, out);
             if !cursor.goto_next_sibling() {
                 break;
             }
@@ -87,7 +88,12 @@ fn is_kotlin_keyword_node(node: Node<'_>) -> bool {
     )
 }
 
-fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {
+fn classify_kotlin_reference(
+    node: Node<'_>,
+    src: &[u8],
+    indexer: &Indexer,
+    uri: &Url,
+) -> Option<u32> {
     if !matches!(node.kind(), KIND_SIMPLE_IDENT | KIND_TYPE_IDENT) || is_declaration_site(node) {
         return None;
     }
@@ -100,19 +106,21 @@ fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> O
         return None;
     }
 
-    if let Some(token_type) = enum_entry_reference_token(node, src, indexer) {
+    if let Some(token_type) = enum_entry_reference_token(node, src, indexer, uri) {
         return Some(token_type);
     }
 
     if node.kind() == KIND_TYPE_IDENT && is_type_reference(node) {
-        if let Some(resolved) = resolve_symbol_kind(node_text(node, src), indexer, is_type_symbol) {
+        if let Some(resolved) =
+            resolve_symbol_kind(node_text(node, src), indexer, uri, is_type_symbol)
+        {
             return symbol_kind_to_token_type(resolved.kind);
         }
         return Some(type_index(&SemanticTokenType::CLASS));
     }
 
     if is_top_level_call_name(node) {
-        return resolve_symbol_kind(node_text(node, src), indexer, |kind| {
+        return resolve_symbol_kind(node_text(node, src), indexer, uri, |kind| {
             matches!(
                 kind,
                 SymbolKind::CLASS | SymbolKind::STRUCT | SymbolKind::FUNCTION | SymbolKind::METHOD
@@ -122,7 +130,7 @@ fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> O
     }
 
     if is_navigation_receiver(node) {
-        return resolve_symbol_kind(node_text(node, src), indexer, |kind| {
+        return resolve_symbol_kind(node_text(node, src), indexer, uri, |kind| {
             kind == SymbolKind::OBJECT
         })
         .map(|_| type_index(&SemanticTokenType::NAMESPACE));
@@ -505,7 +513,12 @@ fn member_return_type(
     find_method_return_type(indexer, receiver_type, member_name, Some(from_uri))
 }
 
-fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {
+fn enum_entry_reference_token(
+    node: Node<'_>,
+    src: &[u8],
+    indexer: &Indexer,
+    uri: &Url,
+) -> Option<u32> {
     let parent = node.parent()?;
     let navigation = parent.parent()?;
     if parent.kind() != crate::queries::KIND_NAV_SUFFIX || navigation.kind() != KIND_NAV_EXPR {
@@ -513,7 +526,7 @@ fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> 
     }
 
     let receiver = navigation.named_child(0)?;
-    let receiver_kind = resolve_symbol_kind(node_text(receiver, src), indexer, |kind| {
+    let receiver_kind = resolve_symbol_kind(node_text(receiver, src), indexer, uri, |kind| {
         kind == SymbolKind::ENUM
     })?;
     let receiver_data = indexer.file_data_for(receiver_kind.uri.as_str())?;
@@ -531,9 +544,10 @@ fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> 
 fn resolve_symbol_kind(
     name: &str,
     indexer: &Indexer,
+    from_uri: &Url,
     matches_kind: impl Fn(SymbolKind) -> bool,
 ) -> Option<ResolvedReference> {
-    for location in indexer.definition_locations(name) {
+    for location in indexer.resolve_symbol_no_rg(name, from_uri) {
         let Some(data) = indexer.file_data_for(location.uri.as_str()) else {
             continue;
         };

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -1525,3 +1525,45 @@ fn soft_keyword_as_emits_keyword_token() {
         "expected KEYWORD for 'as' at (0,23), got: {tokens:?}"
     );
 }
+
+#[test]
+fn cross_package_same_name_type_uses_imported_kind() {
+    // Two packages declare `Widget` with DIFFERENT symbol kinds.
+    // The caller imports `a.Widget` (a class), so the type reference must be
+    // highlighted as CLASS, not NAMESPACE (which `b.Widget`, an object, would yield).
+    // The raw global by-name map could return `b.Widget` first; import-aware
+    // resolution must pick the in-scope `a.Widget`.
+    let indexer = Indexer::new();
+
+    // Index the OBJECT first so the raw definition map is biased toward it.
+    let uri_b = Url::parse("file:///pkg_b_widget.kt").unwrap();
+    indexer.index_content(&uri_b, "package b\n\nobject Widget");
+
+    let uri_a = Url::parse("file:///pkg_a_widget.kt").unwrap();
+    indexer.index_content(&uri_a, "package a\n\nclass Widget");
+
+    let caller_src = "package c\n\nimport a.Widget\n\nfun use(w: Widget) {}\n";
+    let uri_c = Url::parse("file:///pkg_c_caller.kt").unwrap();
+    indexer.index_content(&uri_c, caller_src);
+
+    let doc = parse_kotlin(caller_src);
+    let tokens = decode_all_indexed(&indexer, &uri_c, &doc, Language::Kotlin);
+
+    // `Widget` type reference begins at line 4, col 11 (`fun use(w: Widget) {}`).
+    let class_id = type_id(&SemanticTokenType::CLASS);
+    let namespace_id = type_id(&SemanticTokenType::NAMESPACE);
+
+    assert_token_at(
+        &tokens,
+        4,
+        11,
+        class_id,
+        "imported a.Widget classified as CLASS",
+    );
+    assert!(
+        !tokens
+            .iter()
+            .any(|&(l, c, _, tt, _)| l == 4 && c == 11 && tt == namespace_id),
+        "Widget at (4,11) must not be NAMESPACE (the b.Widget object), got: {tokens:?}"
+    );
+}


### PR DESCRIPTION
**Slice 3a** of the unified-resolution work. Stacked on #190 (base = `refactor/resolution-dead-code`); GitHub will retarget to the base branch once #190 merges.

## Problem (capability #3 in the resolution inventory)
`resolve_symbol_kind` — which picks the semantic-highlight token kind for a Kotlin reference — iterated `indexer.definition_locations(name)`, the **raw global by-name map**, with no import-awareness. When a name is declared as different kinds in different packages (`class Foo` vs `object Foo`), it returned whichever the raw map yielded first, regardless of which `Foo` is in scope → wrong token color.

## Fix
Route classification through scope-aware resolution:
- `resolve_symbol_kind` gains `from_uri` and uses `resolve_symbol_no_rg(name, from_uri)` (local → imports → same-package → star → qualified; **no ripgrep fallback**, keeping this hot per-token path cheap).
- `uri` threaded through `walk_kotlin_references` (recursive), `classify_kotlin_reference`, and `enum_entry_reference_token`.

## Safety
Behavior is **preserved for unambiguous names** — the no-rg chain still finds them, so existing highlighting is unchanged. The only behavioral change is selecting the in-scope symbol when same-named symbols span packages.

New regression test `cross_package_same_name_type_uses_imported_kind`: indexes the decoy `object Widget` **first** (biasing the raw map toward it), then asserts the `import a.Widget` (class) reference highlights as CLASS, not NAMESPACE. Confirmed it fails on the old `definition_locations` path.

## Verification
`cargo test --bin kmp-lsp`: **1419 passed** (1418 + new); no pre-existing test changed; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)