### PR TITLE
refactor(resolver): catalog return-type resolution (ReturnType + 2 methods)

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -355,25 +355,12 @@ impl InferDeps for Indexer {
         if let Some(type_name) = synthetic_enum_method(self, class_name, method_name) {
             return Some(type_name);
         }
-        if let Some(type_name) =
-            crate::resolver::infer::find_method_return_type(self, class_name, method_name, None)
-        {
-            return Some(type_name);
-        }
-        if let Some(type_name) = crate::resolver::infer::find_extension_fn_return_type(
-            self,
-            class_name,
-            method_name,
-            None,
-        ) {
-            return Some(type_name);
-        }
-        crate::resolver::infer::find_method_return_type_via_supertypes(
-            self,
-            class_name,
-            method_name,
-            None,
-        )
+        // The catalog composite covers member fns, extension fns, and supertype
+        // inheritance in one call (see `Resolver::method_return_type`); the
+        // previous explicit `find_extension_fn_return_type` step here was dead —
+        // `find_method_return_type` already probes extensions first.
+        crate::resolver::Resolver::method_return_type(self, class_name, method_name, None)
+            .map(crate::resolver::ReturnType::into_inner)
     }
     fn find_method_params_text(&self, class_name: &str, method_name: &str) -> Option<String> {
         crate::indexer::infer::sig::find_method_params_in_class(self, class_name, method_name)

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -2,9 +2,8 @@
 // Phase 2: Core `resolve_symbol_info` pipeline implementation.
 
 use std::collections::HashMap;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use tower_lsp::lsp_types::{CompletionItem, Position, SymbolKind, Url};
+use tower_lsp::lsp_types::{SymbolKind, Url};
 
 use crate::indexer::doc::extract_doc_comment;
 use crate::indexer::Location;
@@ -135,8 +134,9 @@ pub(crate) trait IndexRead {
 /// does not provide.
 ///
 /// The trait grows only as backend handlers migrate away from direct `Indexer`
-/// access. Current callers use `enclosing_class_at`, `mem_lines_for`,
-/// `completions`, and `is_indexing_in_progress` in addition to definition lookup.
+/// access; until then, capabilities like `enclosing_class_at`, `mem_lines_for`,
+/// `completions`, and `is_indexing_in_progress` are still reached through the
+/// inherent `Indexer` (via `as_indexer`), not this trait.
 pub(crate) trait WorkspaceRead: IndexRead {
     fn as_indexer(&self) -> Option<&super::Indexer> {
         None
@@ -149,35 +149,6 @@ pub(crate) trait WorkspaceRead: IndexRead {
         from_uri: &Url,
     ) -> Vec<Location> {
         self.resolve_locations(name, qualifier, from_uri, true)
-    }
-
-    #[allow(dead_code)]
-    fn enclosing_class_at(&self, uri: &Url, row: u32) -> Option<String> {
-        self.as_indexer()?.enclosing_class_at(uri, row)
-    }
-
-    #[allow(dead_code)]
-    fn mem_lines_for(&self, uri: &str) -> Option<Arc<Vec<String>>> {
-        self.as_indexer()?.mem_lines_for(uri)
-    }
-
-    #[allow(dead_code)]
-    fn completions(
-        &self,
-        uri: &Url,
-        position: Position,
-        snippets: bool,
-    ) -> (Vec<CompletionItem>, bool) {
-        let Some(indexer) = self.as_indexer() else {
-            return (vec![], false);
-        };
-        indexer.completions(uri, position, snippets)
-    }
-
-    #[allow(dead_code)]
-    fn is_indexing_in_progress(&self) -> bool {
-        self.as_indexer()
-            .is_some_and(|indexer| indexer.indexing_in_progress.load(Ordering::Acquire))
     }
 }
 

--- a/src/resolver/api.rs
+++ b/src/resolver/api.rs
@@ -27,7 +27,10 @@ use tower_lsp::lsp_types::{Location, Url};
 
 use crate::indexer::Indexer;
 
-use super::infer::{infer_field_chain_type, infer_receiver_type};
+use super::infer::{
+    find_fun_return_type_by_name, find_fun_return_type_reachable, find_method_return_type,
+    find_method_return_type_via_supertypes, infer_field_chain_type, infer_receiver_type,
+};
 use super::{ReceiverKind, ReceiverType};
 
 /// An ordered list of **definition** sites (where a symbol is *declared*), best
@@ -43,6 +46,39 @@ impl std::ops::Deref for Definitions {
     type Target = [Location];
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+/// The result type of a call — what a function or method *returns*.
+///
+/// Carried as the **as-written** type text from the signature (the text after
+/// the `:`), with generics and a trailing `?` preserved (e.g. `Flow<Event>`,
+/// `String?`). It is *not* normalized: feed it to [`ReceiverType::from_raw`] when
+/// you need the `raw`/`qualified`/`leaf`/`nullable` breakdown. The newtype exists
+/// so a signature returning `Option<ReturnType>` says "a call's return type",
+/// distinct from a receiver type, a field type, or a bare identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReturnType(pub String);
+
+impl ReturnType {
+    /// Consume into the owned return-type `String` (for the downstream
+    /// String-typed inference paths that haven't adopted the newtype yet).
+    /// Borrow with `&*` / [`Deref`](std::ops::Deref) when you only need `&str`.
+    pub(crate) fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl std::ops::Deref for ReturnType {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<ReturnType> for String {
+    fn from(rt: ReturnType) -> Self {
+        rt.0
     }
 }
 
@@ -79,6 +115,39 @@ pub(crate) trait Resolver {
     /// import-aware member lookup; prefer it over reaching into the raw
     /// `definition_locations` map, which is not scope-aware.
     fn resolve_member(&self, member: &str, qualifier: &str, uri: &Url) -> Definitions;
+
+    /// Resolve the [`ReturnType`] of a *free function* `fn_name` called from
+    /// `from_uri`.
+    ///
+    /// Import-aware: binds `fn_name` through the scope chain (imports →
+    /// same-package → star → qualified/jars) and reads the return type of the
+    /// symbol the call actually binds to, falling back to a capped workspace-wide
+    /// by-name lookup only when no in-scope definition is found. Prefer this over
+    /// the raw by-name scan so an unrelated same-named overload in a test file or
+    /// jar can't shadow the real one.
+    ///
+    /// Returns `None` when no definition is found or it has no declared return
+    /// type.
+    fn function_return_type(&self, fn_name: &str, from_uri: &Url) -> Option<ReturnType>;
+
+    /// Resolve the [`ReturnType`] of `method_name` invoked on a receiver whose
+    /// type's base name is `type_name`.
+    ///
+    /// This is the single composite for member resolution: it checks extension
+    /// functions and member functions of the type itself, then walks the type's
+    /// declared supertypes (applying type-argument substitution). When `from_uri`
+    /// is `Some`, extension functions are filtered to those in scope at that file;
+    /// `None` performs an unfiltered global lookup for callers without URI
+    /// context.
+    ///
+    /// Returns `None` when no matching method (own, extension, or inherited) with
+    /// a declared return type is found.
+    fn method_return_type(
+        &self,
+        type_name: &str,
+        method_name: &str,
+        from_uri: Option<&Url>,
+    ) -> Option<ReturnType>;
 }
 
 impl Resolver for Indexer {
@@ -92,5 +161,24 @@ impl Resolver for Indexer {
 
     fn resolve_member(&self, member: &str, qualifier: &str, uri: &Url) -> Definitions {
         Definitions(self.resolve_member_only(member, qualifier, uri))
+    }
+
+    fn function_return_type(&self, fn_name: &str, from_uri: &Url) -> Option<ReturnType> {
+        find_fun_return_type_reachable(self, fn_name, from_uri)
+            .or_else(|| find_fun_return_type_by_name(self, fn_name))
+            .map(ReturnType)
+    }
+
+    fn method_return_type(
+        &self,
+        type_name: &str,
+        method_name: &str,
+        from_uri: Option<&Url>,
+    ) -> Option<ReturnType> {
+        find_method_return_type(self, type_name, method_name, from_uri)
+            .or_else(|| {
+                find_method_return_type_via_supertypes(self, type_name, method_name, from_uri)
+            })
+            .map(ReturnType)
     }
 }

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -597,6 +597,10 @@ fn complete_super(indexer: &Indexer, from_uri: &Url, snippets: bool) -> Vec<Comp
 
 /// Dot-completion: return all members of the receiver's inferred type,
 /// sorted: methods first, then fields/vars, then class-level names last.
+///
+/// Test-only thin wrapper over [`complete_dot_expr`]; production callers build
+/// the [`ReceiverExpr`] directly.
+#[cfg(test)]
 pub(crate) fn complete_dot(
     indexer: &Indexer,
     receiver: &str,
@@ -1868,44 +1872,6 @@ fn trigger_parameter_hints() -> tower_lsp::lsp_types::Command {
         title: "triggerParameterHints".into(),
         command: "editor.action.triggerParameterHints".into(),
         arguments: None,
-    }
-}
-
-// ─── impl Indexer wrappers ────────────────────────────────────────────────────
-
-#[allow(dead_code)]
-impl crate::indexer::Indexer {
-    pub(crate) fn complete_dot(
-        &self,
-        receiver: &str,
-        from_uri: &Url,
-        snippets: bool,
-    ) -> Vec<CompletionItem> {
-        complete_dot(self, receiver, from_uri, snippets, None)
-    }
-    pub(crate) fn complete_bare(
-        &self,
-        prefix: &str,
-        from_uri: &Url,
-        snippets: bool,
-        annotation_only: bool,
-    ) -> (Vec<CompletionItem>, bool) {
-        complete_bare(self, prefix, from_uri, snippets, annotation_only, None)
-    }
-    pub(super) fn complete_super_w(&self, from_uri: &Url, snippets: bool) -> Vec<CompletionItem> {
-        complete_super(self, from_uri, snippets)
-    }
-    pub(super) fn symbols_from_uri_as_completions_w(&self, file_uri: &str) -> Vec<CompletionItem> {
-        symbols_from_uri_as_completions(self, file_uri)
-    }
-    pub(super) fn build_completion_items_w(&self, file_uri: &str) -> Vec<CompletionItem> {
-        build_completion_items(self, file_uri)
-    }
-    pub(crate) fn symbols_from_uri_as_completions_pub(
-        &self,
-        file_uri: &str,
-    ) -> Vec<CompletionItem> {
-        symbols_from_uri_as_completions_pub(self, file_uri)
     }
 }
 

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -14,13 +14,13 @@ use crate::LinesExt;
 use crate::StrExt;
 
 use super::infer::{
-    find_field_type_in_class, find_fun_return_type_by_name, find_method_return_type,
-    infer_receiver_type, infer_receiver_type_at, infer_variable_type_raw, ReceiverKind,
-    ReceiverType,
+    find_field_type_in_class, infer_receiver_type, infer_receiver_type_at, infer_variable_type_raw,
+    ReceiverKind, ReceiverType,
 };
 use super::infer_lines::infer_callable_param_return_type;
 use super::{
     already_imported, ensure_file_data, fqns_for_name, resolve_symbol_no_rg, walk_hierarchy,
+    Resolver,
 };
 
 // ─── CompletionItem.data JSON keys ───────────────────────────────────────────
@@ -691,8 +691,8 @@ fn resolve_dot_receiver_type(
                 return Some(ReceiverType::from_raw(raw));
             }
         }
-        if let Some(ret) = find_fun_return_type_by_name(indexer, receiver) {
-            return Some(ReceiverType::from_raw(ret));
+        if let Some(ret) = indexer.function_return_type(receiver, from_uri) {
+            return Some(ReceiverType::from_raw(ret.into_inner()));
         }
         let file = ensure_file_data(indexer, from_uri)?;
         let ret = infer_callable_param_return_type(&file.lines, receiver)?;
@@ -725,8 +725,8 @@ fn resolve_dot_receiver_type(
     }
 
     // Fallback: function defined in scope (e.g. bare `productFlow` written without `()`).
-    if let Some(ret) = find_fun_return_type_by_name(indexer, receiver) {
-        return Some(ReceiverType::from_raw(ret));
+    if let Some(ret) = indexer.function_return_type(receiver, from_uri) {
+        return Some(ReceiverType::from_raw(ret.into_inner()));
     }
     let file = ensure_file_data(indexer, from_uri)?;
     let ret = infer_callable_param_return_type(&file.lines, receiver)?;
@@ -764,9 +764,9 @@ fn resolve_dotted_receiver_type(indexer: &Indexer, path: &str, uri: &Url) -> Opt
         {
             current_type = next_type;
         } else if let Some(next_type) =
-            find_method_return_type(indexer, current_base_leaf, clean_segment, Some(uri))
+            indexer.method_return_type(current_base_leaf, clean_segment, Some(uri))
         {
-            current_type = next_type;
+            current_type = next_type.into_inner();
         } else {
             return None;
         }

--- a/src/resolver/find.rs
+++ b/src/resolver/find.rs
@@ -139,20 +139,8 @@ pub(crate) fn find_local_declaration(idx: &Indexer, name: &str, uri: &Url) -> Ve
 
 // ─── impl Indexer wrappers ────────────────────────────────────────────────────
 
-#[allow(dead_code)]
 impl crate::indexer::Indexer {
     pub(crate) fn find_name_in_uri(&self, name: &str, file_uri: &str) -> Vec<Location> {
         find_name_in_uri(self, name, file_uri)
-    }
-    pub(crate) fn find_name_in_uri_after_line(
-        &self,
-        name: &str,
-        file_uri: &str,
-        after_line: u32,
-    ) -> Vec<Location> {
-        find_name_in_uri_after_line(self, name, file_uri, after_line)
-    }
-    pub(crate) fn find_local_declaration(&self, name: &str, uri: &Url) -> Vec<Location> {
-        find_local_declaration(self, name, uri)
     }
 }

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -355,3 +355,57 @@ fn return_type_reachable_prefers_imported_symbol() {
         "must bind to the imported compose stringResource (String), not the decoy"
     );
 }
+
+/// `Resolver::function_return_type` is the import-aware catalog entry: it binds
+/// through the scope chain first, then falls back to a workspace-wide by-name
+/// lookup, returning a self-documenting [`ReturnType`]. This asserts the
+/// fallback arm — a function in another package with no import is still found.
+#[test]
+fn catalog_function_return_type_falls_back_to_by_name() {
+    use crate::indexer::Indexer;
+    use crate::resolver::Resolver;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    let def = Url::parse("file:///app/Repo.kt").unwrap();
+    idx.index_content(&def, "package app\nfun buildRepo(): Repository = TODO()\n");
+
+    // Caller in a different package with no import — reachable resolution fails,
+    // so the by-name fallback must carry it.
+    let caller = Url::parse("file:///other/Main.kt").unwrap();
+    idx.index_content(&caller, "package other\nfun m() {}\n");
+
+    assert_eq!(
+        idx.function_return_type("buildRepo", &caller)
+            .map(|r| r.into_inner()),
+        Some("Repository".to_string()),
+        "by-name fallback must find the workspace function"
+    );
+}
+
+/// `Resolver::method_return_type` is the single composite for member resolution:
+/// own/extension methods *and* inherited (supertype) methods resolve through one
+/// call. This asserts the supertype arm — a method declared only on the base
+/// class resolves when queried on the derived class.
+#[test]
+fn catalog_method_return_type_folds_supertype_inheritance() {
+    use crate::indexer::Indexer;
+    use crate::resolver::Resolver;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    let f = Url::parse("file:///app/Types.kt").unwrap();
+    idx.index_content(
+        &f,
+        "package app\nopen class Base { fun who(): Identity = TODO() }\nclass Derived : Base()\n",
+    );
+
+    // `who` is declared only on Base; querying it on Derived must resolve via the
+    // supertype walk that `method_return_type` folds in.
+    assert_eq!(
+        idx.method_return_type("Derived", "who", None)
+            .map(|r| r.into_inner()),
+        Some("Identity".to_string()),
+        "method_return_type must fold supertype inheritance into one call"
+    );
+}

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -16,7 +16,7 @@ mod tests;
 
 // ─── re-exports ───────────────────────────────────────────────────────────────
 
-pub(crate) use api::Resolver;
+pub(crate) use api::{Resolver, ReturnType};
 pub(crate) use complete::symbols_from_uri_as_completions_pub;
 #[cfg(test)]
 pub(crate) use complete::{complete_symbol, complete_symbol_with_context, is_annotation_context};

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -1264,46 +1264,6 @@ pub(crate) fn is_stdlib(pkg: &str) -> bool {
     )
 }
 
-// ─── ResolutionChain trait ────────────────────────────────────────────────────
-
-/// The five ordered resolution steps used by [`resolve_symbol_inner`].
-///
-/// Implementing this trait on a type allows the resolution chain to be driven
-/// generically — e.g. in tests a lightweight stub can replace the full
-/// [`Indexer`] without bringing up a real index.
-///
-/// Step order mirrors the chain in [`resolve_symbol_inner`]:
-/// `local → via_imports → same_package → star_imports → qualified`.
-///
-/// TODO(G4): make `resolve_symbol_inner` generic over `ResolutionChain +
-/// SymbolIndex + ScopeQuery` and migrate call-sites away from `&Indexer`.
-#[allow(dead_code)]
-pub(crate) trait ResolutionChain {
-    fn resolve_local(&self, name: &str, uri: &Url) -> Vec<Location>;
-    fn resolve_via_imports(&self, name: &str, uri: &Url) -> Vec<Location>;
-    fn resolve_same_package(&self, name: &str, uri: &Url) -> Vec<Location>;
-    fn resolve_star_imports(&self, name: &str, uri: &Url) -> Vec<Location>;
-    fn resolve_qualified(&self, name: &str, qualifier: &str, uri: &Url) -> Vec<Location>;
-}
-
-impl ResolutionChain for Indexer {
-    fn resolve_local(&self, name: &str, uri: &Url) -> Vec<Location> {
-        resolve_local(self, name, uri)
-    }
-    fn resolve_via_imports(&self, name: &str, uri: &Url) -> Vec<Location> {
-        resolve_via_imports(self, name, uri)
-    }
-    fn resolve_same_package(&self, name: &str, uri: &Url) -> Vec<Location> {
-        resolve_same_package(self, name, uri)
-    }
-    fn resolve_star_imports(&self, name: &str, uri: &Url) -> Vec<Location> {
-        resolve_star_imports(self, name, uri)
-    }
-    fn resolve_qualified(&self, name: &str, qualifier: &str, uri: &Url) -> Vec<Location> {
-        resolve_qualified(self, name, qualifier, uri)
-    }
-}
-
 // ─── impl Indexer wrappers ────────────────────────────────────────────────────
 
 impl crate::indexer::Indexer {

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -13,10 +13,8 @@ use crate::queries::{
     KIND_KW_IS, KIND_KW_SET, KIND_KW_WHERE, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_NAV_EXPR,
     KIND_SIMPLE_IDENT, KIND_THIS_EXPR, KIND_TYPE_IDENT, KIND_VAR_DECL,
 };
-use crate::resolver::infer::{
-    find_field_type_in_class, find_fun_return_type_by_name, find_method_return_type,
-    infer_variable_type,
-};
+use crate::resolver::infer::{find_field_type_in_class, infer_variable_type};
+use crate::resolver::{Resolver, ReturnType};
 use crate::Language;
 
 use super::helpers::{
@@ -324,8 +322,11 @@ fn navigation_expression_type(
     let receiver_type = expression_type(receiver, doc, starts, indexer, uri)?;
 
     if is_call_callee(node) {
-        return member_return_type(indexer, &receiver_type, &member, uri)
-            .or_else(|| find_fun_return_type_by_name(indexer, &member));
+        return member_return_type(indexer, &receiver_type, &member, uri).or_else(|| {
+            indexer
+                .function_return_type(&member, uri)
+                .map(ReturnType::into_inner)
+        });
     }
 
     find_field_type_in_class(indexer, &receiver_type, &member)
@@ -349,7 +350,9 @@ fn call_expression_type(
             }
         }
     }
-    find_fun_return_type_by_name(indexer, &member)
+    indexer
+        .function_return_type(&member, uri)
+        .map(ReturnType::into_inner)
 }
 
 fn expression_type(
@@ -510,7 +513,9 @@ fn member_return_type(
     member_name: &str,
     from_uri: &Url,
 ) -> Option<String> {
-    find_method_return_type(indexer, receiver_type, member_name, Some(from_uri))
+    indexer
+        .method_return_type(receiver_type, member_name, Some(from_uri))
+        .map(ReturnType::into_inner)
 }
 
 fn enum_entry_reference_token(

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -41,7 +41,7 @@ pub(super) fn walk_references(
     }
     // Tier 1: direct index lookups (type refs, top-level calls, annotations)
     let mut resolved = Vec::new();
-    walk_kotlin_references(doc.tree.root_node(), src, indexer, &mut resolved);
+    walk_kotlin_references(doc.tree.root_node(), src, indexer, uri, &mut resolved);
     raw.extend(resolved);
 
     // Tier 2: receiver-inferred member coloring
@@ -55,17 +55,18 @@ fn walk_kotlin_references(
     node: Node<'_>,
     src: &Source<'_>,
     indexer: &Indexer,
+    uri: &Url,
     out: &mut Vec<RawToken>,
 ) {
     if is_kotlin_keyword_node(node) {
         push_token(node, type_index(&SemanticTokenType::KEYWORD), 0, src, out);
-    } else if let Some(token_type) = classify_kotlin_reference(node, src.bytes, indexer) {
+    } else if let Some(token_type) = classify_kotlin_reference(node, src.bytes, indexer, uri) {
         push_token(node, token_type, 0, src, out);
     }
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
         loop {
-            walk_kotlin_references(cursor.node(), src, indexer, out);
+            walk_kotlin_references(cursor.node(), src, indexer, uri, out);
             if !cursor.goto_next_sibling() {
                 break;
             }
@@ -87,7 +88,12 @@ fn is_kotlin_keyword_node(node: Node<'_>) -> bool {
     )
 }
 
-fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {
+fn classify_kotlin_reference(
+    node: Node<'_>,
+    src: &[u8],
+    indexer: &Indexer,
+    uri: &Url,
+) -> Option<u32> {
     if !matches!(node.kind(), KIND_SIMPLE_IDENT | KIND_TYPE_IDENT) || is_declaration_site(node) {
         return None;
     }
@@ -100,19 +106,21 @@ fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> O
         return None;
     }
 
-    if let Some(token_type) = enum_entry_reference_token(node, src, indexer) {
+    if let Some(token_type) = enum_entry_reference_token(node, src, indexer, uri) {
         return Some(token_type);
     }
 
     if node.kind() == KIND_TYPE_IDENT && is_type_reference(node) {
-        if let Some(resolved) = resolve_symbol_kind(node_text(node, src), indexer, is_type_symbol) {
+        if let Some(resolved) =
+            resolve_symbol_kind(node_text(node, src), indexer, uri, is_type_symbol)
+        {
             return symbol_kind_to_token_type(resolved.kind);
         }
         return Some(type_index(&SemanticTokenType::CLASS));
     }
 
     if is_top_level_call_name(node) {
-        return resolve_symbol_kind(node_text(node, src), indexer, |kind| {
+        return resolve_symbol_kind(node_text(node, src), indexer, uri, |kind| {
             matches!(
                 kind,
                 SymbolKind::CLASS | SymbolKind::STRUCT | SymbolKind::FUNCTION | SymbolKind::METHOD
@@ -122,7 +130,7 @@ fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> O
     }
 
     if is_navigation_receiver(node) {
-        return resolve_symbol_kind(node_text(node, src), indexer, |kind| {
+        return resolve_symbol_kind(node_text(node, src), indexer, uri, |kind| {
             kind == SymbolKind::OBJECT
         })
         .map(|_| type_index(&SemanticTokenType::NAMESPACE));
@@ -505,7 +513,12 @@ fn member_return_type(
     find_method_return_type(indexer, receiver_type, member_name, Some(from_uri))
 }
 
-fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {
+fn enum_entry_reference_token(
+    node: Node<'_>,
+    src: &[u8],
+    indexer: &Indexer,
+    uri: &Url,
+) -> Option<u32> {
     let parent = node.parent()?;
     let navigation = parent.parent()?;
     if parent.kind() != crate::queries::KIND_NAV_SUFFIX || navigation.kind() != KIND_NAV_EXPR {
@@ -513,7 +526,7 @@ fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> 
     }
 
     let receiver = navigation.named_child(0)?;
-    let receiver_kind = resolve_symbol_kind(node_text(receiver, src), indexer, |kind| {
+    let receiver_kind = resolve_symbol_kind(node_text(receiver, src), indexer, uri, |kind| {
         kind == SymbolKind::ENUM
     })?;
     let receiver_data = indexer.file_data_for(receiver_kind.uri.as_str())?;
@@ -531,9 +544,10 @@ fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> 
 fn resolve_symbol_kind(
     name: &str,
     indexer: &Indexer,
+    from_uri: &Url,
     matches_kind: impl Fn(SymbolKind) -> bool,
 ) -> Option<ResolvedReference> {
-    for location in indexer.definition_locations(name) {
+    for location in indexer.resolve_symbol_no_rg(name, from_uri) {
         let Some(data) = indexer.file_data_for(location.uri.as_str()) else {
             continue;
         };

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -1525,3 +1525,45 @@ fn soft_keyword_as_emits_keyword_token() {
         "expected KEYWORD for 'as' at (0,23), got: {tokens:?}"
     );
 }
+
+#[test]
+fn cross_package_same_name_type_uses_imported_kind() {
+    // Two packages declare `Widget` with DIFFERENT symbol kinds.
+    // The caller imports `a.Widget` (a class), so the type reference must be
+    // highlighted as CLASS, not NAMESPACE (which `b.Widget`, an object, would yield).
+    // The raw global by-name map could return `b.Widget` first; import-aware
+    // resolution must pick the in-scope `a.Widget`.
+    let indexer = Indexer::new();
+
+    // Index the OBJECT first so the raw definition map is biased toward it.
+    let uri_b = Url::parse("file:///pkg_b_widget.kt").unwrap();
+    indexer.index_content(&uri_b, "package b\n\nobject Widget");
+
+    let uri_a = Url::parse("file:///pkg_a_widget.kt").unwrap();
+    indexer.index_content(&uri_a, "package a\n\nclass Widget");
+
+    let caller_src = "package c\n\nimport a.Widget\n\nfun use(w: Widget) {}\n";
+    let uri_c = Url::parse("file:///pkg_c_caller.kt").unwrap();
+    indexer.index_content(&uri_c, caller_src);
+
+    let doc = parse_kotlin(caller_src);
+    let tokens = decode_all_indexed(&indexer, &uri_c, &doc, Language::Kotlin);
+
+    // `Widget` type reference begins at line 4, col 11 (`fun use(w: Widget) {}`).
+    let class_id = type_id(&SemanticTokenType::CLASS);
+    let namespace_id = type_id(&SemanticTokenType::NAMESPACE);
+
+    assert_token_at(
+        &tokens,
+        4,
+        11,
+        class_id,
+        "imported a.Widget classified as CLASS",
+    );
+    assert!(
+        !tokens
+            .iter()
+            .any(|&(l, c, _, tt, _)| l == 4 && c == 11 && tt == namespace_id),
+        "Widget at (4,11) must not be NAMESPACE (the b.Widget object), got: {tokens:?}"
+    );
+}


### PR DESCRIPTION
**Slice 4** of the unified-resolution work — collapses inventory hotspot #4 (*"function return-type — 5 variants, all `Option<String>` for different things"*). Stacked on #191 (base `refactor/resolution-catalog-s3`); GitHub will retarget down the stack as each merges.

## The disease
Five free functions in `infer.rs` all return bare `Option<String>` for subtly different questions (by-name vs import-aware vs container vs extension vs supertype), and consumers hand-chained them — `indexer.rs::find_method_return_type_for_type` even called `find_extension_fn_return_type` explicitly **after** `find_method_return_type`, which already probes extensions first (dead step).

## The catalog surface
Two intent-named, documented methods on `Resolver`, returning a self-documenting newtype instead of bare `String`:

- **`ReturnType(String)`** — the as-written result type of a call (generics + `?` preserved). `Deref<str>` + `into_inner()` for the String-typed inference paths not yet migrated.
- **`function_return_type(fn, uri)`** — import-aware: reachable bind first, workspace by-name fallback (exactly what `chain.rs` hand-rolled).
- **`method_return_type(type, method, uri?)`** — the single composite: member/extension methods → supertype inheritance, one call.

## Consumers routed off the loose free fns
- `complete.rs` dot-receiver inference (fn + method) — **now import-aware** (was the raw by-name scan).
- `semantic_tokens/resolve.rs` `member_return_type` + both call-callee function-return sites — now import-aware and gain the supertype fallback.
- `indexer.rs::find_method_return_type_for_type` — **collapsed**: dropped the dead explicit extension step and the separate supertypes call; both now live inside `method_return_type`.

## Safety
Behavior-preserving for unambiguous names (the reachable arm falls back to the old by-name lookup). For same-named-cross-package functions, the routed sites now pick the **in-scope** definition — the same correctness shape as the symbol-kind slice (#191). +2 catalog tests proving the by-name fallback arm and the supertype-folding arm.

`cargo test --bin kmp-lsp`: **1421 passed**; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)