### PR TITLE
refactor(resolve): unify the 3 hand-cloned resolution chains behind ResolveIo

### DIFF
--- a/docs/architecture/unified-resolution-handler.md
+++ b/docs/architecture/unified-resolution-handler.md
@@ -1,0 +1,117 @@
+# Unified Resolution Handler — IO Policy
+
+Status: **proposed** (design before code). Scope: `src/resolver/resolve.rs`.
+
+## Problem
+
+`resolve_symbol`'s resolution chain (local → local-decl → imports → same-package →
+star → hierarchy → rg → global-defs) exists **three times**, hand-cloned. The clones
+differ from each other *only by IO policy* — which subprocesses (`rg`, `fd`) and which
+fallbacks are allowed — yet each clone re-derives the entire chain:
+
+| chain step                     | `resolve_symbol_inner` (Full) | `resolve_symbol_no_rg` (NoRg) | `resolve_type_index_only_simple` (IndexOnly) |
+|--------------------------------|:--:|:--:|:--:|
+| cold-file on-demand index (fs) | ✓ | ✗ | ✗ |
+| local-decl line scan           | ✓ | ✗ | ✗ |
+| import resolution              | + `fd` | + `fd` | **index-only (stale clone)** |
+| Swift fast path                | ✓ | ✗ | ✗ |
+| same-package                   | ✓ | ✓ | ✓ |
+| star imports                   | + `rg` in pkg dir | index-only | index-only |
+| class hierarchy walk           | ✓ | ✗ | ✗ |
+| project-wide `rg`              | ✓ | ✗ | ✗ |
+| global-defs tail fallback      | none | first match | unique-only |
+
+This is the "duplicates are the bug factory" thesis in the resolution plan, made
+concrete. Two costs:
+
+1. **Divergence bug (latent).** `resolve_via_imports_index_only` (resolve.rs:385) is not
+   "`resolve_via_imports` minus `fd`" — it is a *stale, simpler clone*. The IO import path
+   (resolve.rs:846) disambiguates nested sealed classes via `import_container_chain`
+   (`expected_chain`); the index-only clone still uses the older `extract_container_from_import`
+   and so mis-disambiguates `Contract.State.Idle` vs `Contract.Event.Idle`. The `IndexOnly`
+   path (used by `fill_when`) silently resolves to the wrong nested member.
+2. **Maintenance tax.** Every resolution fix must be applied in up to three places or it
+   diverges further (this is how #1 happened).
+
+## Design
+
+One private chain parameterized by an IO policy; the three public entry points become
+thin wrappers so **no caller changes**.
+
+```rust
+/// Which IO and fallbacks a resolution pass may use. The plan's "IoPolicy".
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResolveIo {
+    /// Navigation (go-to-def, hover): may spawn `fd`/`rg`, walk the class
+    /// hierarchy, and index a cold file on demand. No global-defs tail fallback.
+    Full,
+    /// Index-only, but imports may still `fd`. No `rg`, no hierarchy, no cold
+    /// index. Tail fallback: first global-defs match. (completion/highlight hot path)
+    NoRg,
+    /// Strictly in-memory: no `fd`, no `rg`, no hierarchy. Tail fallback:
+    /// unique global-defs match only (ambiguity-safe). (diagnostics keystroke path)
+    IndexOnly,
+}
+```
+
+The policy collapses to four behavioural knobs read inside the one chain:
+
+| `ResolveIo` | cold-index + local-decl + swift + hierarchy + rg | imports `fd` | star `rg` | tail fallback |
+|-------------|:--:|:--:|:--:|:--|
+| `Full`      | ✓ | ✓ | ✓ | none |
+| `NoRg`      | ✗ | ✓ | ✗ | first |
+| `IndexOnly` | ✗ | ✗ | ✗ | unique-only |
+
+`import resolution` becomes a single `resolve_via_imports(indexer, name, uri, allow_fd:
+bool)` — the rich version (with `import_container_chain` disambiguation) gated by one
+bool; the stale `resolve_via_imports_index_only` is deleted (this is the bug fix in #1).
+
+The dotted-name pre-handler (`Outer.Nested`) also differs today (Full walks deep nesting;
+IndexOnly does a single split). Folded into the unified entry: Full keeps the
+multi-segment walk; NoRg/IndexOnly keep the single split. Same code, policy-keyed.
+
+### Public surface (unchanged signatures, now wrappers)
+
+```rust
+pub(crate) fn resolve_symbol(idx, name, qualifier, from_uri)      // → chain(Full)   (+ qualifier/dotted pre-pass)
+pub(crate) fn resolve_symbol_no_rg(idx, name, from_uri)           // → chain(NoRg)
+pub(crate) fn resolve_type_index_only(idx, name, from_uri)        // → chain(IndexOnly) (+ dotted pre-pass)
+```
+
+The 18 `resolve_symbol_no_rg` callers and the 1 `resolve_type_index_only` caller
+(`fill_when`) are untouched — they keep calling the same-named wrapper.
+
+## Deletion accounting
+
+| delete | ~lines |
+|---|--:|
+| `resolve_symbol_no_rg` body                | 38 |
+| `resolve_type_index_only_simple` body      | 38 |
+| `resolve_via_imports_index_only`           | 58 |
+| **deleted total**                          | **134** |
+
+| add | ~lines |
+|---|--:|
+| `ResolveIo` enum + doc                      | 18 |
+| policy branch points in the unified chain   | ~25 |
+| `allow_fd` param threading in imports       | ~12 |
+| **added total**                             | **~55** |
+
+**Net ≈ −80**, plus the latent nested-class divergence bug closed.
+
+## Verification
+
+- `cargo test --bin kmp-lsp` green (binary-only crate; `--lib` runs 0 tests).
+  Focused loops: `-- nullable_call`, `-- resolution`, `-- fill_when`.
+- Behaviour-preserving for `Full`/`NoRg`: the existing resolver + completion + hierarchy
+  suites are the net (every caller routes through the unchanged wrapper).
+- `IndexOnly` *changes* on purpose: add a RED test with nested sealed-class decoys
+  (`Contract.State.Idle` vs `Contract.Event.Idle`) proving the index-only import path now
+  disambiguates correctly. This is the only intended behaviour change.
+
+## Risk
+
+Hottest path in the server; touched by ~18 callers. Mitigation: signatures of the three
+public fns are preserved, so the blast radius is contained to `resolve.rs` internals; the
+only intended behaviour delta is the `IndexOnly` import disambiguation, which is covered
+by a new RED test rather than left implicit.

--- a/src/backend/format.rs
+++ b/src/backend/format.rs
@@ -33,10 +33,34 @@ pub(crate) fn format_symbol_hover(info: &ResolvedSymbol, uri_path: &str) -> Stri
         format!("```{lang}\n{sig}\n```")
     };
 
+    // Body assembled from the widened record: an optional deprecation marker
+    // above the signature and an optional `package.Container` context footer for
+    // members — both read straight off `ResolvedSymbol`, no second index lookup.
+    let mut body = String::new();
+    if info.deprecated {
+        body.push_str("**⚠ Deprecated**\n\n");
+    }
+    body.push_str(&code_block);
+    if let Some(ctx) = qualified_context(info) {
+        body.push_str(&format!("\n\n*in `{ctx}`*"));
+    }
+
     if info.doc.is_empty() {
-        code_block
+        body
     } else {
-        format!("{}\n\n---\n\n{code_block}", info.doc)
+        format!("{}\n\n---\n\n{body}", info.doc)
+    }
+}
+
+/// The `package.Container` home of a *member* symbol, for the hover footer.
+///
+/// Returns `None` for top-level declarations (no enclosing container) so their
+/// hover stays unchanged; `package` is folded in when the file declares one.
+fn qualified_context(info: &ResolvedSymbol) -> Option<String> {
+    let container = info.container.as_deref()?;
+    match info.package.as_deref() {
+        Some(pkg) => Some(format!("{pkg}.{container}")),
+        None => Some(container.to_string()),
     }
 }
 

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -16,6 +16,7 @@ use crate::queries::{
     KIND_STATEMENTS, KIND_TYPE_IDENT, KIND_TYPE_TEST, KIND_USER_TYPE, KIND_VAR_DECL,
     KIND_WHEN_CONDITION, KIND_WHEN_ENTRY, KIND_WHEN_EXPR, KIND_WHEN_SUBJECT,
 };
+use crate::StrExt;
 
 /// Memoizes `collect_sealed_members` results within a single `when_diagnostics` pass.
 /// Key: `(sealed_name, parent_uri_string, range)`.
@@ -57,7 +58,7 @@ fn analyze_when<'a>(
 
     let subject_type = resolve_subject_type_from_cst(&when_node, &subject_var, source_bytes)
         .or_else(|| crate::resolver::infer::infer_variable_type(indexer, &subject_var, uri))?;
-    let subject_type = strip_nullable(&subject_type).to_string();
+    let subject_type = subject_type.strip_nullable().to_string();
 
     let (type_kind, members) = resolve_type_members(
         indexer,
@@ -472,10 +473,6 @@ fn extract_subject_identifier(subject_node: &tree_sitter::Node, source: &[u8]) -
         }
     }
     None
-}
-
-fn strip_nullable(type_name: &str) -> &str {
-    type_name.strip_suffix('?').unwrap_or(type_name)
 }
 
 /// Resolve whether the type is an enum, sealed class, or Boolean, and return its members.

--- a/src/features/hover.rs
+++ b/src/features/hover.rs
@@ -15,6 +15,7 @@ use crate::indexer::resolution::{
     WorkspaceRead,
 };
 use crate::resolver::ReceiverType;
+use crate::StrExt;
 
 /// Compute a hover response for the cursor at `position` in `uri`.
 ///
@@ -184,7 +185,7 @@ fn type_detail_parts(type_name: &str) -> (&str, Option<&str>) {
         .split('<')
         .next()
         .unwrap_or(type_name)
-        .trim_end_matches('?')
+        .strip_nullable()
         .trim_end_matches('.');
     match base.rsplit_once('.') {
         Some((qualifier, leaf)) => (leaf, Some(qualifier)),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -355,25 +355,12 @@ impl InferDeps for Indexer {
         if let Some(type_name) = synthetic_enum_method(self, class_name, method_name) {
             return Some(type_name);
         }
-        if let Some(type_name) =
-            crate::resolver::infer::find_method_return_type(self, class_name, method_name, None)
-        {
-            return Some(type_name);
-        }
-        if let Some(type_name) = crate::resolver::infer::find_extension_fn_return_type(
-            self,
-            class_name,
-            method_name,
-            None,
-        ) {
-            return Some(type_name);
-        }
-        crate::resolver::infer::find_method_return_type_via_supertypes(
-            self,
-            class_name,
-            method_name,
-            None,
-        )
+        // The catalog composite covers member fns, extension fns, and supertype
+        // inheritance in one call (see `Resolver::method_return_type`); the
+        // previous explicit `find_extension_fn_return_type` step here was dead —
+        // `find_method_return_type` already probes extensions first.
+        crate::resolver::Resolver::method_return_type(self, class_name, method_name, None)
+            .map(crate::resolver::ReturnType::into_inner)
     }
     fn find_method_params_text(&self, class_name: &str, method_name: &str) -> Option<String> {
         crate::indexer::infer::sig::find_method_params_in_class(self, class_name, method_name)

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -163,7 +163,7 @@ pub(super) fn forward_resolve_segments(
                         }
                     }
                     if let Some(ret_ty) = deps.find_fun_return_type(name) {
-                        let ret_base = ret_ty.trim_end_matches('?').dotted_ident_prefix();
+                        let ret_base = ret_ty.strip_nullable().dotted_ident_prefix();
                         let ret_base = ret_base.trim_end_matches('.');
                         if !is_generic_param(ret_base) {
                             current_type = Some(ret_ty);
@@ -313,7 +313,7 @@ pub(super) fn resolve_member_type_on(
     if let Some(field_ty) = deps.find_field_type(&effective_type, member) {
         let subst = build_type_arg_subst(deps, &effective_type, current_type);
         let applied = crate::indexer::apply_type_subst(&field_ty, &subst);
-        if is_generic_param(applied.trim_end_matches('?')) {
+        if is_generic_param(applied.strip_nullable()) {
             return first_type_arg_raw(current_type);
         }
         return Some(applied);
@@ -321,7 +321,7 @@ pub(super) fn resolve_member_type_on(
     if let Some(ret_ty) = deps.find_method_return_type_for_type(&effective_type, member) {
         let subst = build_type_arg_subst(deps, &effective_type, current_type);
         let applied = crate::indexer::apply_type_subst(&ret_ty, &subst);
-        if is_generic_param(applied.trim_end_matches('?')) {
+        if is_generic_param(applied.strip_nullable()) {
             return first_type_arg_raw(current_type);
         }
         return Some(applied);

--- a/src/indexer/infer/cst_lambda.rs
+++ b/src/indexer/infer/cst_lambda.rs
@@ -222,7 +222,7 @@ fn lambda_this_ctx(
         if let Some(receiver_type) =
             call_expression.and_then(|call| resolve_receiver_type(&call, &doc.bytes, idx, uri))
         {
-            let dotted_prefix = receiver_type.trim_end_matches('?').dotted_ident_prefix();
+            let dotted_prefix = receiver_type.strip_nullable().dotted_ident_prefix();
             let base_name = dotted_prefix.trim_end_matches('.').last_segment();
             if !base_name.is_empty() {
                 return ThisLambdaCtx::Resolved(base_name.to_owned());

--- a/src/indexer/infer/receiver.rs
+++ b/src/indexer/infer/receiver.rs
@@ -182,7 +182,7 @@ fn chain_with_type_subst(
     {
         let subst = build_type_arg_subst(deps, &intermediate_base, &intermediate_type_raw);
         let applied = crate::indexer::apply_type_subst(&method_return, &subst);
-        let base = applied.trim_end_matches('?').dotted_ident_prefix();
+        let base = applied.strip_nullable().dotted_ident_prefix();
         let base = base.trim_end_matches('.');
         if base.is_empty() || is_generic_param(base) {
             first_concrete_type_arg_str(&intermediate_type_raw)?

--- a/src/indexer/infer/type_subst.rs
+++ b/src/indexer/infer/type_subst.rs
@@ -32,7 +32,7 @@ pub(super) fn build_type_arg_subst(
     };
     let type_args: Vec<String> = split_top_level_commas(inner)
         .into_iter()
-        .map(|s| s.trim().trim_end_matches('?').to_owned())
+        .map(|s| s.trim().strip_nullable().to_owned())
         .filter(|s| !s.is_empty())
         .collect();
     type_params.into_iter().zip(type_args).collect()
@@ -128,8 +128,8 @@ fn match_type_args_recursive(
     params: &[String],
     map: &mut std::collections::HashMap<String, String>,
 ) {
-    let decl_base = declared.trim().trim_end_matches('?');
-    let conc_base = concrete.trim().trim_end_matches('?');
+    let decl_base = declared.trim().strip_nullable();
+    let conc_base = concrete.trim().strip_nullable();
     if decl_base.is_empty() || conc_base.is_empty() {
         return;
     }

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -11,7 +11,14 @@ use crate::resolver::InferenceChain;
 use crate::types::{CallerContext, FileData, SymbolEntry};
 use crate::LinesExt;
 
-/// Domain-level resolution result. Small, owned data suitable for LSP adapters.
+/// Domain-level resolution result: a **rich, complete** record of a resolved
+/// symbol, owned and suitable for LSP adapters.
+///
+/// The fields are *joined* from the index's separate structs at enrichment time
+/// (`SymbolEntry` → kind/deprecated/container; `FileData` → package) so a
+/// consumer gets everything it needs from one resolve call and never re-fetches
+/// the underlying entry to read one more attribute. Adding a needed attribute
+/// here is preferred over a consumer reaching back into the raw maps.
 pub(crate) struct ResolvedSymbol {
     /// Symbol definition location; only accessed in tests and future callers.
     #[allow(dead_code)]
@@ -27,6 +34,15 @@ pub(crate) struct ResolvedSymbol {
     #[allow(dead_code)]
     pub subst: HashMap<String, String>,
     pub doc: String,
+    /// True when the declaration carries an `@Deprecated` annotation
+    /// (joined from `SymbolEntry::deprecated`). Rendered as a hover marker.
+    pub deprecated: bool,
+    /// Enclosing class/object/interface name, or `None` for a top-level
+    /// declaration (joined from `SymbolEntry::container`).
+    pub container: Option<String>,
+    /// The declaring file's package, or `None` when unpackaged (joined from
+    /// `FileData::package`). With `container`, gives the symbol's qualified home.
+    pub package: Option<String>,
 }
 
 /// Options controlling resolution behaviour and allowed fallbacks.
@@ -388,6 +404,9 @@ fn enrich_symbol<I: IndexRead>(
         signature,
         subst,
         doc,
+        deprecated: sym.deprecated,
+        container: sym.container.clone(),
+        package: data.package.clone(),
     })
 }
 

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -2,9 +2,8 @@
 // Phase 2: Core `resolve_symbol_info` pipeline implementation.
 
 use std::collections::HashMap;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use tower_lsp::lsp_types::{CompletionItem, Position, SymbolKind, Url};
+use tower_lsp::lsp_types::{SymbolKind, Url};
 
 use crate::indexer::doc::extract_doc_comment;
 use crate::indexer::Location;
@@ -135,8 +134,9 @@ pub(crate) trait IndexRead {
 /// does not provide.
 ///
 /// The trait grows only as backend handlers migrate away from direct `Indexer`
-/// access. Current callers use `enclosing_class_at`, `mem_lines_for`,
-/// `completions`, and `is_indexing_in_progress` in addition to definition lookup.
+/// access; until then, capabilities like `enclosing_class_at`, `mem_lines_for`,
+/// `completions`, and `is_indexing_in_progress` are still reached through the
+/// inherent `Indexer` (via `as_indexer`), not this trait.
 pub(crate) trait WorkspaceRead: IndexRead {
     fn as_indexer(&self) -> Option<&super::Indexer> {
         None
@@ -149,35 +149,6 @@ pub(crate) trait WorkspaceRead: IndexRead {
         from_uri: &Url,
     ) -> Vec<Location> {
         self.resolve_locations(name, qualifier, from_uri, true)
-    }
-
-    #[allow(dead_code)]
-    fn enclosing_class_at(&self, uri: &Url, row: u32) -> Option<String> {
-        self.as_indexer()?.enclosing_class_at(uri, row)
-    }
-
-    #[allow(dead_code)]
-    fn mem_lines_for(&self, uri: &str) -> Option<Arc<Vec<String>>> {
-        self.as_indexer()?.mem_lines_for(uri)
-    }
-
-    #[allow(dead_code)]
-    fn completions(
-        &self,
-        uri: &Url,
-        position: Position,
-        snippets: bool,
-    ) -> (Vec<CompletionItem>, bool) {
-        let Some(indexer) = self.as_indexer() else {
-            return (vec![], false);
-        };
-        indexer.completions(uri, position, snippets)
-    }
-
-    #[allow(dead_code)]
-    fn is_indexing_in_progress(&self) -> bool {
-        self.as_indexer()
-            .is_some_and(|indexer| indexer.indexing_in_progress.load(Ordering::Acquire))
     }
 }
 

--- a/src/indexer/resolution_tests.rs
+++ b/src/indexer/resolution_tests.rs
@@ -412,6 +412,67 @@ fn resolve_symbol_info_basic_lookup() {
     );
 }
 
+/// The widened `ResolvedSymbol` joins `deprecated`/`container` from the symbol
+/// entry and `package` from the file; the hover formatter then renders both a
+/// deprecation marker and a `package.Container` context footer for members —
+/// all from the one record, no second lookup.
+#[test]
+fn resolve_symbol_info_widens_deprecated_with_qualified_context() {
+    use crate::backend::format::format_symbol_hover;
+
+    let file_uri = "file:///widget.kt";
+
+    let mut sym = make_sym("render", SymbolKind::METHOD, 2, 8);
+    sym.detail = "fun render(): Unit".to_owned();
+    sym.container = Some("Widget".to_owned());
+    sym.deprecated = true;
+
+    let file_data = Arc::new(crate::types::FileData {
+        symbols: vec![sym],
+        package: Some("com.example.ui".to_owned()),
+        lines: std::sync::Arc::new(vec![
+            "package com.example.ui".to_owned(),
+            "class Widget {".to_owned(),
+            "    @Deprecated fun render(): Unit {}".to_owned(),
+            "}".to_owned(),
+        ]),
+        ..Default::default()
+    });
+
+    let mut files = HashMap::new();
+    files.insert(file_uri.to_owned(), file_data);
+    let mut definitions = HashMap::new();
+    definitions.insert("render".to_owned(), vec![make_location(file_uri, 2)]);
+    let idx = RealTestIndex { files, definitions };
+
+    let r = resolve_symbol_info(
+        &idx,
+        "render",
+        None,
+        &Url::parse("file:///caller.kt").unwrap(),
+        SubstitutionContext::None,
+        &ResolveOptions::hover(),
+    )
+    .expect("render should resolve");
+
+    assert!(
+        r.deprecated,
+        "deprecated must be joined from the symbol entry"
+    );
+    assert_eq!(r.container.as_deref(), Some("Widget"));
+    assert_eq!(r.package.as_deref(), Some("com.example.ui"));
+
+    let hover = format_symbol_hover(&r, file_uri);
+    assert!(
+        hover.contains("⚠ Deprecated"),
+        "hover marks deprecation: {hover}"
+    );
+    assert!(
+        hover.contains("*in `com.example.ui.Widget`*"),
+        "hover shows qualified member context: {hover}"
+    );
+}
+
 /// With substitution context: `{T→String}` applied to the signature.
 #[test]
 fn resolve_symbol_info_applies_precomputed_subst() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2145,7 +2145,7 @@ fn extract_type_arg_from_call_suffix(call: Node, bytes: &[u8]) -> Option<String>
     let args = call_suffix.type_arg_strings(bytes);
     let first = args.into_iter().next()?;
     // Strip nullability marker and whitespace
-    let clean = first.trim().trim_end_matches('?');
+    let clean = first.trim().strip_nullable();
     if clean.is_empty() || !clean.starts_with_uppercase() {
         return None;
     }

--- a/src/resolver/api.rs
+++ b/src/resolver/api.rs
@@ -27,7 +27,10 @@ use tower_lsp::lsp_types::{Location, Url};
 
 use crate::indexer::Indexer;
 
-use super::infer::{infer_field_chain_type, infer_receiver_type};
+use super::infer::{
+    find_fun_return_type_by_name, find_fun_return_type_reachable, find_method_return_type,
+    find_method_return_type_via_supertypes, infer_field_chain_type, infer_receiver_type,
+};
 use super::{ReceiverKind, ReceiverType};
 
 /// An ordered list of **definition** sites (where a symbol is *declared*), best
@@ -43,6 +46,39 @@ impl std::ops::Deref for Definitions {
     type Target = [Location];
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+/// The result type of a call — what a function or method *returns*.
+///
+/// Carried as the **as-written** type text from the signature (the text after
+/// the `:`), with generics and a trailing `?` preserved (e.g. `Flow<Event>`,
+/// `String?`). It is *not* normalized: feed it to [`ReceiverType::from_raw`] when
+/// you need the `raw`/`qualified`/`leaf`/`nullable` breakdown. The newtype exists
+/// so a signature returning `Option<ReturnType>` says "a call's return type",
+/// distinct from a receiver type, a field type, or a bare identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReturnType(pub String);
+
+impl ReturnType {
+    /// Consume into the owned return-type `String` (for the downstream
+    /// String-typed inference paths that haven't adopted the newtype yet).
+    /// Borrow with `&*` / [`Deref`](std::ops::Deref) when you only need `&str`.
+    pub(crate) fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl std::ops::Deref for ReturnType {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<ReturnType> for String {
+    fn from(rt: ReturnType) -> Self {
+        rt.0
     }
 }
 
@@ -79,6 +115,39 @@ pub(crate) trait Resolver {
     /// import-aware member lookup; prefer it over reaching into the raw
     /// `definition_locations` map, which is not scope-aware.
     fn resolve_member(&self, member: &str, qualifier: &str, uri: &Url) -> Definitions;
+
+    /// Resolve the [`ReturnType`] of a *free function* `fn_name` called from
+    /// `from_uri`.
+    ///
+    /// Import-aware: binds `fn_name` through the scope chain (imports →
+    /// same-package → star → qualified/jars) and reads the return type of the
+    /// symbol the call actually binds to, falling back to a capped workspace-wide
+    /// by-name lookup only when no in-scope definition is found. Prefer this over
+    /// the raw by-name scan so an unrelated same-named overload in a test file or
+    /// jar can't shadow the real one.
+    ///
+    /// Returns `None` when no definition is found or it has no declared return
+    /// type.
+    fn function_return_type(&self, fn_name: &str, from_uri: &Url) -> Option<ReturnType>;
+
+    /// Resolve the [`ReturnType`] of `method_name` invoked on a receiver whose
+    /// type's base name is `type_name`.
+    ///
+    /// This is the single composite for member resolution: it checks extension
+    /// functions and member functions of the type itself, then walks the type's
+    /// declared supertypes (applying type-argument substitution). When `from_uri`
+    /// is `Some`, extension functions are filtered to those in scope at that file;
+    /// `None` performs an unfiltered global lookup for callers without URI
+    /// context.
+    ///
+    /// Returns `None` when no matching method (own, extension, or inherited) with
+    /// a declared return type is found.
+    fn method_return_type(
+        &self,
+        type_name: &str,
+        method_name: &str,
+        from_uri: Option<&Url>,
+    ) -> Option<ReturnType>;
 }
 
 impl Resolver for Indexer {
@@ -92,5 +161,24 @@ impl Resolver for Indexer {
 
     fn resolve_member(&self, member: &str, qualifier: &str, uri: &Url) -> Definitions {
         Definitions(self.resolve_member_only(member, qualifier, uri))
+    }
+
+    fn function_return_type(&self, fn_name: &str, from_uri: &Url) -> Option<ReturnType> {
+        find_fun_return_type_reachable(self, fn_name, from_uri)
+            .or_else(|| find_fun_return_type_by_name(self, fn_name))
+            .map(ReturnType)
+    }
+
+    fn method_return_type(
+        &self,
+        type_name: &str,
+        method_name: &str,
+        from_uri: Option<&Url>,
+    ) -> Option<ReturnType> {
+        find_method_return_type(self, type_name, method_name, from_uri)
+            .or_else(|| {
+                find_method_return_type_via_supertypes(self, type_name, method_name, from_uri)
+            })
+            .map(ReturnType)
     }
 }

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -752,11 +752,7 @@ fn resolve_dotted_receiver_type(indexer: &Indexer, path: &str, uri: &Url) -> Opt
 
     for &segment in &segments[1..] {
         let current_base = current_type.split('<').next()?.trim();
-        let current_base_leaf = current_base
-            .rsplit('.')
-            .next()?
-            .trim()
-            .trim_end_matches('?');
+        let current_base_leaf = current_base.rsplit('.').next()?.trim().strip_nullable();
 
         let clean_segment = segment.trim_end_matches("()").trim();
 

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -597,6 +597,10 @@ fn complete_super(indexer: &Indexer, from_uri: &Url, snippets: bool) -> Vec<Comp
 
 /// Dot-completion: return all members of the receiver's inferred type,
 /// sorted: methods first, then fields/vars, then class-level names last.
+///
+/// Test-only thin wrapper over [`complete_dot_expr`]; production callers build
+/// the [`ReceiverExpr`] directly.
+#[cfg(test)]
 pub(crate) fn complete_dot(
     indexer: &Indexer,
     receiver: &str,
@@ -1868,44 +1872,6 @@ fn trigger_parameter_hints() -> tower_lsp::lsp_types::Command {
         title: "triggerParameterHints".into(),
         command: "editor.action.triggerParameterHints".into(),
         arguments: None,
-    }
-}
-
-// ─── impl Indexer wrappers ────────────────────────────────────────────────────
-
-#[allow(dead_code)]
-impl crate::indexer::Indexer {
-    pub(crate) fn complete_dot(
-        &self,
-        receiver: &str,
-        from_uri: &Url,
-        snippets: bool,
-    ) -> Vec<CompletionItem> {
-        complete_dot(self, receiver, from_uri, snippets, None)
-    }
-    pub(crate) fn complete_bare(
-        &self,
-        prefix: &str,
-        from_uri: &Url,
-        snippets: bool,
-        annotation_only: bool,
-    ) -> (Vec<CompletionItem>, bool) {
-        complete_bare(self, prefix, from_uri, snippets, annotation_only, None)
-    }
-    pub(super) fn complete_super_w(&self, from_uri: &Url, snippets: bool) -> Vec<CompletionItem> {
-        complete_super(self, from_uri, snippets)
-    }
-    pub(super) fn symbols_from_uri_as_completions_w(&self, file_uri: &str) -> Vec<CompletionItem> {
-        symbols_from_uri_as_completions(self, file_uri)
-    }
-    pub(super) fn build_completion_items_w(&self, file_uri: &str) -> Vec<CompletionItem> {
-        build_completion_items(self, file_uri)
-    }
-    pub(crate) fn symbols_from_uri_as_completions_pub(
-        &self,
-        file_uri: &str,
-    ) -> Vec<CompletionItem> {
-        symbols_from_uri_as_completions_pub(self, file_uri)
     }
 }
 

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -14,13 +14,13 @@ use crate::LinesExt;
 use crate::StrExt;
 
 use super::infer::{
-    find_field_type_in_class, find_fun_return_type_by_name, find_method_return_type,
-    infer_receiver_type, infer_receiver_type_at, infer_variable_type_raw, ReceiverKind,
-    ReceiverType,
+    find_field_type_in_class, infer_receiver_type, infer_receiver_type_at, infer_variable_type_raw,
+    ReceiverKind, ReceiverType,
 };
 use super::infer_lines::infer_callable_param_return_type;
 use super::{
     already_imported, ensure_file_data, fqns_for_name, resolve_symbol_no_rg, walk_hierarchy,
+    Resolver,
 };
 
 // ─── CompletionItem.data JSON keys ───────────────────────────────────────────
@@ -691,8 +691,8 @@ fn resolve_dot_receiver_type(
                 return Some(ReceiverType::from_raw(raw));
             }
         }
-        if let Some(ret) = find_fun_return_type_by_name(indexer, receiver) {
-            return Some(ReceiverType::from_raw(ret));
+        if let Some(ret) = indexer.function_return_type(receiver, from_uri) {
+            return Some(ReceiverType::from_raw(ret.into_inner()));
         }
         let file = ensure_file_data(indexer, from_uri)?;
         let ret = infer_callable_param_return_type(&file.lines, receiver)?;
@@ -725,8 +725,8 @@ fn resolve_dot_receiver_type(
     }
 
     // Fallback: function defined in scope (e.g. bare `productFlow` written without `()`).
-    if let Some(ret) = find_fun_return_type_by_name(indexer, receiver) {
-        return Some(ReceiverType::from_raw(ret));
+    if let Some(ret) = indexer.function_return_type(receiver, from_uri) {
+        return Some(ReceiverType::from_raw(ret.into_inner()));
     }
     let file = ensure_file_data(indexer, from_uri)?;
     let ret = infer_callable_param_return_type(&file.lines, receiver)?;
@@ -764,9 +764,9 @@ fn resolve_dotted_receiver_type(indexer: &Indexer, path: &str, uri: &Url) -> Opt
         {
             current_type = next_type;
         } else if let Some(next_type) =
-            find_method_return_type(indexer, current_base_leaf, clean_segment, Some(uri))
+            indexer.method_return_type(current_base_leaf, clean_segment, Some(uri))
         {
-            current_type = next_type;
+            current_type = next_type.into_inner();
         } else {
             return None;
         }

--- a/src/resolver/find.rs
+++ b/src/resolver/find.rs
@@ -139,20 +139,8 @@ pub(crate) fn find_local_declaration(idx: &Indexer, name: &str, uri: &Url) -> Ve
 
 // ─── impl Indexer wrappers ────────────────────────────────────────────────────
 
-#[allow(dead_code)]
 impl crate::indexer::Indexer {
     pub(crate) fn find_name_in_uri(&self, name: &str, file_uri: &str) -> Vec<Location> {
         find_name_in_uri(self, name, file_uri)
-    }
-    pub(crate) fn find_name_in_uri_after_line(
-        &self,
-        name: &str,
-        file_uri: &str,
-        after_line: u32,
-    ) -> Vec<Location> {
-        find_name_in_uri_after_line(self, name, file_uri, after_line)
-    }
-    pub(crate) fn find_local_declaration(&self, name: &str, uri: &Url) -> Vec<Location> {
-        find_local_declaration(self, name, uri)
     }
 }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -127,7 +127,7 @@ impl ReceiverType {
         // Only a *trailing* `?` makes the outer type nullable. A `?` inside a
         // generic argument (`Box<String?>`) does not — so test the end, not the
         // whole string.
-        let nullable = raw.trim_end().ends_with('?');
+        let nullable = raw.is_nullable();
         let outer = qualified
             .split('.')
             .next()
@@ -213,7 +213,7 @@ pub(crate) fn infer_field_chain_type(
             .rsplit('.')
             .next()
             .unwrap_or(&current)
-            .trim_end_matches('?');
+            .strip_nullable();
         let field_raw = find_field_type_in_class(indexer, class_base, field)?;
         current = field_raw.clone();
         leaf_raw = field_raw;
@@ -415,7 +415,7 @@ fn infer_var_from_rhs_data(
                 .rsplit('.')
                 .next()
                 .unwrap_or(recv_stripped)
-                .trim_end_matches('?');
+                .strip_nullable();
             if let Some(field_type) = find_field_type_in_class(indexer, recv_base, &field) {
                 return Some(field_type);
             }

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -355,3 +355,57 @@ fn return_type_reachable_prefers_imported_symbol() {
         "must bind to the imported compose stringResource (String), not the decoy"
     );
 }
+
+/// `Resolver::function_return_type` is the import-aware catalog entry: it binds
+/// through the scope chain first, then falls back to a workspace-wide by-name
+/// lookup, returning a self-documenting [`ReturnType`]. This asserts the
+/// fallback arm — a function in another package with no import is still found.
+#[test]
+fn catalog_function_return_type_falls_back_to_by_name() {
+    use crate::indexer::Indexer;
+    use crate::resolver::Resolver;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    let def = Url::parse("file:///app/Repo.kt").unwrap();
+    idx.index_content(&def, "package app\nfun buildRepo(): Repository = TODO()\n");
+
+    // Caller in a different package with no import — reachable resolution fails,
+    // so the by-name fallback must carry it.
+    let caller = Url::parse("file:///other/Main.kt").unwrap();
+    idx.index_content(&caller, "package other\nfun m() {}\n");
+
+    assert_eq!(
+        idx.function_return_type("buildRepo", &caller)
+            .map(|r| r.into_inner()),
+        Some("Repository".to_string()),
+        "by-name fallback must find the workspace function"
+    );
+}
+
+/// `Resolver::method_return_type` is the single composite for member resolution:
+/// own/extension methods *and* inherited (supertype) methods resolve through one
+/// call. This asserts the supertype arm — a method declared only on the base
+/// class resolves when queried on the derived class.
+#[test]
+fn catalog_method_return_type_folds_supertype_inheritance() {
+    use crate::indexer::Indexer;
+    use crate::resolver::Resolver;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    let f = Url::parse("file:///app/Types.kt").unwrap();
+    idx.index_content(
+        &f,
+        "package app\nopen class Base { fun who(): Identity = TODO() }\nclass Derived : Base()\n",
+    );
+
+    // `who` is declared only on Base; querying it on Derived must resolve via the
+    // supertype walk that `method_return_type` folds in.
+    assert_eq!(
+        idx.method_return_type("Derived", "who", None)
+            .map(|r| r.into_inner()),
+        Some("Identity".to_string()),
+        "method_return_type must fold supertype inheritance into one call"
+    );
+}

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -16,7 +16,7 @@ mod tests;
 
 // ─── re-exports ───────────────────────────────────────────────────────────────
 
-pub(crate) use api::Resolver;
+pub(crate) use api::{Resolver, ReturnType};
 pub(crate) use complete::symbols_from_uri_as_completions_pub;
 #[cfg(test)]
 pub(crate) use complete::{complete_symbol, complete_symbol_with_context, is_annotation_context};

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -618,7 +618,7 @@ fn resolve_qualified(
     // A nullable receiver resolves members from its underlying (non-null) class,
     // so drop any trailing `?` before resolving the type to a file — otherwise
     // `resolve_symbol("Confirmation?")` would find nothing.
-    let start_type = start_type.trim_end_matches('?');
+    let start_type = start_type.strip_nullable();
 
     // `start_type` may be a dotted nested type like `Outer.Inner`.
     // Split into outer (for file resolution) and optional inner (nested class).

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -1264,46 +1264,6 @@ pub(crate) fn is_stdlib(pkg: &str) -> bool {
     )
 }
 
-// ─── ResolutionChain trait ────────────────────────────────────────────────────
-
-/// The five ordered resolution steps used by [`resolve_symbol_inner`].
-///
-/// Implementing this trait on a type allows the resolution chain to be driven
-/// generically — e.g. in tests a lightweight stub can replace the full
-/// [`Indexer`] without bringing up a real index.
-///
-/// Step order mirrors the chain in [`resolve_symbol_inner`]:
-/// `local → via_imports → same_package → star_imports → qualified`.
-///
-/// TODO(G4): make `resolve_symbol_inner` generic over `ResolutionChain +
-/// SymbolIndex + ScopeQuery` and migrate call-sites away from `&Indexer`.
-#[allow(dead_code)]
-pub(crate) trait ResolutionChain {
-    fn resolve_local(&self, name: &str, uri: &Url) -> Vec<Location>;
-    fn resolve_via_imports(&self, name: &str, uri: &Url) -> Vec<Location>;
-    fn resolve_same_package(&self, name: &str, uri: &Url) -> Vec<Location>;
-    fn resolve_star_imports(&self, name: &str, uri: &Url) -> Vec<Location>;
-    fn resolve_qualified(&self, name: &str, qualifier: &str, uri: &Url) -> Vec<Location>;
-}
-
-impl ResolutionChain for Indexer {
-    fn resolve_local(&self, name: &str, uri: &Url) -> Vec<Location> {
-        resolve_local(self, name, uri)
-    }
-    fn resolve_via_imports(&self, name: &str, uri: &Url) -> Vec<Location> {
-        resolve_via_imports(self, name, uri)
-    }
-    fn resolve_same_package(&self, name: &str, uri: &Url) -> Vec<Location> {
-        resolve_same_package(self, name, uri)
-    }
-    fn resolve_star_imports(&self, name: &str, uri: &Url) -> Vec<Location> {
-        resolve_star_imports(self, name, uri)
-    }
-    fn resolve_qualified(&self, name: &str, qualifier: &str, uri: &Url) -> Vec<Location> {
-        resolve_qualified(self, name, qualifier, uri)
-    }
-}
-
 // ─── impl Indexer wrappers ────────────────────────────────────────────────────
 
 impl crate::indexer::Indexer {

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -68,6 +68,20 @@ pub(crate) fn fqns_for_name(indexer: &Indexer, name: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Which IO and fallbacks a resolution pass may use. The plan's "IoPolicy".
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResolveIo {
+    /// Navigation (go-to-def, hover): may spawn `fd`/`rg`, walk the class
+    /// hierarchy, and index a cold file on demand. No global-defs tail fallback.
+    Full,
+    /// Index-only, but imports may still `fd`. No `rg`, no hierarchy, no cold
+    /// index. Tail fallback: first global-defs match. (completion/highlight hot path)
+    NoRg,
+    /// Strictly in-memory: no `fd`, no `rg`, no hierarchy. Tail fallback:
+    /// unique global-defs match only (ambiguity-safe). (diagnostics keystroke path)
+    IndexOnly,
+}
+
 /// Resolve `name` as seen from `from_uri`, returning all known definition
 /// `Location`s in priority order.  Returns an empty vec only when nothing was
 /// found by any strategy including `rg`.
@@ -154,10 +168,39 @@ pub(crate) fn resolve_symbol_inner(
     from_uri: &Url,
     with_hierarchy: bool,
 ) -> Vec<Location> {
+    resolve_chain(indexer, name, from_uri, ResolveIo::Full, with_hierarchy)
+}
+
+/// The single prioritised resolution chain, parameterised by IO policy.
+///
+/// `resolve_symbol_inner` (`Full`), `resolve_symbol_no_rg` (`NoRg`) and
+/// `resolve_type_index_only_simple` (`IndexOnly`) are all thin wrappers over this
+/// function. The `ResolveIo` policy selects which subprocess fallbacks (`fd`/`rg`),
+/// the hierarchy walk, the cold-file on-demand index, and which global-defs tail
+/// fallback are permitted — see the `ResolveIo` doc-comment for the per-policy table.
+///
+/// The chain order is fixed (local → local-decl → imports → swift → same-package →
+/// star → hierarchy → rg → tail); each step that is policy-gated simply no-ops when
+/// the policy forbids it, so every policy walks the same steps in the same order.
+fn resolve_chain(
+    indexer: &Indexer,
+    name: &str,
+    from_uri: &Url,
+    io: ResolveIo,
+    with_hierarchy: bool,
+) -> Vec<Location> {
+    // Behavioural knobs derived from the policy (see the `ResolveIo` table):
+    //  - `full_io`: cold-index + local-decl + swift + hierarchy + project-wide rg
+    //  - `allow_fd`: import resolution may spawn `fd` (everything except IndexOnly)
+    //  - `star_rg`: star imports may `rg` the package dir (Full only)
+    let full_io = matches!(io, ResolveIo::Full);
+    let allow_fd = !matches!(io, ResolveIo::IndexOnly);
+    let star_rg = matches!(io, ResolveIo::Full);
+
     // 0.5 ── on-demand index of the current file if not yet indexed ────────────
     // Ensures resolve_local and find_local_declaration work even at cold start
     // (e.g. the user invokes gd/hover before indexing has reached this file).
-    if !indexer.files.contains_key(from_uri.as_str()) {
+    if full_io && !indexer.files.contains_key(from_uri.as_str()) {
         if let Ok(path) = from_uri.to_file_path() {
             if let Ok(content) = std::fs::read_to_string(&path) {
                 indexer.index_content(from_uri, &content);
@@ -175,7 +218,7 @@ pub(crate) fn resolve_symbol_inner(
     // Catches function parameters without val/var that aren't in the symbol index.
     // Also catches named lambda parameters: `{ item -> ...}` found via the
     // `name ->` pattern in find_declaration_range_in_lines.
-    if !name.starts_with_uppercase() {
+    if full_io && !name.starts_with_uppercase() {
         let decl = find_local_declaration(indexer, name, from_uri);
         if !decl.is_empty() {
             return decl;
@@ -183,7 +226,7 @@ pub(crate) fn resolve_symbol_inner(
     }
 
     // 2 ── explicit imports ───────────────────────────────────────────────────
-    let imported = resolve_via_imports(indexer, name, from_uri);
+    let imported = resolve_via_imports(indexer, name, from_uri, allow_fd);
     if !imported.is_empty() {
         return imported;
     }
@@ -192,7 +235,8 @@ pub(crate) fn resolve_symbol_inner(
     // Swift files have no package declarations, so same-package and star-import
     // steps return empty. Use the in-memory definitions index directly to avoid
     // expensive project-wide rg fallback at step 5.
-    if crate::Language::from_path(from_uri.path()) == crate::Language::Swift
+    if full_io
+        && crate::Language::from_path(from_uri.path()) == crate::Language::Swift
         && name.starts_with_uppercase()
     {
         if let Some(locs_ref) = indexer.definitions.get(name) {
@@ -219,13 +263,30 @@ pub(crate) fn resolve_symbol_inner(
     }
 
     // 4 ── star imports ───────────────────────────────────────────────────────
-    let star = resolve_star_imports(indexer, name, from_uri);
-    if !star.is_empty() {
-        return star;
+    if star_rg {
+        // Indexed-package scan, then `rg` scoped to the package dir for unindexed files.
+        let star = resolve_star_imports(indexer, name, from_uri);
+        if !star.is_empty() {
+            return star;
+        }
+    } else {
+        // Index-only scan (no rg fallback for unindexed files).
+        let star_pkgs: Vec<String> = match indexer.files.get(from_uri.as_str()) {
+            Some(f) => f
+                .imports
+                .iter()
+                .filter(|i| i.is_star && !is_stdlib(&i.full_path))
+                .map(|i| i.full_path.clone())
+                .collect(),
+            None => vec![],
+        };
+        if let Some(loc) = find_in_star_imports(indexer, name, &star_pkgs) {
+            return vec![loc];
+        }
     }
 
     // 4.5 ── superclass / interface hierarchy ─────────────────────────────────
-    if with_hierarchy {
+    if full_io && with_hierarchy {
         let inherited = resolve_from_class_hierarchy(indexer, name, from_uri);
         if !inherited.is_empty() {
             return inherited;
@@ -233,22 +294,45 @@ pub(crate) fn resolve_symbol_inner(
     }
 
     // 5 ── project-wide rg ───────────────────────────────────────────────────
-    let (root, source_roots, matcher) = indexer.rg_scope_for_path(None);
-    // Skip when an explicit import for this name already went through all
-    // source-tree lookups (qualified index + definitions index + fd) and came
-    // up empty.  rg searches the same source tree and cannot add anything new.
-    // The package-dir check is the authoritative gate: if `android/os/` doesn't
-    // exist under any source root, the symbol simply isn't in the project.
-    if import_package_absent_from_source_roots(
-        indexer,
-        name,
-        from_uri,
-        root.as_deref(),
-        &source_roots,
-    ) {
-        return vec![];
+    if full_io {
+        let (root, source_roots, matcher) = indexer.rg_scope_for_path(None);
+        // Skip when an explicit import for this name already went through all
+        // source-tree lookups (qualified index + definitions index + fd) and came
+        // up empty.  rg searches the same source tree and cannot add anything new.
+        // The package-dir check is the authoritative gate: if `android/os/` doesn't
+        // exist under any source root, the symbol simply isn't in the project.
+        if import_package_absent_from_source_roots(
+            indexer,
+            name,
+            from_uri,
+            root.as_deref(),
+            &source_roots,
+        ) {
+            return vec![];
+        }
+        return rg_find_definition(name, root.as_deref(), &source_roots, matcher.as_deref());
     }
-    rg_find_definition(name, root.as_deref(), &source_roots, matcher.as_deref())
+
+    // Tail fallback — global definitions index (includes JAR symbols).
+    //  - NoRg: first match.   - IndexOnly: unique match only (ambiguity-safe).
+    //  - Full: never reached (returns inside the rg branch above).
+    match io {
+        ResolveIo::Full => vec![],
+        ResolveIo::NoRg => indexer
+            .lookup_definitions(name)
+            .into_iter()
+            .next()
+            .map(|loc| vec![loc])
+            .unwrap_or_default(),
+        ResolveIo::IndexOnly => {
+            let locs = indexer.lookup_definitions(name);
+            if locs.len() == 1 {
+                locs
+            } else {
+                vec![]
+            }
+        }
+    }
 }
 
 /// Returns the first Location found by scanning star-import packages.
@@ -271,42 +355,7 @@ fn find_in_star_imports(indexer: &Indexer, name: &str, star_pkgs: &[String]) -> 
 /// Completion is triggered on every keystroke; spawning external `rg`/`fd`
 /// processes on each request would block the LSP thread and spike CPU.
 pub(crate) fn resolve_symbol_no_rg(indexer: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
-    let local = resolve_local(indexer, name, from_uri);
-    if !local.is_empty() {
-        return local;
-    }
-
-    let imported = resolve_via_imports(indexer, name, from_uri);
-    if !imported.is_empty() {
-        return imported;
-    }
-
-    let same_pkg = resolve_same_package(indexer, name, from_uri);
-    if !same_pkg.is_empty() {
-        return same_pkg;
-    }
-
-    // Star imports: index-only scan (no rg fallback for unindexed files).
-    let star_pkgs: Vec<String> = match indexer.files.get(from_uri.as_str()) {
-        Some(f) => f
-            .imports
-            .iter()
-            .filter(|i| i.is_star && !is_stdlib(&i.full_path))
-            .map(|i| i.full_path.clone())
-            .collect(),
-        None => vec![],
-    };
-    if let Some(loc) = find_in_star_imports(indexer, name, &star_pkgs) {
-        return vec![loc];
-    }
-
-    // Check the global definitions index as a final fast fallback (includes JAR symbols).
-    let locs = indexer.lookup_definitions(name);
-    if let Some(loc) = locs.into_iter().next() {
-        return vec![loc];
-    }
-
-    vec![]
+    resolve_chain(indexer, name, from_uri, ResolveIo::NoRg, false)
 }
 
 /// Index-only type resolver for the diagnostics hot path.
@@ -342,116 +391,7 @@ pub(crate) fn resolve_type_index_only(
 
 /// Inner helper: resolves a simple (non-dotted) type name using the index-only chain.
 fn resolve_type_index_only_simple(indexer: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
-    let local = resolve_local(indexer, name, from_uri);
-    if !local.is_empty() {
-        return local;
-    }
-
-    let imported = resolve_via_imports_index_only(indexer, name, from_uri);
-    if !imported.is_empty() {
-        return imported;
-    }
-
-    let same_pkg = resolve_same_package(indexer, name, from_uri);
-    if !same_pkg.is_empty() {
-        return same_pkg;
-    }
-
-    // Star imports: index-only scan.
-    let star_pkgs: Vec<String> = match indexer.files.get(from_uri.as_str()) {
-        Some(f) => f
-            .imports
-            .iter()
-            .filter(|i| i.is_star && !is_stdlib(&i.full_path))
-            .map(|i| i.full_path.clone())
-            .collect(),
-        None => vec![],
-    };
-    if let Some(loc) = find_in_star_imports(indexer, name, &star_pkgs) {
-        return vec![loc];
-    }
-
-    // Ambiguity-safe global fallback (includes JAR symbols): only return if exactly one candidate.
-    let locs = indexer.lookup_definitions(name);
-    if locs.len() == 1 {
-        return locs;
-    }
-
-    vec![]
-}
-
-/// Import resolution without subprocess fallback (no `fd_find_and_parse`).
-/// Uses only the in-memory qualified index and definitions index.
-fn resolve_via_imports_index_only(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
-    let imports: Vec<crate::types::ImportEntry> = match indexer.files.get(uri.as_str()) {
-        Some(f) => f.imports.iter().filter(|i| !i.is_star).cloned().collect(),
-        None => return vec![],
-    };
-
-    for imp in imports.iter().filter(|i| i.local_name == name) {
-        // i) qualified index — exact FQN
-        if let Some(loc) = indexer.qualified.get(&imp.full_path) {
-            return vec![loc.clone()];
-        }
-
-        // ii) short-name index filtered to the expected package
-        let short = imp.full_path.last_segment();
-        let expected_pkg = import_package_prefix(&imp.full_path);
-        // For nested class imports (e.g. OverviewProductContract.Event), extract
-        // the container name to disambiguate when multiple classes with the same
-        // short name exist in the same package.
-        let expected_container = extract_container_from_import(&imp.full_path);
-
-        let mut all_locations: Vec<tower_lsp::lsp_types::Location> = Vec::new();
-        if let Some(locs) = indexer.definitions.get(short) {
-            all_locations.extend(locs.iter().cloned());
-        }
-        if let Some(locs) = indexer.jar_definitions.get(short) {
-            all_locations.extend(locs.iter().cloned());
-        }
-        if !all_locations.is_empty() {
-            let filtered: Vec<_> = all_locations
-                .iter()
-                .filter(|loc| {
-                    // Package filter
-                    let pkg_match = indexer
-                        .files
-                        .get(loc.uri.as_str())
-                        .or_else(|| indexer.jar_files.get(loc.uri.as_str()))
-                        .and_then(|f| f.package.clone())
-                        .map(|p| p == expected_pkg || p.starts_with(&format!("{expected_pkg}.")))
-                        .unwrap_or(false);
-
-                    if !pkg_match {
-                        return false;
-                    }
-
-                    // Container filter for nested classes
-                    if let Some(ref container) = expected_container {
-                        // Find the symbol at this location to check its container field
-                        if let Some(file_data) = indexer.file_data_for(loc.uri.as_str()) {
-                            if let Some(symbol) = file_data
-                                .symbols
-                                .iter()
-                                .find(|s| s.selection_range == loc.range)
-                            {
-                                return symbol.container.as_deref() == Some(container.as_str());
-                            }
-                        }
-                        return false;
-                    }
-
-                    true
-                })
-                .cloned()
-                .collect();
-            if !filtered.is_empty() {
-                return filtered;
-            }
-        }
-        // No fd fallback — index-only
-    }
-    vec![]
+    resolve_chain(indexer, name, from_uri, ResolveIo::IndexOnly, false)
 }
 
 // ─── step implementations ────────────────────────────────────────────────────
@@ -842,8 +782,10 @@ fn resolve_companion_member(
 ///   i.   qualified index  — exact match, O(1), works once file is indexed
 ///   ii.  definitions index — short-name, filtered to expected package
 ///   iii. fd + on-demand parse — works at cold start; tries parent class file
-///        first for nested symbols (AccountPickerContract.kt before Event.kt)
-fn resolve_via_imports(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
+///        first for nested symbols (AccountPickerContract.kt before Event.kt).
+///        Gated by `allow_fd`: the index-only policy passes `false` to stay
+///        strictly in-memory (no subprocess spawns) while keeping sub-steps i–ii.
+fn resolve_via_imports(indexer: &Indexer, name: &str, uri: &Url, allow_fd: bool) -> Vec<Location> {
     let imports: Vec<crate::types::ImportEntry> = match indexer.files.get(uri.as_str()) {
         Some(f) => f.imports.iter().filter(|i| !i.is_star).cloned().collect(),
         None => return vec![],
@@ -931,11 +873,14 @@ fn resolve_via_imports(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Location
         // any source root.  A single stat() per import prevents spawning fd
         // processes for SDK/stdlib packages (android.os, androidx.*…) whose
         // sources are never present in the project tree.
-        let (root, source_roots, matcher) = indexer.rg_scope_for_path(None);
-        if package_dir_in_source_roots(&imp.full_path, root.as_deref(), &source_roots) {
-            let locs = fd_find_and_parse(name, &imp.full_path, root.as_deref(), matcher.as_deref());
-            if !locs.is_empty() {
-                return locs;
+        if allow_fd {
+            let (root, source_roots, matcher) = indexer.rg_scope_for_path(None);
+            if package_dir_in_source_roots(&imp.full_path, root.as_deref(), &source_roots) {
+                let locs =
+                    fd_find_and_parse(name, &imp.full_path, root.as_deref(), matcher.as_deref());
+                if !locs.is_empty() {
+                    return locs;
+                }
             }
         }
     }
@@ -1162,25 +1107,6 @@ fn rg_in_package_dir(
 }
 
 // ─── shared helpers ───────────────────────────────────────────────────────────
-
-/// Extract the container name from a nested class import path.
-/// E.g. `"cz.moneta.OverviewProductContract.Event"` → `Some("OverviewProductContract")`
-/// E.g. `"cz.moneta.Event"` → `None` (not a nested class)
-fn extract_container_from_import(import_path: &str) -> Option<String> {
-    use crate::StrExt;
-    let segments: Vec<&str> = import_path.split('.').collect();
-    // Find the last two uppercase segments. If they exist, the first is the container.
-    let upper: Vec<&str> = segments
-        .iter()
-        .copied()
-        .filter(|s| s.starts_with_uppercase())
-        .collect();
-    if upper.len() >= 2 {
-        Some(upper[upper.len() - 2].to_string())
-    } else {
-        None
-    }
-}
 
 /// Returns `true` if the package directory derived from `import_path` exists as a
 /// subdirectory of at least one search root.

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -3659,6 +3659,50 @@ fn import_disambiguates_deeply_nested_member_by_full_chain() {
     assert_eq!(locs[0].range.start.line, 4);
 }
 
+/// IndexOnly path (diagnostics / `fill_when`, via `resolve_type_index_only`) must
+/// disambiguate nested sealed-class members exactly like navigation does. Two
+/// sibling sealed classes expose identically-named members one level below a
+/// shared immediate container (`State.Sub.Idle` vs `Event.Sub.Idle`, both nested
+/// in a `Sub`); only a *whole enclosing-chain* match resolves the import to the
+/// right one. The retired index-only import clone compared only the immediate
+/// parent (`Sub`), so it kept both — this guards the unified chain routing
+/// IndexOnly through the rich `resolve_via_imports(.., allow_fd=false)`.
+#[test]
+fn index_only_import_disambiguates_deeply_nested_member_by_full_chain() {
+    let idx = Indexer::new();
+    let contract = uri("/Contract.kt");
+    let use_uri = uri("/ui/Use.kt");
+    idx.index_content(
+        &contract,
+        "package com.app\n\
+         interface Contract {\n\
+         \x20 sealed class State {\n\
+         \x20   sealed class Sub {\n\
+         \x20     object Idle : Sub()\n\
+         \x20   }\n\
+         \x20 }\n\
+         \x20 sealed class Event {\n\
+         \x20   sealed class Sub {\n\
+         \x20     object Idle : Sub()\n\
+         \x20   }\n\
+         \x20 }\n\
+         }",
+    );
+    idx.index_content(
+        &use_uri,
+        "package com.app.ui\nimport com.app.Contract.State.Sub.Idle\nval x = Idle",
+    );
+    let locs = resolve::resolve_type_index_only(&idx, "Idle", &use_uri);
+    assert_eq!(
+        locs.len(),
+        1,
+        "expected only State.Sub.Idle; got {:?}",
+        locs.iter().map(|l| l.range.start.line).collect::<Vec<_>>()
+    );
+    // State.Sub.Idle is the object on line 4 (0-indexed); Event.Sub.Idle is line 9.
+    assert_eq!(locs[0].range.start.line, 4);
+}
+
 #[test]
 fn jar_to_jar_supertype_walk_resolves_inherited_member() {
     // Base + its member live in one JAR; Child (which extends Base via `supers`)

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -13,10 +13,8 @@ use crate::queries::{
     KIND_KW_IS, KIND_KW_SET, KIND_KW_WHERE, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_NAV_EXPR,
     KIND_SIMPLE_IDENT, KIND_THIS_EXPR, KIND_TYPE_IDENT, KIND_VAR_DECL,
 };
-use crate::resolver::infer::{
-    find_field_type_in_class, find_fun_return_type_by_name, find_method_return_type,
-    infer_variable_type,
-};
+use crate::resolver::infer::{find_field_type_in_class, infer_variable_type};
+use crate::resolver::{Resolver, ReturnType};
 use crate::Language;
 
 use super::helpers::{
@@ -324,8 +322,11 @@ fn navigation_expression_type(
     let receiver_type = expression_type(receiver, doc, starts, indexer, uri)?;
 
     if is_call_callee(node) {
-        return member_return_type(indexer, &receiver_type, &member, uri)
-            .or_else(|| find_fun_return_type_by_name(indexer, &member));
+        return member_return_type(indexer, &receiver_type, &member, uri).or_else(|| {
+            indexer
+                .function_return_type(&member, uri)
+                .map(ReturnType::into_inner)
+        });
     }
 
     find_field_type_in_class(indexer, &receiver_type, &member)
@@ -349,7 +350,9 @@ fn call_expression_type(
             }
         }
     }
-    find_fun_return_type_by_name(indexer, &member)
+    indexer
+        .function_return_type(&member, uri)
+        .map(ReturnType::into_inner)
 }
 
 fn expression_type(
@@ -510,7 +513,9 @@ fn member_return_type(
     member_name: &str,
     from_uri: &Url,
 ) -> Option<String> {
-    find_method_return_type(indexer, receiver_type, member_name, Some(from_uri))
+    indexer
+        .method_return_type(receiver_type, member_name, Some(from_uri))
+        .map(ReturnType::into_inner)
 }
 
 fn enum_entry_reference_token(

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -41,7 +41,7 @@ pub(super) fn walk_references(
     }
     // Tier 1: direct index lookups (type refs, top-level calls, annotations)
     let mut resolved = Vec::new();
-    walk_kotlin_references(doc.tree.root_node(), src, indexer, &mut resolved);
+    walk_kotlin_references(doc.tree.root_node(), src, indexer, uri, &mut resolved);
     raw.extend(resolved);
 
     // Tier 2: receiver-inferred member coloring
@@ -55,17 +55,18 @@ fn walk_kotlin_references(
     node: Node<'_>,
     src: &Source<'_>,
     indexer: &Indexer,
+    uri: &Url,
     out: &mut Vec<RawToken>,
 ) {
     if is_kotlin_keyword_node(node) {
         push_token(node, type_index(&SemanticTokenType::KEYWORD), 0, src, out);
-    } else if let Some(token_type) = classify_kotlin_reference(node, src.bytes, indexer) {
+    } else if let Some(token_type) = classify_kotlin_reference(node, src.bytes, indexer, uri) {
         push_token(node, token_type, 0, src, out);
     }
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
         loop {
-            walk_kotlin_references(cursor.node(), src, indexer, out);
+            walk_kotlin_references(cursor.node(), src, indexer, uri, out);
             if !cursor.goto_next_sibling() {
                 break;
             }
@@ -87,7 +88,12 @@ fn is_kotlin_keyword_node(node: Node<'_>) -> bool {
     )
 }
 
-fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {
+fn classify_kotlin_reference(
+    node: Node<'_>,
+    src: &[u8],
+    indexer: &Indexer,
+    uri: &Url,
+) -> Option<u32> {
     if !matches!(node.kind(), KIND_SIMPLE_IDENT | KIND_TYPE_IDENT) || is_declaration_site(node) {
         return None;
     }
@@ -100,19 +106,21 @@ fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> O
         return None;
     }
 
-    if let Some(token_type) = enum_entry_reference_token(node, src, indexer) {
+    if let Some(token_type) = enum_entry_reference_token(node, src, indexer, uri) {
         return Some(token_type);
     }
 
     if node.kind() == KIND_TYPE_IDENT && is_type_reference(node) {
-        if let Some(resolved) = resolve_symbol_kind(node_text(node, src), indexer, is_type_symbol) {
+        if let Some(resolved) =
+            resolve_symbol_kind(node_text(node, src), indexer, uri, is_type_symbol)
+        {
             return symbol_kind_to_token_type(resolved.kind);
         }
         return Some(type_index(&SemanticTokenType::CLASS));
     }
 
     if is_top_level_call_name(node) {
-        return resolve_symbol_kind(node_text(node, src), indexer, |kind| {
+        return resolve_symbol_kind(node_text(node, src), indexer, uri, |kind| {
             matches!(
                 kind,
                 SymbolKind::CLASS | SymbolKind::STRUCT | SymbolKind::FUNCTION | SymbolKind::METHOD
@@ -122,7 +130,7 @@ fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> O
     }
 
     if is_navigation_receiver(node) {
-        return resolve_symbol_kind(node_text(node, src), indexer, |kind| {
+        return resolve_symbol_kind(node_text(node, src), indexer, uri, |kind| {
             kind == SymbolKind::OBJECT
         })
         .map(|_| type_index(&SemanticTokenType::NAMESPACE));
@@ -505,7 +513,12 @@ fn member_return_type(
     find_method_return_type(indexer, receiver_type, member_name, Some(from_uri))
 }
 
-fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {
+fn enum_entry_reference_token(
+    node: Node<'_>,
+    src: &[u8],
+    indexer: &Indexer,
+    uri: &Url,
+) -> Option<u32> {
     let parent = node.parent()?;
     let navigation = parent.parent()?;
     if parent.kind() != crate::queries::KIND_NAV_SUFFIX || navigation.kind() != KIND_NAV_EXPR {
@@ -513,7 +526,7 @@ fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> 
     }
 
     let receiver = navigation.named_child(0)?;
-    let receiver_kind = resolve_symbol_kind(node_text(receiver, src), indexer, |kind| {
+    let receiver_kind = resolve_symbol_kind(node_text(receiver, src), indexer, uri, |kind| {
         kind == SymbolKind::ENUM
     })?;
     let receiver_data = indexer.file_data_for(receiver_kind.uri.as_str())?;
@@ -531,9 +544,10 @@ fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> 
 fn resolve_symbol_kind(
     name: &str,
     indexer: &Indexer,
+    from_uri: &Url,
     matches_kind: impl Fn(SymbolKind) -> bool,
 ) -> Option<ResolvedReference> {
-    for location in indexer.definition_locations(name) {
+    for location in indexer.resolve_symbol_no_rg(name, from_uri) {
         let Some(data) = indexer.file_data_for(location.uri.as_str()) else {
             continue;
         };

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -1525,3 +1525,45 @@ fn soft_keyword_as_emits_keyword_token() {
         "expected KEYWORD for 'as' at (0,23), got: {tokens:?}"
     );
 }
+
+#[test]
+fn cross_package_same_name_type_uses_imported_kind() {
+    // Two packages declare `Widget` with DIFFERENT symbol kinds.
+    // The caller imports `a.Widget` (a class), so the type reference must be
+    // highlighted as CLASS, not NAMESPACE (which `b.Widget`, an object, would yield).
+    // The raw global by-name map could return `b.Widget` first; import-aware
+    // resolution must pick the in-scope `a.Widget`.
+    let indexer = Indexer::new();
+
+    // Index the OBJECT first so the raw definition map is biased toward it.
+    let uri_b = Url::parse("file:///pkg_b_widget.kt").unwrap();
+    indexer.index_content(&uri_b, "package b\n\nobject Widget");
+
+    let uri_a = Url::parse("file:///pkg_a_widget.kt").unwrap();
+    indexer.index_content(&uri_a, "package a\n\nclass Widget");
+
+    let caller_src = "package c\n\nimport a.Widget\n\nfun use(w: Widget) {}\n";
+    let uri_c = Url::parse("file:///pkg_c_caller.kt").unwrap();
+    indexer.index_content(&uri_c, caller_src);
+
+    let doc = parse_kotlin(caller_src);
+    let tokens = decode_all_indexed(&indexer, &uri_c, &doc, Language::Kotlin);
+
+    // `Widget` type reference begins at line 4, col 11 (`fun use(w: Widget) {}`).
+    let class_id = type_id(&SemanticTokenType::CLASS);
+    let namespace_id = type_id(&SemanticTokenType::NAMESPACE);
+
+    assert_token_at(
+        &tokens,
+        4,
+        11,
+        class_id,
+        "imported a.Widget classified as CLASS",
+    );
+    assert!(
+        !tokens
+            .iter()
+            .any(|&(l, c, _, tt, _)| l == 4 && c == 11 && tt == namespace_id),
+        "Widget at (4,11) must not be NAMESPACE (the b.Widget object), got: {tokens:?}"
+    );
+}

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -613,7 +613,7 @@ pub(crate) fn dot_completions_for(
         || rt.starts_with("hashmap")
         || rt.starts_with("linkedhashmap")
         || rt.starts_with("sortedmap");
-    let is_nullable = receiver_type.ends_with('?');
+    let is_nullable = receiver_type.is_nullable();
 
     let sources: Vec<&[StdlibEntry]> = if is_string {
         vec![

--- a/src/str_ext.rs
+++ b/src/str_ext.rs
@@ -22,6 +22,20 @@ pub(crate) trait StrExt {
     /// `"com.example.Foo"` → `"Foo"`, `"Foo"` → `"Foo"`.
     fn last_segment(&self) -> &str;
 
+    /// Returns `true` if `self` is a nullable type string — i.e. it ends with the
+    /// Kotlin/Swift `?` nullable marker (ignoring trailing whitespace).
+    ///
+    /// The single canonical place the nullable rule is *read*; every consumer
+    /// asks here instead of re-deriving `ends_with('?')` inline.
+    fn is_nullable(&self) -> bool;
+
+    /// Returns `self` with any trailing `?` nullable marker(s) removed.
+    /// `"Foo?"` → `"Foo"`, `"Foo"` → `"Foo"`.
+    ///
+    /// The single canonical place the nullable marker is *stripped*. (Java type
+    /// strings never carry `?`, so this is a no-op there — safe language-agnostic.)
+    fn strip_nullable(&self) -> &str;
+
     /// Returns the declaration-keyword prefix of `self` — strips leading whitespace and annotations.
     fn decl_prefix(&self) -> &str;
 
@@ -61,6 +75,16 @@ impl StrExt for str {
     #[inline]
     fn last_segment(&self) -> &str {
         self.rsplit('.').next().unwrap_or(self)
+    }
+
+    #[inline]
+    fn is_nullable(&self) -> bool {
+        self.trim_end().ends_with('?')
+    }
+
+    #[inline]
+    fn strip_nullable(&self) -> &str {
+        self.trim_end_matches('?')
     }
 
     #[inline]

--- a/src/str_ext_tests.rs
+++ b/src/str_ext_tests.rs
@@ -1,5 +1,31 @@
 use super::StrExt;
 
+// ── is_nullable / strip_nullable ─────────────────────────────────────
+
+#[test]
+fn is_nullable_detects_trailing_marker() {
+    assert!("Foo?".is_nullable());
+    assert!(!"Foo".is_nullable());
+}
+
+#[test]
+fn strip_nullable_removes_trailing_marker() {
+    assert_eq!("Foo?".strip_nullable(), "Foo");
+    assert_eq!("Foo".strip_nullable(), "Foo");
+}
+
+#[test]
+fn is_nullable_ignores_trailing_whitespace() {
+    // A trailing-`?` after whitespace still marks the type nullable.
+    assert!("Foo? ".is_nullable());
+}
+
+#[test]
+fn nullable_only_at_the_end_not_inside_generics() {
+    // `Box<String?>` is itself non-nullable — the `?` is on the type argument.
+    assert!(!"Box<String?>".is_nullable());
+}
+
 // ── word_at_utf16_col ────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Stacked on #193. The genuine "unify resolution" slice from `docs/architecture/unified-resolution-handler.md`.

## What & why
`resolve_symbol_inner` / `resolve_symbol_no_rg` / `resolve_type_index_only_simple` asked the *same* question (name + caller URI → definition) but each re-derived the whole resolution chain (local → imports → swift → same-pkg → star → hierarchy → rg), differing **only by IO policy**. That duplication is the bug factory: the index-only import path had drifted into a stale clone.

This folds the three into one private `resolve_chain(.., io: ResolveIo)` keyed by three knobs:
- `full_io` — cold-index, local-decl scan, Swift fast path, hierarchy walk, project-wide `rg`
- `allow_fd` — import resolution may spawn `fd` (everything except `IndexOnly`)
- `star_rg` — star imports may `rg` the package dir (`Full` only)

The three former functions become thin wrappers, so **no caller changes** and `Full`/`NoRg` are behaviour-preserving.

## Bug fixed
Deletes the stale `resolve_via_imports_index_only` clone (and the now-dead `extract_container_from_import`). `IndexOnly` now routes through the rich `resolve_via_imports(.., allow_fd=false)`, gaining whole-`import_container_chain` disambiguation. Previously the index-only path (used by `fill_when` / diagnostics) returned the **wrong** nested member when two sibling sealed classes share an immediate container — `Contract.State.Sub.Idle` vs `Contract.Event.Sub.Idle` (shared `Sub`). New RED-then-green regression test covers exactly this, driven through `resolve_type_index_only`.

> Note: the design doc's headline example (`State.Idle` vs `Event.Idle`) is **not** actually buggy — the immediate-parent filter already distinguishes those. The divergence only bites when the differing container sits *above* a shared immediate parent, hence the deeper decoy in the test.

### Behaviour-delta note (from review)
Routing `IndexOnly` through the rich `resolve_via_imports` is slightly broader than "full-chain disambiguation": it also adopts that function's `jar_symbol_package` filtering and its **fail-open** package filter (`.unwrap_or(true)`) in place of the deleted clone's **fail-closed** `.unwrap_or(false)`. Net effect on the diagnostics path: an import candidate whose package can't be determined is now **kept** rather than dropped. This is intentional — it matches the rich navigation path ("fail open so we never regress") — and is benign (resolving more, not fewer, candidates), but is called out here so it isn't a silent change.

## Also included
A small prep commit centralizing the Kotlin/Swift trailing-`?` nullable rule behind `StrExt::is_nullable` / `strip_nullable` (routes ~13 inline `trim_end_matches('?')` / `ends_with('?')` sites through one canonical place — a down-payment on the planned `LanguageModel` slice).

## Verification
- `cargo test --bin kmp-lsp`: **1426 passed, 0 failed** (1425 baseline + 1 new regression test)
- `cargo clippy --bin kmp-lsp` clean
- Net **−74 lines** in `resolve.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)