### PR TITLE
refactor(cst): CST resolution catalogue (Phase 1) + design docs

### DIFF
--- a/docs/architecture/parse-to-lsp-paths.md
+++ b/docs/architecture/parse-to-lsp-paths.md
@@ -1,0 +1,177 @@
+# Parse → LSP Paths (reference)
+
+*Generated reference — 2026-06-30. Grounded in source at that date; update when
+pipelines change. Line numbers are 1-based.*
+
+---
+
+## Pipeline overview
+
+```
+   ┌─ textDocument/didOpen ─────────────────────────────────────────────────┐
+   │  src/backend/mod.rs:161 → Event::FileOpened → Actor channel           │
+   └─ textDocument/didChange ───────────────────────────────────────────────┘
+      src/backend/mod.rs:178
+      │   (synchronous, before event is queued)
+      ├── Indexer::remove_live_tree   (invalidate stale CST)
+      └── Indexer::set_live_lines     src/indexer.rs:693
+                                      (stores raw content lines)
+          │
+          └── Event::FileChanged → Actor channel
+                     │
+              ┌──────┴──────────────────────────────────┐
+              │  workspace/actor.rs                     │
+              │  DocumentHandler / FileChangeHandler    │
+              │  src/workspace/{document,file_change}_handler.rs
+              └──────┬──────────────────────────────────┘
+                     │
+         ┌───────────┴────────────────────┐
+         │  INDEX PATH (every file)       │  LIVE-TREE PATH (open files only)
+         ▼                                ▼
+  Indexer::index_content           parse_live (live_tree.rs)
+  src/indexer/apply.rs:1042        src/indexer/live_tree.rs:57
+         │                                │
+  parse_file → parse_by_extension         │ tree-sitter Tree + raw bytes
+  src/indexer/apply.rs:498                └──→ LiveDoc { tree, bytes }
+  src/parser.rs:286                            stored in live_trees DashMap
+         │                                     (key = URI, open files only)
+  Language::parser().parse(content)
+         │
+  FileData { lines, symbols, imports,
+             sigs, packages, syntax_errors }
+         │
+  apply_file_result
+         │
+  Shared maps in Arc<Indexer>:
+    definitions       – name → [Location]
+    packages          – uri → package
+    subtypes          – type → [subtype]
+    extension_by_receiver – receiver → [ext_fn]
+    files             – uri → Arc<FileData>
+    type_annotations  – uri → {name: type}
+         │
+         └──── JAR symbols added separately via sidecar (src/sidecar.rs)
+
+                    ╔══════════════════════════════════════════╗
+                    ║  Arc<Indexer>  (shared, concurrent read) ║
+                    ╚═══════════════╤══════════════════════════╝
+                                    │
+              LSP request handler   │  (LanguageServer impl, mod.rs:71)
+                                    │
+               ┌────────────────────┼────────────────────────────────────┐
+               │  CursorContext     │  src/backend/cursor.rs:42          │
+               │  (identifier-based │  features: hover, goto-def, refs)  │
+               │   word + qualifier + contextual ReceiverType            │
+               │   infer_receiver_type (resolver/infer.rs) = BOTH       │
+               └────────────────────┼────────────────────────────────────┘
+                                    │
+               ┌────────────────────┼────────────────────────────────────┐
+               │  STRING engine     │  src/indexer/resolution.rs         │
+               │  (index-based)     │  resolve_symbol_info:175           │
+               │  locate_symbol → FileData → enrich_symbol → signature  │
+               │  Also: resolver/resolve.rs, resolver/complete.rs,      │
+               │        resolver/infer.rs (line-scan type inference)     │
+               └────────────────────┼────────────────────────────────────┘
+                                    │
+               ┌────────────────────┼────────────────────────────────────┐
+               │  CST engine        │  src/indexer/infer/*               │
+               │  (live-tree-based) │  src/semantic_tokens/resolve.rs    │
+               │  live_doc_or_parse → Tree walk                         │
+               │  infer_expr_type, infer_lambda_param_type_at           │
+               └────────────────────┴────────────────────────────────────┘
+```
+
+**Two distinct stores underlie every feature:**
+
+- **Index store** (`Arc<Indexer>` maps): populated by `index_content` → `parse_by_extension`.
+  String-keyed, survives file close. Drives symbol lookup, completion, references.
+- **Live-tree store** (`live_trees` DashMap): populated by `parse_live` on `didOpen`/`didChange`.
+  CST per open file. Required for positional tree-sitter queries. Evicted on close.
+
+---
+
+## Per-feature paths
+
+> **Resolution engine key:**
+> - **STRING** — operates on indexed `FileData` (lines, symbols, signatures) without a CST.
+> - **CST** — requires a live tree-sitter `Tree` (`LiveDoc`).
+> - **BOTH** — uses both; column "Resolution engine" notes which is primary.
+
+| Feature | Handler entry (file:line) | State read | Resolution engine | Notes |
+|---------|--------------------------|------------|-------------------|-------|
+| **hover** | `src/backend/handlers.rs:8` → `features/hover.rs:19` | live_tree (CursorContext), index (FileData) | BOTH — STRING primary | 3 branches: `contextual_lambda_hover`, `contextual_receiver_hover`, `regular_symbol_hover`. All converge on `resolve_symbol_info` (STRING). CursorContext builds `contextual` via `infer_receiver_type` which has a CST fallback (`infer_variable_type_from_cst`). |
+| **completion** | `src/backend/actions.rs:7` → `features/completion.rs:116` | live_lines + index | BOTH — STRING primary | `run_completions` → `complete_symbol_with_context` (`resolver/complete.rs`). Dot-completion resolves receiver via `infer_receiver_type_at` which walks the CST. Bare completion is index-only. |
+| **semantic tokens** | `src/backend/mod.rs` (LanguageServer impl) → `semantic_tokens/mod.rs:138` | live_tree | BOTH — CST primary | Phase 1: pure CST syntax walk (kotlin.rs/java.rs). Phase 1b: param-use walk. Phase 2: `resolve::walk_references` → `expression_type` (`semantic_tokens/resolve.rs`) calls `infer_lambda_param_type_at` (CST, `indexer/infer/`) and `infer_variable_type` (STRING fallback). |
+| **inlay hints** | `src/backend/handlers.rs:73` → `inlay_hints.rs:29` | live_tree (or re-parse from live_lines) | BOTH — CST primary | `cst_hints` walks live tree; for `it`/`this` nodes calls `infer_receiver_type` which delegates to `infer_lambda_param_type_at` (CST, `indexer/infer/receiver.rs`). Falls back to re-parsing `live_lines` if no live tree. |
+| **diag: when-exhaustiveness** | actor `workspace/document_handler.rs:199` → `features/fill_when.rs:151` | live_tree + index | BOTH — CST primary | `collect_when_nodes` walks CST; `resolve_type_members` queries index for sealed/enum members. Pushed by actor on open/change/scan-complete. Suppressed during workspace scan. |
+| **diag: call-arg count** | actor `workspace/document_handler.rs:201` → `features/call_arg_diagnostics.rs:22` | live_tree + index | BOTH — CST primary | `collect_call_nodes` walks CST; `check_call_args` looks up signatures via `sig_cache` (STRING, `indexer/infer/sig.rs`). Suppressed during JAR loading. |
+| **diag: nullable-dot** | actor `workspace/document_handler.rs:202` → `features/nullable_call_diagnostics.rs:27` | live_tree + index | BOTH — CST primary | `collect_nav_nodes` walks CST for plain-`.` navigation expressions; `resolve_receiver` calls `Resolver::resolve_member` (STRING) to confirm nullable type. |
+| **goto_definition** | `src/backend/nav.rs:10` → `features/definition.rs:130` | index | STRING (+ rg fallback) | `find_definition_qualified` → `resolve_locations` (resolver/resolve.rs). Falls back to `rg_resolve`. CursorContext.contextual provides pre-resolved location for `it`/`this`/lambda params (CST-assisted). |
+| **goto_implementation** | `src/backend/nav.rs:24` → `features/implementation.rs:21` | index | STRING | `find_type_implementations` / `find_method_implementations` query subtypes map + rg. |
+| **find_references** | `src/backend/handlers.rs:27` → `features/references.rs:16` | index + live_lines | STRING | `rg_locations` (ripgrep) + `add_current_file_locations` (line scan). Scope resolved via index. |
+| **signature_help** | `src/backend/handlers.rs:118` → `features/signature_help.rs:19` | live_tree + index | BOTH — hard split | CST half: `call_info_at` → `cst_call_info` (indexer): extracts fn name + active param from live tree. STRING half: `find_fun_signature_with_receiver` (`indexer/infer/sig.rs`): looks up signature text from index. |
+| **folding_range** | `src/backend/handlers.rs:139` → `features/folding.rs:12` → `indexer/cst_folding.rs:33` | live_tree | CST only | `cst_folding_ranges` walks `live_doc`; returns `None` if file not open. |
+| **document_highlight** | `src/backend/handlers.rs:149` → `features/highlight.rs:8` | live_lines + index | STRING only | `word_and_qualifier_at` (line scan) + `definition_locations` (index map). All occurrences found by scanning live_lines. |
+| **fill_when (code action)** | `src/backend/actions.rs:65` → `features/fill_when.rs:build_fill_when_action` | live_tree + index | BOTH — CST primary | Same `analyze_when` / `resolve_type_members` logic as when-exhaustiveness diagnostic; driven from code-action path instead of actor. |
+| **document_symbol** | `src/backend/handlers.rs:61` | index (`FileData.symbols`) | STRING only | `file_symbols` from index; triggers on-demand `index_content` if file not indexed. |
+| **workspace_symbols** | `src/backend/handlers.rs:109` → `features/workspace_symbols.rs` | index | STRING only | Fuzzy scan over `definitions` map. |
+| **rename** | `src/backend/rename.rs` | index + live_lines | STRING | Index lookup for declaration site; rg to find all occurrences. |
+
+---
+
+## String vs CST split
+
+This is the blast-radius map for the unified-resolution redesign.
+
+### Pure CST (no STRING resolution)
+- **folding_range** — CST tree walk only; no index needed.
+
+### CST-primary (STRING used only for type/signature lookup)
+- **semantic tokens** (phase 2)
+- **inlay hints**
+- **diag: when-exhaustiveness**
+- **diag: call-arg count**
+- **diag: nullable-dot**
+- **fill_when (code action)**
+- **signature_help** (CST for position, STRING for sig text — hard split; both are essential)
+
+### STRING-primary (CST used only for receiver-type narrowing via `infer_receiver_type`)
+- **hover** — STRING `resolve_symbol_info`; `CursorContext` build uses CST fallback
+- **completion** — STRING `complete_dot`/`complete_bare`; `infer_receiver_type_at` uses CST for smart-cast narrowing
+
+### Pure STRING (no CST dependency)
+- **goto_definition** (+ rg fallback)
+- **goto_implementation**
+- **find_references** (+ rg)
+- **document_highlight**
+- **document_symbol**
+- **workspace_symbols**
+- **rename**
+
+---
+
+## Key cross-cutting observations
+
+**`CursorContext` is the pre-compute seam** (`src/backend/cursor.rs:42`).
+It is built once per handler invocation for identifier-based features and holds the
+resolved `contextual` receiver type. Internally it calls `infer_receiver_type`
+(`resolver/infer.rs`), which is itself BOTH: a string line-scan with a CST
+initializer-fallback (`infer_variable_type_from_cst`). This means even nominally
+STRING features (hover, goto-def) touch the CST indirectly through `CursorContext`.
+
+**Diagnostics are actor-pushed, not handler-pulled.**
+The three semantic diagnostic passes (when, call_arg, nullable_dot) run inside
+`spawn_blocking` in `workspace/document_handler.rs` and `file_change_handler.rs`.
+They are not driven by LSP `textDocument/diagnostic` requests.
+
+**`live_doc_or_parse` bridges the two worlds.**
+When a CST-primary feature is invoked but the live tree is absent (e.g. the file
+has lines but hasn't been opened), `live_doc_or_parse`
+(`src/indexer/live_tree_impl.rs:39`) reconstructs content from `live_lines` or
+`FileData.lines` and re-parses. This makes CST features degrade gracefully rather
+than silently return nothing.
+
+**The redesign's primary target** is the STRING engine's fragmentation across
+`resolver/resolve.rs`, `resolver/complete.rs`, `resolver/infer.rs`, and callers
+that reach into `Indexer` directly. The CST engine (`indexer/infer/*`) is mostly
+self-contained and not the focus of the unification.

--- a/docs/superpowers/plans/2026-06-30-cst-resolution-phase1-catalogue.md
+++ b/docs/superpowers/plans/2026-06-30-cst-resolution-phase1-catalogue.md
@@ -1,0 +1,305 @@
+# CST Resolution Unification — Phase 1: Catalogue + absorb semantic_tokens expr walk
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended)
+> or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Stand up the `CstResolve` catalogue facade over `InferDeps`, give it a complete `expr_type`
+that covers all expression node kinds, route `semantic_tokens` through it, and **delete** its bespoke
+`expression_type` walk — a deletion-bearing first slice.
+
+**Architecture:** One catalogue trait (`CstResolve`) implemented for `Indexer` (an `InferDeps`), exposing
+CST type resolution. Phase 1 unifies the *expression-type* capability: today it is split between
+`indexer/infer/expr_type.rs::infer_expr_type` (literals/call/if/range) and
+`semantic_tokens/resolve.rs::expression_type` (ident/nav/call). Phase 1 moves the ident/nav dispatch into
+the catalogue so one `expr_type` covers every kind, then routes `semantic_tokens` to it and deletes the
+duplicate.
+
+**Tech Stack:** Rust, tree-sitter (`tree_sitter::Node`), `tower_lsp`, binary-only crate (`kmp-lsp`).
+
+## Global Constraints
+
+- Binary-only crate — tests run with `cargo test --bin kmp-lsp` (`--lib` runs 0 tests).
+- No `unwrap()`/`expect()` in production code (`#[cfg(test)]` may).
+- Tests in companion `*_tests.rs` files; never inline `mod tests {}`.
+- Minimal visibility: `pub(crate)` only when crossing modules; `#[warn(unreachable_pub)]` is on.
+- No abbreviations in names (`index` not `idx`, `symbol` not `sym`).
+- Pre-commit runs `cargo fmt` + `cargo clippy`; if fmt rewrites, `git add -A` and re-commit.
+- **Move-don't-rewrite:** copy bodies verbatim, adjust only what the new home requires, delete the
+  original. Do not re-derive logic.
+- **Each slice deletes its dead functions.** A slice is incomplete while `find_referencing_symbols` shows
+  any remaining caller of a function it replaced. The PR diff must show deletions.
+- Branch: `refactor/cst-resolution` (already created off `refactor/unified-resolution`).
+- **Return-type decision (user, 2026-06-30): rich surface from the start.** Phase 1 defines
+  `Resolution<T>` + `ResolvedType` + `Fqn` and `expr_type` returns `Resolution<ResolvedType>`. It wraps
+  the existing `Option<String>` functions at the boundary, so it stays **behaviour-preserving**:
+  `ResolvedType` carries the inferred type *as-written* (no lossy normalization in Phase 1) and exposes
+  it via `as_type_str()`. `expr_type` emits only `Resolved`/`Unresolved` in Phase 1 (`Ambiguous` is part
+  of the enum for later methods). The `RawTypeName`/`TypeName` normalized split, the `CstExpr` exhaustive
+  dispatch, and construction-sealing remain slice 5.
+
+---
+
+## File structure
+
+- `src/indexer/infer/mod.rs` — **the catalogue.** Gains `CstCtx` (input struct) + the `CstResolve` trait.
+  Zero logic beyond the trait's `impl` delegating to submodule functions. (Currently only module decls +
+  doc comments.)
+- `src/indexer/infer/expr_type.rs` — gains the ident/nav/call dispatch moved out of `semantic_tokens`,
+  so `infer_expr_type` (or a new `infer_expr_type_full`) covers every expression kind. Becomes the single
+  implementation the catalogue's `expr_type` calls.
+- `src/semantic_tokens/resolve.rs` — **delete** `expression_type`, `identifier_type`,
+  `navigation_expression_type`, `call_expression_type`; call `CstResolve::expr_type` instead.
+- `src/indexer/infer/mod_tests.rs` (new) — `TestDeps`-driven unit tests for the catalogue.
+- `src/semantic_tokens_tests.rs` — existing suite is the behaviour net (must stay green).
+
+---
+
+## Task 1: Move ident/nav/call expr dispatch into `expr_type.rs`; cover all kinds
+
+**Files:**
+- Modify: `src/indexer/infer/expr_type.rs` (extend `infer_expr_type` dispatch to ident/nav/call)
+- Read first (verbatim move source): `src/semantic_tokens/resolve.rs:291-356`
+  (`identifier_type`, `navigation_expression_type`, `call_expression_type`)
+- Test: `src/indexer/infer/expr_type_tests.rs` (existing companion if present, else create)
+
+**Interfaces:**
+- Consumes: `infer_expr_type(node: Node, bytes: &[u8], deps: &impl InferDeps, uri: &Url) -> Option<String>`
+  (existing, `expr_type.rs:45`); `InferDeps` methods (`find_var_type`, `find_field_type`,
+  `find_fun_return_type`, …); `infer_lambda_param_type_at` (`indexer/scope.rs:211`);
+  `find_field_type_in_class` / `infer_variable_type` (`resolver/infer.rs`).
+- Produces: `infer_expr_type` now also handles `KIND_SIMPLE_IDENT`/`KIND_TYPE_IDENT`, `KIND_NAV_EXPR`,
+  `KIND_THIS_EXPR` — same `Option<String>` signature. This is the single full expression-type resolver.
+
+- [ ] **Step 1: Read the three source functions in full** (`semantic_tokens/resolve.rs:291-356`) and the
+  current `infer_expr_type` (`expr_type.rs:41-72`). Confirm the node kinds each handles; the union must be
+  literals + call + if/range + prefix/comparison (have) ∪ ident + nav + this (to add).
+
+- [ ] **Step 2: Write a failing test** for the gap (ident + nav through the *infer* entry).
+
+```rust
+// src/indexer/infer/expr_type_tests.rs
+#[test]
+fn infer_expr_type_resolves_navigation_chain_receiver() {
+    // `data.field` where `data: Holder` and `Holder.field: Foo` → "Foo"
+    let deps = TestDeps::new()
+        .with_var("file:///A.kt", "data", "Holder")
+        .with_field("file:///A.kt", "Holder", "field", "Foo");
+    // build a NAV_EXPR node for `data.field` via the test parse helper, then:
+    let ty = infer_expr_type(nav_node, source.as_bytes(), &deps, &uri);
+    assert_eq!(ty.as_deref(), Some("Foo"));
+}
+```
+
+- [ ] **Step 3: Run it, verify it fails** (ident/nav not yet handled by `infer_expr_type`).
+
+Run: `cargo test --bin kmp-lsp infer_expr_type_resolves_navigation_chain_receiver`
+Expected: FAIL (`None`, arm falls through `_ => None`).
+
+- [ ] **Step 4: Move the dispatch.** Add match arms to `infer_expr_type` for `KIND_SIMPLE_IDENT |
+  KIND_TYPE_IDENT`, `KIND_NAV_EXPR`, `KIND_THIS_EXPR`, copying the bodies of `identifier_type` /
+  `navigation_expression_type` / `call_expression_type` **verbatim**, adapting parameters: they took
+  `(node, doc, starts, indexer, uri)`; here use `(node, bytes, deps, uri)`. Where they called
+  `expression_type(receiver, …)` recursively, call `infer_expr_type(receiver, bytes, deps, uri)`. Where
+  they used `indexer.infer_lambda_param_type_at(name, uri, pos)`, keep that call (the `deps`/`Indexer`
+  provides it — see Step 5 note). Add private helpers in `expr_type.rs` as needed (don't inline a large
+  match arm — extract `identifier_type`/`navigation_expression_type`/`call_expression_type` as private
+  fns *in this file*).
+
+- [ ] **Step 5: Reconcile the `infer_lambda_param_type_at` dependency.** It is an `Indexer` method
+  (`scope.rs:211`), not on `InferDeps`. If `infer_expr_type`'s new arms need it, add it to the `InferDeps`
+  trait (default `None`, real impl on `Indexer`) so the move stays within the `deps` seam. Confirm
+  `TestDeps` still compiles (default returns `None`).
+
+- [ ] **Step 6: Run the new test + full suite.**
+
+Run: `cargo test --bin kmp-lsp`
+Expected: new test PASS; baseline (1426+) all green.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add -A
+git commit -m "refactor(infer): make infer_expr_type cover ident/nav/this kinds"
+```
+
+---
+
+## Task 2: Introduce the `CstResolve` catalogue + `CstCtx` + rich return types in `mod.rs`
+
+**Files:**
+- Modify: `src/indexer/infer/mod.rs` (add `CstCtx`, `Resolution<T>`, `ResolvedType`, `Fqn`, the
+  `CstResolve` trait + `impl CstResolve for Indexer`)
+- Test: `src/indexer/infer/mod_tests.rs` (create)
+
+**Interfaces:**
+- Consumes: `infer_expr_type` (now full, from Task 1).
+- Produces:
+  ```rust
+  /// Per-request CST resolution input: document bytes + URI + IO policy.
+  pub(crate) struct CstCtx<'a> { pub bytes: &'a [u8], pub uri: &'a Url, pub io: ResolveIo }
+
+  /// Importable fully-qualified name (newtype over the FQN string).
+  pub(crate) struct Fqn(pub String);
+
+  /// Outcome of resolving something to `T`. Reused across the catalogue so an agent
+  /// learns the three outcomes once and reads them off every signature.
+  pub(crate) enum Resolution<T> { Resolved(T), Ambiguous(Vec<Fqn>), Unresolved }
+
+  /// A resolved expression type. Phase 1: carries the inferred type *as-written*
+  /// (no lossy normalization); the RawTypeName/TypeName split is slice 5.
+  pub(crate) struct ResolvedType { type_name: String, nullable: bool }
+  impl ResolvedType {
+      /// Construct from an inferred type string (nullability = trailing `?`).
+      fn from_inferred(raw: String) -> Self { /* nullable = raw.is_nullable() (StrExt) */ }
+      /// The type as-written (what the old Option<String> callers consumed).
+      pub fn as_type_str(&self) -> &str { &self.type_name }
+      pub fn is_nullable(&self) -> bool { self.nullable }
+  }
+  impl<T> Resolution<T> {
+      /// `Resolved(t) -> Some(t)`, else `None`. Bridges callers not yet ambiguity-aware.
+      pub fn resolved(self) -> Option<T> { /* match */ }
+      pub fn resolved_ref(&self) -> Option<&T> { /* match */ }
+  }
+
+  /// The catalogue of CST-driven type resolution. (Phase 1: expr_type only.)
+  pub(crate) trait CstResolve {
+      /// Type of any expression node. Covers ident/nav/call/literals/this/if/range.
+      fn expr_type(&self, node: Node, ctx: &CstCtx) -> Resolution<ResolvedType>;
+  }
+  ```
+  (`io` is carried now though Phase 1 does not branch on it — wiring the seam; later slices add methods.
+  `Ambiguous` is unused by `expr_type` in Phase 1 but the enum is complete for later methods.)
+
+- [ ] **Step 1: Write a failing catalogue test** (via the real `Indexer`, smallest path).
+
+```rust
+// src/indexer/infer/mod_tests.rs
+#[test]
+fn cst_resolve_expr_type_resolves_int_literal() {
+    let index = Indexer::new();
+    let uri = uri("/A.kt");
+    let source = "val n = 1\n";
+    index.index_content(&uri, source);
+    // integer-literal node for `1` (build via the existing expr_type test parse helper):
+    let ctx = CstCtx { bytes: source.as_bytes(), uri: &uri, io: ResolveIo::IndexOnly };
+    let resolved = index.expr_type(int_literal_node, &ctx).resolved();
+    assert_eq!(resolved.map(|t| t.as_type_str().to_owned()).as_deref(), Some("Int"));
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails** (trait/types not defined).
+
+Run: `cargo test --bin kmp-lsp cst_resolve_expr_type_resolves_int_literal`
+Expected: FAIL (does not compile / method missing).
+
+- [ ] **Step 3: Define the types + trait in `mod.rs`**, with `impl CstResolve for Indexer` wrapping the
+  existing `Option<String>` function at the boundary:
+
+```rust
+fn expr_type(&self, node: Node, ctx: &CstCtx) -> Resolution<ResolvedType> {
+    match crate::indexer::infer::expr_type::infer_expr_type(node, ctx.bytes, self, ctx.uri) {
+        Some(raw) => Resolution::Resolved(ResolvedType::from_inferred(raw)),
+        None => Resolution::Unresolved,
+    }
+}
+```
+Re-export `CstCtx`, `CstResolve`, `Resolution`, `ResolvedType`, `Fqn` from `mod.rs` per the "mod.rs is the
+catalogue" rule. Keep zero logic in the impl beyond the wrap. Use `StrExt::is_nullable` for the nullable
+flag (do not re-derive `ends_with('?')`).
+
+- [ ] **Step 4: Run the test + full suite.**
+
+Run: `cargo test --bin kmp-lsp`
+Expected: new test PASS; suite green.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add -A
+git commit -m "refactor(infer): add CstResolve catalogue facade with expr_type"
+```
+
+---
+
+## Task 3: Route `semantic_tokens` through `CstResolve`; DELETE the bespoke walk
+
+**Files:**
+- Modify: `src/semantic_tokens/resolve.rs` (callers at `:161`, `:322`, `:345`; delete `:291/313/335/358`)
+- Test: `src/semantic_tokens_tests.rs` (existing net)
+
+**Interfaces:**
+- Consumes: `CstResolve::expr_type` + `CstCtx` (Task 2).
+- Produces: `semantic_tokens/resolve.rs` no longer defines `expression_type`/`identifier_type`/
+  `navigation_expression_type`/`call_expression_type`; no `use crate::resolver::infer::{...}` leakage for
+  expression typing.
+
+- [ ] **Step 1: Enumerate callers.** Use `find_referencing_symbols` on `expression_type`
+  (`semantic_tokens/resolve.rs`): expect the recursive callers (`navigation_expression_type:322`,
+  `call_expression_type:345`) and `walk_kotlin_references:161`. Confirm no callers outside this file.
+
+- [ ] **Step 2: Replace the call sites.** At each caller, build a `CstCtx { bytes: &doc.bytes, uri,
+  io: ResolveIo::IndexOnly }` (semantic tokens is a hot path → `IndexOnly`) and call
+  `indexer.expr_type(node, &ctx)` in place of `expression_type(node, doc, starts, indexer, uri)`. The old
+  callers consumed `Option<String>`; map the new return with
+  `.resolved().map(|t| t.as_type_str().to_owned())` (or `.resolved_ref()` where a borrow suffices) so the
+  surrounding logic is unchanged. The `starts` argument is no longer needed for these calls.
+
+- [ ] **Step 3: DELETE** `expression_type` (358), `identifier_type` (291), `navigation_expression_type`
+  (313), `call_expression_type` (335) from `semantic_tokens/resolve.rs`. Remove now-unused imports
+  (`find_field_type_in_class`, `infer_variable_type` if unused; `member_return_type` if unused).
+
+- [ ] **Step 4: Verify zero remaining references.**
+
+Run: `grep -rn "expression_type\|identifier_type\|navigation_expression_type\|call_expression_type" src/semantic_tokens/`
+Expected: no matches (definitions gone, callers routed).
+
+- [ ] **Step 5: Run the semantic-tokens suite + full suite.**
+
+Run: `cargo test --bin kmp-lsp -- semantic` then `cargo test --bin kmp-lsp`
+Expected: all green (behaviour preserved; the walk now goes through the catalogue).
+
+- [ ] **Step 6: Diff highlighting output (spot check).** Pick one semantic-tokens test fixture; confirm
+  the token stream is unchanged vs `refactor/unified-resolution` (behaviour-preserving deletion).
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add -A
+git commit -m "refactor(semantic-tokens): route expression typing through CstResolve; delete bespoke walk"
+```
+
+---
+
+## Phase 1 acceptance
+
+- `CstResolve` + `CstCtx` exist in `infer/mod.rs`; `expr_type` covers every expression kind.
+- `semantic_tokens` no longer has its own expression walk; the four functions are deleted; PR diff is
+  net-negative in `semantic_tokens/resolve.rs`.
+- `cargo test --bin kmp-lsp` green; `cargo clippy` clean; highlighting output unchanged.
+
+---
+
+## Roadmap — subsequent slices (each its own plan, written just-in-time)
+
+Each is a PR that **deletes** the functions it replaces (`find_referencing_symbols` = 0 callers before
+close). Detailed bite-sized steps are written when the slice is reached, because each depends on the
+shapes the previous slice lands.
+
+- **Slice 2 — route the remaining CST consumers** (`completion_context`, `inlay_hints`,
+  `nullable_call_diagnostics`, hover, signature_help, `fill_when`) onto `CstResolve`; add `receiver_type`
+  + `lambda_scope` catalogue methods (delegating for now); delete each consumer's hand-rolled entry use.
+- **Slice 3 — collapse the lambda triad.** `lambda_scope` becomes the one CST classifier; fold
+  `receiver.rs` text variants + `it_this.rs` line variants in; **re-home heuristics** (scope-function
+  receiver classification → `ThisLambdaCtx::Receiver`) onto CST inputs; delete the text/line-scanning
+  mechanisms. Promote + extend the existing `LambdaScope` (`completion_context.rs:16`).
+- **Slice 4 — collapse the chain walk.** `chain.rs` becomes the chain step of `expr_type`; delete the
+  echoed chain logic in `receiver.rs`.
+- **Slice 5 — type-driven hardening / sweep.** Introduce `Resolution<T>` (generalising `SignatureResult`),
+  `ResolvedType`/`TypeName`/`RawTypeName`/`Fqn`, the `CstExpr` exhaustive dispatch, construction-sealed
+  outputs; migrate the catalogue surface off `Option<String>`. Remove dead helpers/constants.
+- **Slice 6 — CST-aware navigation family** (go-to-def, goto-impl, find-refs, document-highlight, rename):
+  generalise the `CursorContext` → CST bridge through `CstResolve`; string + rg fallback preserved.
+
+See `docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md` for the full design,
+reuse inventory, and the governing principle (CST is the source of structure; string parsing is a
+mistake; keep only genuine heuristics).

--- a/docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md
+++ b/docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md
@@ -61,9 +61,15 @@ string = *what* the signature text says) that does not collapse into one engine.
    unrepresentable).
 5. Delete the reinvented walks (`semantic_tokens` bespoke walk, the text/line lambda engines, echoed
    chain logic) — the substantial deletion the catalogue work so far did not deliver.
+6. Make navigation features (**go-to-def** first) **CST-aware**: resolve the receiver/chain type via the
+   catalogue when the project is synced (gaining chain/lambda/generics/overload accuracy), with the
+   string + rg path as the guaranteed fallback. Layered, not engine-merging. (Post-catalogue phase.)
 
 **Non-goals**
-- Touching the **string path** (heuristic by design; separate later analysis).
+- Unifying the **string engine's internal heuristics** (heuristic by design; separate later analysis).
+  Note: navigation features *gain a CST-first layer* (Goal 6), but the string engine itself is untouched
+  and **remains the fallback** — go-def/find-refs must still work with no CST (cold start / unsynced /
+  agent find).
 - A shared cross-domain **IR** that both string and CST paths lower into — explicitly rejected as
   added complexity / a new domain.
 - Changing observable behaviour beyond intended consolidation (existing CST suites are the net).
@@ -263,6 +269,9 @@ mechanism becomes a *phase*, not a parallel path:
    chain logic in `receiver.rs`.
 5. **Sweep** — remove dead helpers/constants; introduce the `CstExpr` exhaustive dispatch + the
    construction-sealed outcome/types; confirm `mod.rs` is the only public face.
+6. **CST-aware navigation** (post-catalogue) — generalize the `CursorContext` → CST bridge so go-to-def
+   resolves any receiver via `CstResolve`, string + rg as fallback (see the dedicated section). Depends
+   on 1–5.
 
 Deletion lands mostly in steps 2–4 (the bespoke walk + text/line lambda engines + echoed chain logic):
 on the order of a thousand-plus lines, with the three-mechanism divergence closed.
@@ -273,6 +282,37 @@ Each consuming feature's `mod.rs` exposes its own small catalogue trait (e.g. `S
 `InlayInference`, `HoverFacts`) listing what that feature *produces*, as a thin projection of
 `CstResolve`, with that feature's own I/O types beside it. An agent opens the feature `mod.rs`, sees its
 catalogue delegating to `CstResolve`, and has no reason to hand-roll inference.
+
+## CST-aware navigation (layered; post-catalogue phase)
+
+Today go-to-def resolves receivers via the **string** `find_definition_qualified`, except for the narrow
+`it`/`this`/named-param case where `CursorContext` already bridges to CST
+(`infer_receiver_type(Contextual)` → `infer_variable_type_from_cst`). So go-def misses the unified
+benefits — chain/lambda walk, generics subst, receiver-typed member/overload accuracy — for general
+member access (`someVar.field.method`, dotted chains, generics).
+
+**Refinement:** generalize the existing `CursorContext` → CST bridge through the catalogue. Navigation
+becomes **CST-first with string fallback**:
+
+```
+goto-def / hover / completion (receiver-qualified):
+  1. CstResolve::receiver_type / expr_type (CST)  — when synced, accurate
+     → map type → definition via resolve_member / find_definition_qualified
+  2. fall back to string find_definition_qualified + rg  — unsynced / agent / cold start
+```
+
+- **Seam:** `CursorContext.contextual` is already a `ReceiverType` from CST; widen it to resolve *any*
+  qualifier via `CstResolve`, not just `it`/`this`. Reuses `resolve_member` (`Definitions`) for the
+  type→location mapping — minimal new code, large accuracy gain.
+- **Invariant preserved:** the string + rg path stays as the fallback, so go-def/find-refs still work
+  with no CST (the unsynced/agent capability the string domain exists for).
+- **IO:** navigation is not a keystroke hot path — `CstCtx.io = Full` is fine here.
+- **Scope (open):** go-to-def is the clear first consumer. `find_references` / `document_highlight` /
+  `rename` are name-based (+rg) and benefit less / are larger; candidates for a later increment, not
+  necessarily this phase.
+
+This phase **depends on the catalogue + consolidation landing first** (it consumes `CstResolve`), so it
+sequences after step 5.
 
 ## Migration & branch strategy
 

--- a/docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md
+++ b/docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md
@@ -61,9 +61,12 @@ string = *what* the signature text says) that does not collapse into one engine.
    unrepresentable).
 5. Delete the reinvented walks (`semantic_tokens` bespoke walk, the text/line lambda engines, echoed
    chain logic) — the substantial deletion the catalogue work so far did not deliver.
-6. Make navigation features (**go-to-def** first) **CST-aware**: resolve the receiver/chain type via the
-   catalogue when the project is synced (gaining chain/lambda/generics/overload accuracy), with the
-   string + rg path as the guaranteed fallback. Layered, not engine-merging. (Post-catalogue phase.)
+6. Make the **symbol-identity-at-cursor** navigation family **CST-aware** — go-to-def,
+   goto-implementation, find-references, document-highlight, rename. They all answer "which symbol does
+   this identifier refer to?" name-based today (hence noisy); the catalogue gives them the precise
+   receiver-typed identity, with string + rg as the guaranteed fallback. Layered, not engine-merging.
+   (Post-catalogue phase.) Pure listing/fuzzy features (document-symbol, workspace-symbols) are **not**
+   in this family and stay as-is.
 
 **Non-goals**
 - Unifying the **string engine's internal heuristics** (heuristic by design; separate later analysis).
@@ -269,9 +272,9 @@ mechanism becomes a *phase*, not a parallel path:
    chain logic in `receiver.rs`.
 5. **Sweep** — remove dead helpers/constants; introduce the `CstExpr` exhaustive dispatch + the
    construction-sealed outcome/types; confirm `mod.rs` is the only public face.
-6. **CST-aware navigation** (post-catalogue) — generalize the `CursorContext` → CST bridge so go-to-def
-   resolves any receiver via `CstResolve`, string + rg as fallback (see the dedicated section). Depends
-   on 1–5.
+6. **CST-aware navigation** (post-catalogue) — generalize the `CursorContext` → CST bridge so the
+   symbol-identity family (go-to-def, goto-impl, find-refs, document-highlight, rename) resolves via
+   `CstResolve`, string + rg as fallback; one slice per feature (see the dedicated section). Depends on 1–5.
 
 Deletion lands mostly in steps 2–4 (the bespoke walk + text/line lambda engines + echoed chain logic):
 on the order of a thousand-plus lines, with the three-mechanism divergence closed.
@@ -285,34 +288,41 @@ catalogue delegating to `CstResolve`, and has no reason to hand-roll inference.
 
 ## CST-aware navigation (layered; post-catalogue phase)
 
-Today go-to-def resolves receivers via the **string** `find_definition_qualified`, except for the narrow
-`it`/`this`/named-param case where `CursorContext` already bridges to CST
-(`infer_receiver_type(Contextual)` → `infer_variable_type_from_cst`). So go-def misses the unified
-benefits — chain/lambda walk, generics subst, receiver-typed member/overload accuracy — for general
-member access (`someVar.field.method`, dotted chains, generics).
+The **symbol-identity-at-cursor family** — go-to-def, goto-implementation, find-references,
+document-highlight, rename — all answer "which symbol does this identifier refer to?" **name-based**
+today (string + rg + line scans), which is why they're noisy. Only the narrow `it`/`this`/named-param
+case touches CST, via the existing `CursorContext` bridge
+(`infer_receiver_type(Contextual)` → `infer_variable_type_from_cst`). They miss the unified benefits —
+chain/lambda walk, generics subst, receiver-typed member/overload accuracy — for general member access
+(`someVar.field.method`, dotted chains, generics). These are the "forgotten orphans."
 
-**Refinement:** generalize the existing `CursorContext` → CST bridge through the catalogue. Navigation
-becomes **CST-first with string fallback**:
+**Refinement:** generalize the `CursorContext` → CST bridge through the catalogue so the whole family is
+**CST-first with string fallback**. The CST role differs by feature:
 
-```
-goto-def / hover / completion (receiver-qualified):
-  1. CstResolve::receiver_type / expr_type (CST)  — when synced, accurate
-     → map type → definition via resolve_member / find_definition_qualified
-  2. fall back to string find_definition_qualified + rg  — unsynced / agent / cold start
-```
+- **go-to-def / goto-impl** (resolve target): `CstResolve::receiver_type`/`expr_type` → map type →
+  definition via `resolve_member` (`Definitions`), then string `find_definition_qualified` + rg fallback.
+  ```
+  1. CstResolve::receiver_type / expr_type (CST, when synced)  → resolve_member → Definitions
+  2. fall back to string find_definition_qualified + rg        (unsynced / agent / cold start)
+  ```
+- **find-refs / document-highlight / rename** (identify + filter): CST resolves the *target's* declaring
+  type / FQN at the cursor, then **filters** the rg/name candidate set to references whose receiver type
+  matches. This is the principled replacement for the manual **findReferences noise-mitigation**
+  heuristics (qualified-pattern rg / package scoping) — type resolution instead of string tricks.
 
+Shared properties:
 - **Seam:** `CursorContext.contextual` is already a `ReceiverType` from CST; widen it to resolve *any*
-  qualifier via `CstResolve`, not just `it`/`this`. Reuses `resolve_member` (`Definitions`) for the
-  type→location mapping — minimal new code, large accuracy gain.
-- **Invariant preserved:** the string + rg path stays as the fallback, so go-def/find-refs still work
-  with no CST (the unsynced/agent capability the string domain exists for).
-- **IO:** navigation is not a keystroke hot path — `CstCtx.io = Full` is fine here.
-- **Scope (open):** go-to-def is the clear first consumer. `find_references` / `document_highlight` /
-  `rename` are name-based (+rg) and benefit less / are larger; candidates for a later increment, not
-  necessarily this phase.
+  qualifier via `CstResolve`, not just `it`/`this`. Reuses `resolve_member`/`Definitions` — minimal new
+  code, large accuracy gain.
+- **Invariant preserved:** the string + rg path stays as the fallback, so the family still works with no
+  CST (the unsynced/agent capability the string domain exists for).
+- **IO:** navigation is not a keystroke hot path — `CstCtx.io = Full` is fine.
+- **Out of family:** document-symbol (lists `FileData.symbols`) and workspace-symbols (fuzzy name scan)
+  are pure listing/fuzzy — no symbol-identity resolution, left as-is.
 
 This phase **depends on the catalogue + consolidation landing first** (it consumes `CstResolve`), so it
-sequences after step 5.
+sequences after step 5. Each feature is its own slice (uniform pattern, per-feature behaviour change
+guarded by the existing nav/refs/rename suites).
 
 ## Migration & branch strategy
 

--- a/docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md
+++ b/docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md
@@ -40,6 +40,13 @@ The CST engine already has good bones: a documented one-responsibility submodule
 **`InferDeps`** data-access trait (+ `TestDeps` stub for unit-testing), and pure-read infer functions.
 What's missing is a **single catalogue** consumers request from instead of hand-rolling.
 
+**Reference:** `docs/architecture/parse-to-lsp-paths.md` maps the full parse→LSP request pipeline and
+classifies every feature's resolution engine (string / CST / both) — the redesign's blast-radius map.
+Key caveat from it: `CursorContext::build` bridges nominally-*string* features (hover, goto-def) into
+the CST engine via `infer_variable_type_from_cst`, so the CST blast radius is wider than the obviously-CST
+feature set. Conversely, signature help is a *hard* string/CST split (CST = *where* the call/param is;
+string = *what* the signature text says) that does not collapse into one engine.
+
 ## Goals / non-goals
 
 **Goals**

--- a/docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md
+++ b/docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md
@@ -247,6 +247,28 @@ Model the domain so illegal states are unrepresentable:
    nullability a typed field — can't pass un-normalized where normalized is required. Enforced via
    distinct types, not a `_raw` naming convention.
 
+## Principle: the CST is the source of structure — string *parsing* is a mistake
+
+The CST holds the program's structure *exactly*. Recovering structure from text — line scans,
+`rsplit('.')`, finding a lambda brace by text position, `before_brace` / `cst_before_open_text`
+substring walks, counting unclosed parens — is error-prone re-derivation of what the CST already has.
+Within the CST domain **every such string-parsing mechanism is a mistake to eliminate, not an
+alternative strategy.** This is the real reason `receiver.rs` (text heuristics) and `it_this.rs` (line
+scans) collapse into the CST walk: not dedup for its own sake, but removing a class of imprecision.
+
+**What is *not* a mistake — genuine heuristics, which stay:** best-effort guesses where *no precise
+answer exists even with the CST*:
+- **Stdlib scope-function receiver inference** — `apply`/`run`/`with`/`also`/`let` and indexed
+  receiver-lambda fns, where the receiver object's type is genuinely unresolvable. This is already
+  modelled by `ThisLambdaCtx::Receiver` ("known receiver context, type not found") — keep the
+  classification; it is semantic knowledge, not structure recovery.
+- **The string-domain unsynced/agent fallback** for navigation (no index/CST available at all).
+
+The discriminator for every line of the old engines: *is it recovering structure the CST already has
+(→ delete, drive from the CST node) or guessing semantics the CST cannot give (→ keep as a heuristic,
+re-homed onto CST-derived inputs, never fed by text scanning)?* Heuristic **content** is preserved; the
+**text-scanning mechanism feeding it** is not.
+
 ## Internal consolidation plan (four walks → one)
 
 The one walk lives in `indexer/infer`, CST-driven, dispatched by the `CstExpr` shape. Each former
@@ -267,7 +289,9 @@ mechanism becomes a *phase*, not a parallel path:
 2. **Route consumers** onto the catalogue (semantic_tokens, completion_context, inlay, diagnostics,
    hover, sig-help, fill_when); **delete `semantic_tokens`'s bespoke walk** + its string-engine leakage.
 3. **Collapse the lambda triad** — `lambda_scope` becomes the one CST classifier; fold `receiver.rs`
-   text variants + `it_this.rs` line variants in; delete both sets.
+   text variants + `it_this.rs` line variants in. Per the principle above: **re-home the genuine
+   heuristics** (scope-function receiver classification → `ThisLambdaCtx::Receiver`) onto CST-derived
+   inputs, and **delete the text/line-scanning mechanisms** that recovered structure.
 4. **Collapse the chain walk** — `chain.rs` becomes the chain step of `expr_type`; delete the echoed
    chain logic in `receiver.rs`.
 5. **Sweep** — remove dead helpers/constants; introduce the `CstExpr` exhaustive dispatch + the

--- a/docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md
+++ b/docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md
@@ -1,0 +1,300 @@
+# CST Resolution Unification — Design
+
+Status: **approved design** (brainstormed with the user 2026-06-30). Implementation plan to follow
+(writing-plans). Branch: `refactor/cst-resolution` off `refactor/unified-resolution`.
+
+## Context (why)
+
+Symbol/type resolution in the LSP is **fragmented**: the same question — "what's the type of this
+receiver / expression / lambda variable?" — is answered by several engines, each with its own walk,
+reachability filter, generics handling, and `it`/`this` logic. Divergent copies are the bug factory:
+most resolution fixes have been per-consumer patches over the same gaps.
+
+There are **two deliberately separate domains**, and they should stay separate:
+
+- **String path** (`resolver/resolve.rs`, `resolver/complete.rs`, the string `infer_*`) — powers
+  go-to-def / find-refs **without a synced project**, plus optimized agent find. Intentionally
+  heuristic; "good enough" is the bar. **Out of scope** here. Whether anything is shareable among its
+  ad-hoc heuristics is a separate later investigation.
+- **CST path** (`indexer/infer/*` + a bespoke walk in `semantic_tokens/resolve.rs`) — the
+  **authoritative** engine for LSP features + diagnostics. **This is what we unify.**
+
+### The CST fragmentation, concretely
+
+Within the CST domain there are **four parallel mechanisms** answering overlapping questions:
+
+| Mechanism | ~lines | Strategy |
+|---|---|---|
+| `indexer/infer/cst_lambda.rs` | ~892 | CST-node based (`ThisLambdaCtx`) |
+| `indexer/infer/receiver.rs` | ~518 | text-context heuristics (~12 `*_lambda_type` variants) |
+| `indexer/infer/it_this.rs` | ~523 | line-string scans (`find_it_element_type*`) |
+| `indexer/infer/chain.rs` | ~553 | nav-chain segment walk (chain logic also echoed in `receiver.rs`) |
+| `semantic_tokens/resolve.rs` `expression_type` family | ~150 | **its own** CST walk, wired sideways into the *string* engine (`use crate::resolver::infer::…`) |
+
+The three lambda/`it`/`this` engines (CST + text + line) all answer the *same* question with different
+mechanisms — that triad is where the bulk of the ~2,000 lines and the divergence bugs live. Consumers
+reach into three different entry points (`infer_lambda_param_type_at`, `lambda_receiver_type_from_context`,
+`find_it_element_type*`), so each feature re-derives slightly differently → the next divergence.
+
+The CST engine already has good bones: a documented one-responsibility submodule layout, the
+**`InferDeps`** data-access trait (+ `TestDeps` stub for unit-testing), and pure-read infer functions.
+What's missing is a **single catalogue** consumers request from instead of hand-rolling.
+
+## Goals / non-goals
+
+**Goals**
+1. One **CST-driven walk** (CST is authoritative) that does the proper traversal through long dotted
+   chains *and* lambda bodies, absorbing the text/line lambda engines and the chain walk.
+2. A **single catalogue facade trait** (`CstResolve`) that is the complete, intent-named map of CST
+   resolution capabilities, returning self-documenting types. Built on `InferDeps`; pure reads.
+3. **`mod.rs` is the catalogue** — every resolution module (and consuming feature) exposes its I/O
+   structs + catalogue trait in `mod.rs` with zero logic, so agents read one file and route to the
+   existing capability instead of reinventing.
+4. **Model the domain in enums/structs** so the compiler catches logic errors (illegal states
+   unrepresentable).
+5. Delete the reinvented walks (`semantic_tokens` bespoke walk, the text/line lambda engines, echoed
+   chain logic) — the substantial deletion the catalogue work so far did not deliver.
+
+**Non-goals**
+- Touching the **string path** (heuristic by design; separate later analysis).
+- A shared cross-domain **IR** that both string and CST paths lower into — explicitly rejected as
+  added complexity / a new domain.
+- Changing observable behaviour beyond intended consolidation (existing CST suites are the net).
+
+## Architecture
+
+One shared CST resolution library inside `indexer/infer`, exposing a single facade catalogue trait
+built on the existing `InferDeps` data seam. Every CST consumer requests through the facade.
+
+```
+features (hover, semantic_tokens, inlay, diagnostics, completion, sig-help, fill_when)
+      │  each exposes its own thin *feature catalogue trait* in its mod.rs
+      ▼
+  CstResolve  ◄── THE catalogue facade (capabilities + self-documenting I/O types)
+      │  built on
+      ▼
+  InferDeps (data seam, exists)  +  ONE unified CST walk
+```
+
+Design tracing (per house rule WHY→WHAT→HOW):
+- **WHY** — infer functions are pure reads over a snapshot; consumers must not re-derive resolution.
+- **WHAT** — a catalogue trait over `InferDeps`; self-documenting newtypes; one walk.
+- **HOW** — `trait CstResolve` implemented for `D: InferDeps` (static dispatch, generics over `dyn`).
+
+## The `CstResolve` catalogue (the trait surface)
+
+Implemented for any `D: InferDeps` (so `TestDeps` drives it without an `Indexer`). CST input
+(node/pos/doc) is passed in; data access via `self`; cross-cutting context bundled into one newtype.
+
+```rust
+/// The single catalogue of CST-driven type resolution for LSP + diagnostics.
+/// Pure reads over `InferDeps`. Every returned type is ALREADY reachability-
+/// filtered and generic-substituted — a consumer never re-derives those.
+pub(crate) trait CstResolve {
+    /// Type of any expression node — ident, nav-chain, call, literal, if/range.
+    /// Walks long dotted chains and into lambda results in one traversal.
+    fn expr_type(&self, node: Node, ctx: &CstCtx) -> Resolution<ResolvedType>;
+
+    /// Receiver type for a member access: outer / leaf / nullable breakdown.
+    fn receiver_type(&self, node: Node, ctx: &CstCtx) -> Resolution<ReceiverType>;
+
+    /// Implicit lambda scope at a cursor: `this`, `it`, named params — in-scope only.
+    /// Subsumes the 3 scattered it/this/receiver entries.
+    fn lambda_scope(&self, pos: CursorPos, ctx: &CstCtx) -> LambdaScope;
+
+    /// Return type of a call resolved from an (optional) receiver + name.
+    fn call_return_type(&self, receiver: Option<&ReceiverType>, name: &str, ctx: &CstCtx)
+        -> Resolution<ReturnType>;
+}
+```
+
+### Signatures maximize agent information (the governing rule)
+
+Read every signature from the perspective of an agent that will only see the *declaration*: it must
+yield the highest possible information context without reading the body.
+
+- **Outcome enums over `Option`.** `-> Resolution<ReceiverType>` states the full contract (resolved /
+  ambiguous / absent); `-> Option<ReceiverType>` hides *why* it's `None` and invites a guess or a
+  body-read. Every resolving method returns `Resolution<T>` (below), not `Option`/empty-`Vec`.
+- **Named newtypes over primitives** (`ReceiverType`/`ReturnType`/`ResolvedType`, never `String`/`bool`).
+- **A named context struct over loose params** (`ctx: &CstCtx` documents uri+doc+IO and their
+  invariants in one hop, vs positional `(uri, doc, io)`).
+
+The signature plus one hop to its named types *is* the documentation — that is what stops an agent
+re-deriving a capability that already exists.
+
+### Capability mapping (the user's five)
+
+| Capability | Home |
+|---|---|
+| 1. import/package/super-aware **filter** | *Invariant* — applied internally in every method; an unfiltered result never escapes the facade (compiler-enforced, see Type-driven correctness) |
+| 2. generics **substitution** | *Invariant* — returned types are already subst-applied |
+| 3. optional in-scope **`it`/`this`** | `lambda_scope` → `LambdaScope { this, it, named }` |
+| 4. **chain + lambda walk** (return inference) | `expr_type` / `receiver_type` (the one traversal); `call_return_type` for the call layer |
+| 5. **IO / no-IO** (rg/fd bound) | `CstCtx.io: ResolveIo` — threaded into underlying name→definition lookups; hot paths pass `IndexOnly`, hover/go-to-def pass `Full` |
+
+### Supporting I/O types
+
+- **`CstCtx { uri, doc, io: ResolveIo }`** *(new)* — per-request resolution *input* (document + IO
+  policy; keeps signatures short). Distinct from the existing **`CursorContext`** (backend/cursor.rs —
+  the resolved cursor *token*: word/qualifier/contextual/lambda_decl); reconcile, do not duplicate.
+- **`ResolvedType`** *(new)* — a normalized `TypeName` + nullability flag (the `expr_type` result);
+  **`ReceiverType`** *(exists — resolver/infer.rs, raw/qualified/outer/leaf/nullable)* **/ `ReturnType`**
+  *(exists — resolver/api.rs)*. Self-documenting; bare `Option<String>` banned from the surface. The
+  `RawTypeName` vs `TypeName` distinction (Type-driven correctness §5) is what these wrap.
+- **`LambdaScope`** *(exists — `features/completion_context.rs`: `{ it_type, named_params, label }`,
+  bare `String`)* — **promote to the catalogue and extend**: add a `this` field carrying the existing
+  tri-state **`ThisLambdaCtx`** *(exists — `cst_lambda.rs`: `Resolved/Receiver/NotReceiver`; keep the
+  distinction, do NOT flatten to `Option` — `Receiver` vs `NotReceiver` controls fallback)*, and upgrade
+  the bare `String`s to `ReceiverType`. It subsumes `infer_lambda_param_type_at` +
+  `lambda_receiver_type_from_context` + `find_it_element_type*`.
+- **`CursorPos`** *(exists — types.rs)* for `lambda_scope`'s position; **`CallableInfo`** *(exists —
+  infer/deps.rs)* and **`LambdaParamResolution`** *(exists — infer/lambda_resolution.rs, the stage-2
+  it/this record)* reused inside the walk; **`ResolvedSymbol`** *(exists — indexer/resolution.rs, widened)*
+  and **`Definitions`** *(exists — resolver/api.rs)* for symbol/definition-returning paths.
+
+## Reuse inventory (existing types — do not reinvent)
+
+Audited with Serena before designing the surface. Most of the vocabulary already exists; the catalogue
+**reuses** it and adds only a few small newtypes.
+
+| Type the design needs | Status | Location | Decision |
+|---|---|---|---|
+| `Resolution<T>` outcome enum | **new** (pattern exists) | — | Generalizes `SignatureResult`; migrate it on later |
+| `SignatureResult` | exists | `indexer/infer/sig.rs:41` | Becomes `Resolution<Signature>` post-catalogue |
+| `ReceiverType` | exists | `resolver/infer.rs:100` | Reuse as-is |
+| `ReceiverKind` | exists | `resolver/infer.rs:88` | Reuse |
+| `ReturnType` | exists | `resolver/api.rs:51` | Reuse |
+| `LambdaScope` | exists | `features/completion_context.rs:15` | **Promote to catalogue + extend** (add `this`, richer types) |
+| `ThisLambdaCtx` (this tri-state) | exists | `indexer/infer/cst_lambda.rs:65` | Reuse as `LambdaScope.this`; **do not flatten** |
+| `LambdaParamResolution` | exists | `indexer/infer/lambda_resolution.rs:44` | Reuse as the stage-2 it/this record |
+| `CallableInfo` | exists | `indexer/infer/deps.rs:21` | Reuse |
+| `CursorPos` | exists | `types.rs:114` | Reuse for `lambda_scope(pos)` |
+| `CursorContext` | exists | `backend/cursor.rs:16` | Distinct role (resolved token); reconcile with `CstCtx` |
+| `ResolvedSymbol` | exists | `indexer/resolution.rs:13` | Reuse for symbol-returning paths |
+| `Definitions` | exists | `resolver/api.rs:35` | Reuse for definition lists |
+| `InferDeps` / `TestDeps` | exists | `indexer/infer/deps.rs` | The data seam — build on |
+| `ResolveIo` | exists | `resolver/resolve.rs` | Reuse for `CstCtx.io` |
+| `CstCtx { uri, doc, io }` | **new** | — | Thin input bundle (≠ `CursorContext`) |
+| `ResolvedType` | **new** | — | normalized `TypeName` + nullability |
+| `TypeName` / `RawTypeName` | **new** | — | normalized vs as-written newtypes |
+| `Fqn` | **new** | — | importable-FQN newtype for `Resolution::Ambiguous` |
+
+Net: ~13 existing types reused, **6 genuinely new** (`Resolution<T>`, `CstCtx`, `ResolvedType`,
+`TypeName`, `RawTypeName`, `Fqn`) — all small. The catalogue is mostly *assembly + promotion* of
+existing pieces, not new construction.
+
+## `mod.rs` is the catalogue (structural rule)
+
+Each resolution module's `mod.rs` contains exactly three things, in order, with **zero logic**:
+
+1. **Input structs** — `CstCtx`, `CursorPos` — doc-commented ("what you pass in").
+2. **Output structs** — `Resolution<T>`, `ResolvedType`, `ReceiverType`, `ReturnType`, `LambdaScope`
+   — doc-commented *with their invariants* ("what you get back, and what's guaranteed").
+3. **The catalogue trait** — `CstResolve` — intent-named methods wired to those I/O types.
+
+The walk and helpers live in submodules (`chain`, `lambda`, `expr_type`, …), never in `mod.rs`.
+Shared output types living elsewhere (`ReceiverType`/`ReturnType` in `resolver/infer.rs`) are
+**re-exported from the catalogue `mod.rs`** so it reads self-contained — open one file, see the whole
+I/O vocabulary + every capability. The same rule applies to each consuming **feature** `mod.rs`
+(its feature-catalogue trait + that feature's I/O types).
+
+## Type-driven correctness (compiler catches logic errors)
+
+Model the domain so illegal states are unrepresentable:
+
+1. **One generic outcome enum, never empty-`Vec`/`None` overloading.** "Not found" and "ambiguous
+   overload" must not both collapse to empty:
+   ```rust
+   /// Outcome of resolving something to `T`. Reused across the catalogue so an
+   /// agent learns the three outcomes once and reads them off every signature.
+   enum Resolution<T> { Resolved(T), Ambiguous(Vec<Fqn>), Unresolved }
+   ```
+   This **generalizes the existing `SignatureResult`** (sig.rs — `Unique{..} / Overloaded / NotFound /
+   UnresolvableReceiver`), which already models found/ambiguous/absent for signatures; migrate
+   `SignatureResult` onto `Resolution<Signature>` once the catalogue lands. The consumer *must* match
+   `Ambiguous`.
+2. **Construction-sealed outputs — invariants become types.** `ReceiverType`/`ResolvedType` have
+   private fields, constructible only inside the catalogue. Holding one is *proof* it was
+   reachability-filtered + subst-applied — a consumer cannot fabricate an unfiltered one and feed it
+   back. The "invariant" stops being a doc promise.
+3. **Exhaustive CST dispatch — no silent `_ => None`.** Lower a node *once* into a thin, CST-local
+   shape enum and match exhaustively:
+   ```rust
+   enum CstExpr<'a> { Ident(..), Nav(..), Call(..), Literal(..), Cond(..), Range(..) }
+   ```
+   Adding a handled node kind becomes a compile error until handled. CST-local dispatch sugar — **not**
+   the rejected cross-domain IR; it never leaves the walk.
+4. **Lambda scope as a sum type.** `ThisLambdaCtx`/`ThisContext` are already enums; `LambdaScope` keeps
+   "no implicit receiver" as a *variant*, not an empty struct.
+5. **Raw vs normalized in the type.** `RawTypeName` (generics + `?`) vs `TypeName` (normalized);
+   nullability a typed field — can't pass un-normalized where normalized is required. Enforced via
+   distinct types, not a `_raw` naming convention.
+
+## Internal consolidation plan (four walks → one)
+
+The one walk lives in `indexer/infer`, CST-driven, dispatched by the `CstExpr` shape. Each former
+mechanism becomes a *phase*, not a parallel path:
+
+| Former mechanism | Folds into | Deleted |
+|---|---|---|
+| `cst_lambda.rs` (CST `ThisLambdaCtx`) | the **spine** — CST traversal + lambda-context classifier | standalone entry points |
+| `chain.rs` (nav-segment walk) | the **chain-segment step** of `expr_type` | duplicate chain logic in `receiver.rs` (`method_chain_lambda_type`, `chain_with_type_subst`) |
+| `receiver.rs` (text heuristics) | the **lambda-receiver step**, CST-driven | the text-scan variants (`receiver_dot_lambda_type`, `nested_receiver_lambda_type`, `has_unclosed_paren`, …) |
+| `it_this.rs` (line scans) | the **`it`/`this`** resolution feeding `lambda_scope` | the line-scan variants + back-scan constants |
+| `semantic_tokens::expression_type` family | calls `CstResolve::expr_type` | the bespoke walk + its string-engine `use` leakage |
+
+### Sequencing (each step green via `cargo test --bin kmp-lsp` before the next; move-don't-rewrite)
+
+1. **Stand up the catalogue** — `CstResolve` + I/O structs + `CstCtx` + `Resolution<T>` in
+   `infer/mod.rs`; methods are thin delegations to *today's* functions. Behaviour-identical, no deletion.
+2. **Route consumers** onto the catalogue (semantic_tokens, completion_context, inlay, diagnostics,
+   hover, sig-help, fill_when); **delete `semantic_tokens`'s bespoke walk** + its string-engine leakage.
+3. **Collapse the lambda triad** — `lambda_scope` becomes the one CST classifier; fold `receiver.rs`
+   text variants + `it_this.rs` line variants in; delete both sets.
+4. **Collapse the chain walk** — `chain.rs` becomes the chain step of `expr_type`; delete the echoed
+   chain logic in `receiver.rs`.
+5. **Sweep** — remove dead helpers/constants; introduce the `CstExpr` exhaustive dispatch + the
+   construction-sealed outcome/types; confirm `mod.rs` is the only public face.
+
+Deletion lands mostly in steps 2–4 (the bespoke walk + text/line lambda engines + echoed chain logic):
+on the order of a thousand-plus lines, with the three-mechanism divergence closed.
+
+## Per-feature catalogues
+
+Each consuming feature's `mod.rs` exposes its own small catalogue trait (e.g. `SemanticClassification`,
+`InlayInference`, `HoverFacts`) listing what that feature *produces*, as a thin projection of
+`CstResolve`, with that feature's own I/O types beside it. An agent opens the feature `mod.rs`, sees its
+catalogue delegating to `CstResolve`, and has no reason to hand-roll inference.
+
+## Migration & branch strategy
+
+Per-slice PRs onto `refactor/cst-resolution` (off the merged `refactor/unified-resolution`), one per
+sequencing step, each green before the next (bisectable; move-don't-rewrite). Steps 1–2 are low-risk and
+land first; steps 3–4 carry the deletion and the risk. Open PRs only when asked.
+
+## Testing & verification
+
+- The existing CST suites are the behaviour net: hover / inlay / semantic-tokens / completion /
+  `fill_when` / diagnostics must stay green through every deletion. `cargo test --bin kmp-lsp`
+  (binary-only crate; `--lib` runs 0 tests). Focused loops: `-- semantic`, `-- inlay`, `-- completion`,
+  `-- fill_when`, `-- nullable_call`.
+- `TestDeps` drives `CstResolve` unit tests directly (no `Indexer`).
+- Where a consolidation step changes a path, add a decoy regression test *first* (red→green); diff
+  semantic-tokens / inlay output before vs after each deletion.
+- `find_referencing_symbols` (Serena) to enumerate every consumer before routing/deleting — the
+  anti-reinvention completeness check.
+
+## Risks
+
+- **`cst_lambda.rs` is 892 lines of the most correctness-sensitive code.** Mitigation: it becomes the
+  spine (kept, not rewritten); the text/line engines fold *into* it incrementally, each step suite-gated.
+- **Hot-path latency** (semantic tokens / diagnostics on every keystroke). Mitigation: `CstCtx.io =
+  IndexOnly` on those paths bounds rg/fd; behaviour-preserving for `Full`.
+- **Behaviour drift during consolidation.** Mitigation: move-don't-rewrite, per-step suite green, output
+  diffs, decoy tests for changed paths.
+
+## Out of scope
+
+- The **string path** and any unification of its heuristics (separate later analysis).
+- A shared cross-domain **IR**.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -54,6 +54,8 @@ pub(crate) use self::infer::{
     },
     type_subst::find_last_dot_at_depth_zero,
 };
+#[allow(unused_imports)]
+pub(crate) use self::infer::{CstCtx, CstResolve, ResolveIo};
 
 mod cache;
 pub(crate) use self::cache::workspace_cache_path;
@@ -410,6 +412,26 @@ impl InferDeps for Indexer {
     ) -> Option<String> {
         use tower_lsp::lsp_types::Position;
         self.infer_lambda_param_type_at(name, uri, Position::new(line as u32, col as u32))
+    }
+    fn has_type_definition(&self, name: &str) -> bool {
+        self.definition_locations(name).into_iter().any(|loc| {
+            self.files
+                .get(loc.uri.as_str())
+                .map(|file_data| {
+                    file_data.symbols.iter().any(|symbol| {
+                        symbol.name == name
+                            && matches!(
+                                symbol.kind,
+                                SymbolKind::CLASS
+                                    | SymbolKind::INTERFACE
+                                    | SymbolKind::ENUM
+                                    | SymbolKind::OBJECT
+                                    | SymbolKind::STRUCT
+                            )
+                    })
+                })
+                .unwrap_or(false)
+        })
     }
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -54,7 +54,6 @@ pub(crate) use self::infer::{
     },
     type_subst::find_last_dot_at_depth_zero,
 };
-#[allow(unused_imports)]
 pub(crate) use self::infer::{CstCtx, CstResolve, ResolveIo};
 
 mod cache;

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -171,6 +171,8 @@ pub(crate) struct TestDeps {
     pub method_params: std::collections::HashMap<(String, String), String>,
     /// `fn_name` → callable info (type params + extension receiver type)
     pub callable_infos: std::collections::HashMap<String, CallableInfo>,
+    /// `(uri_str, name)` → contextual type (for `this`, `it`, named lambda params)
+    pub contextual_types: std::collections::HashMap<(String, String), String>,
 }
 
 #[cfg(test)]
@@ -185,6 +187,7 @@ impl TestDeps {
             method_return_types: std::collections::HashMap::new(),
             method_params: std::collections::HashMap::new(),
             callable_infos: std::collections::HashMap::new(),
+            contextual_types: std::collections::HashMap::new(),
         }
     }
 
@@ -263,6 +266,16 @@ impl TestDeps {
         self
     }
 
+    /// Register `name` → `type_name` as a contextual type for `uri`.
+    ///
+    /// Used to stub `find_contextual_type` for `this`, `it`, and named lambda
+    /// parameters without needing position (line/col) matching in unit tests.
+    pub(crate) fn with_contextual(mut self, uri: &str, name: &str, type_name: &str) -> Self {
+        self.contextual_types
+            .insert((uri.to_string(), name.to_string()), type_name.to_string());
+        self
+    }
+
     /// Register `fn_name` → callable info for generic extension function tests.
     #[allow(dead_code)]
     pub(crate) fn with_callable_info(
@@ -324,5 +337,16 @@ impl InferDeps for TestDeps {
     }
     fn find_fun_callable_info(&self, fn_name: &str, _uri: &Url) -> Option<CallableInfo> {
         self.callable_infos.get(fn_name).cloned()
+    }
+    fn find_contextual_type(
+        &self,
+        name: &str,
+        uri: &Url,
+        _line: usize,
+        _col: usize,
+    ) -> Option<String> {
+        self.contextual_types
+            .get(&(uri.to_string(), name.to_string()))
+            .cloned()
     }
 }

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -145,6 +145,19 @@ pub(crate) trait InferDeps {
     ) -> Option<String> {
         None
     }
+
+    /// Return `true` when `name` is defined as a type (class, interface, enum,
+    /// object, or struct) somewhere in the workspace index.
+    ///
+    /// Used to distinguish bare type-name receivers (e.g. `Foo.CONSTANT`,
+    /// companion object access) from ordinary variable identifiers: when a
+    /// `simple_identifier` starts with an uppercase letter and this returns
+    /// `true`, the identifier itself is the type string.
+    ///
+    /// The default implementation returns `false`; overridden by `Indexer`.
+    fn has_type_definition(&self, _name: &str) -> bool {
+        false
+    }
 }
 
 // ─── Test stub ───────────────────────────────────────────────────────────────
@@ -173,6 +186,8 @@ pub(crate) struct TestDeps {
     pub callable_infos: std::collections::HashMap<String, CallableInfo>,
     /// `(uri_str, name)` → contextual type (for `this`, `it`, named lambda params)
     pub contextual_types: std::collections::HashMap<(String, String), String>,
+    /// Type names that have a type definition (class/interface/enum/object/struct).
+    pub type_names: std::collections::HashSet<String>,
 }
 
 #[cfg(test)]
@@ -188,6 +203,7 @@ impl TestDeps {
             method_params: std::collections::HashMap::new(),
             callable_infos: std::collections::HashMap::new(),
             contextual_types: std::collections::HashMap::new(),
+            type_names: std::collections::HashSet::new(),
         }
     }
 
@@ -276,6 +292,14 @@ impl TestDeps {
         self
     }
 
+    /// Register `name` as a known type definition (class / interface / enum /
+    /// object / struct).  Stubs `has_type_definition` for unit tests that need
+    /// the bare-uppercase-identifier branch in `infer_ident_type`.
+    pub(crate) fn with_type(mut self, name: &str) -> Self {
+        self.type_names.insert(name.to_string());
+        self
+    }
+
     /// Register `fn_name` → callable info for generic extension function tests.
     #[allow(dead_code)]
     pub(crate) fn with_callable_info(
@@ -348,5 +372,8 @@ impl InferDeps for TestDeps {
         self.contextual_types
             .get(&(uri.to_string(), name.to_string()))
             .cloned()
+    }
+    fn has_type_definition(&self, name: &str) -> bool {
+        self.type_names.contains(name)
     }
 }

--- a/src/indexer/infer/expr_type.rs
+++ b/src/indexer/infer/expr_type.rs
@@ -41,6 +41,7 @@ use crate::queries::{
     KIND_PREFIX_EXPR, KIND_RANGE_EXPR, KIND_REAL_LITERAL, KIND_SIMPLE_IDENT, KIND_STRING_LITERAL,
     KIND_THIS_EXPR, KIND_TYPE_IDENT,
 };
+use crate::StrExt as _;
 
 use super::deps::InferDeps;
 
@@ -111,13 +112,11 @@ fn infer_call_expr_type(
 ///
 /// Adapted from `semantic_tokens::resolve::identifier_type`.
 /// Consults contextual lambda-param inference first (handles `it` / `this` /
-/// named lambda params), then falls back to declared-variable type.
-///
-/// Note: the `has_type_definition` check from the original (which returns the
-/// name itself for class-level identifiers like companion objects) is omitted
-/// here — it depends on full index symbol scans that are not representable
-/// through `InferDeps`.  Constructor forms reach this code as `KIND_CALL_EXPR`
-/// and are handled by `infer_call_expr_type` instead.
+/// named lambda params), then falls back to the declared-variable type.
+/// As a last resort, a bare uppercase identifier that names a known type
+/// (class, interface, enum, object, companion) resolves to itself — this
+/// covers companion-object access like `Foo.CONSTANT` where `Foo` is the
+/// receiver identifier.
 fn infer_ident_type(
     node: Node<'_>,
     bytes: &[u8],
@@ -130,7 +129,13 @@ fn infer_ident_type(
     if let Some(inferred) = deps.find_contextual_type(&name, uri, start.row, col) {
         return Some(inferred);
     }
-    deps.find_var_type(&name, uri)
+    if let Some(inferred) = deps.find_var_type(&name, uri) {
+        return Some(inferred);
+    }
+    if name.starts_with_uppercase() && deps.has_type_definition(&name) {
+        return Some(name);
+    }
+    None
 }
 
 /// Resolve the type of a `this_expression`.

--- a/src/indexer/infer/expr_type.rs
+++ b/src/indexer/infer/expr_type.rs
@@ -130,7 +130,15 @@ fn infer_ident_type(
         return Some(inferred);
     }
     if let Some(inferred) = deps.find_var_type(&name, uri) {
-        return Some(inferred);
+        // Strip generic parameters from the raw type (e.g. "List<String>" → "List",
+        // "Outer.Inner<T>" → "Outer.Inner") to match the output of the old
+        // `infer_variable_type` (keep_generics=false).  The downstream member-
+        // classification path does an exact-key HashMap lookup via
+        // `definition_locations(receiver_leaf)` — "List<String>" would find nothing.
+        // `dotted_ident_prefix` stops at `<` while preserving dotted type names.
+        // Chain inference (`chain.rs`, `type_subst.rs`) still gets the raw form via
+        // `find_var_type` directly — this strip is local to `infer_ident_type` only.
+        return Some(inferred.dotted_ident_prefix());
     }
     if name.starts_with_uppercase() && deps.has_type_definition(&name) {
         return Some(name);

--- a/src/indexer/infer/expr_type.rs
+++ b/src/indexer/infer/expr_type.rs
@@ -64,7 +64,9 @@ pub(crate) fn infer_expr_type(
         KIND_BOOLEAN_LITERAL => Some("Boolean".to_owned()),
         KIND_NULL_LITERAL => Some("Nothing?".to_owned()),
         KIND_CHARACTER_LITERAL => Some("Char".to_owned()),
-        KIND_SIMPLE_IDENT | KIND_TYPE_IDENT => infer_ident_type(node, bytes, deps, uri),
+        k if k == KIND_SIMPLE_IDENT || k == KIND_TYPE_IDENT => {
+            infer_ident_type(node, bytes, deps, uri)
+        }
         k if k == KIND_THIS_EXPR => infer_this_expr_type(node, bytes, deps, uri),
         k if k == KIND_NAV_EXPR => infer_navigation_expr_type(node, bytes, deps, uri),
         k if k == KIND_CALL_EXPR => infer_call_expr_type(node, bytes, deps, uri),
@@ -162,6 +164,11 @@ fn infer_navigation_expr_type(
     let receiver_type = infer_expr_type(receiver, bytes, deps, uri)?;
 
     if nav_is_call_callee(node) {
+        // The two-step `find_fun_return_type_reachable` → `find_fun_return_type` replicates
+        // `Resolver::function_return_type`'s reachable→by_name fallback behaviour (see
+        // `src/resolver/api.rs`) through the `InferDeps` seam rather than calling the
+        // `Resolver` trait directly.  Together they are equivalent to the original
+        // `indexer.function_return_type(&member, uri)` call in `navigation_expression_type`.
         return deps
             .find_method_return_type_for_type(&receiver_type, &member)
             .or_else(|| deps.find_fun_return_type_reachable(&member, uri))

--- a/src/indexer/infer/expr_type.rs
+++ b/src/indexer/infer/expr_type.rs
@@ -19,20 +19,27 @@
 //! | `prefix_expression` (`!`) | `Boolean`              |
 //! | `if_expression`           | type when both branches agree |
 //! | `range_expression` (int)  | `IntRange`             |
+//! | `simple_identifier`       | variable type from index |
+//! | `type_identifier`         | variable type from index |
+//! | `navigation_expression`   | field/method return type from index |
+//! | `this_expression`         | contextual lambda-receiver type |
 //!
-//! Navigation expressions (e.g. `list.size`), `when` expressions, and other
+//! Simple identifiers, navigation expressions (e.g. `list.size`), and `this`
+//! are now resolved through the `InferDeps` seam. `when` expressions and other
 //! compound forms are not resolved — callers receive `None` and can omit the
 //! type annotation.
 
 use tower_lsp::lsp_types::Url;
 use tree_sitter::Node;
 
+use crate::indexer::NodeExt;
 use crate::queries::{
     KIND_BOOLEAN_LITERAL, KIND_CALL_EXPR, KIND_CHARACTER_LITERAL, KIND_CHECK_EXPR,
     KIND_COMPARISON_EXPR, KIND_CONJUNCTION_EXPR, KIND_CONTROL_STRUCTURE_BODY,
     KIND_DISJUNCTION_EXPR, KIND_ELSE, KIND_IF_EXPR, KIND_INTEGER_LITERAL, KIND_LONG_LITERAL,
-    KIND_MULTILINE_STRING_LITERAL, KIND_NULL_LITERAL, KIND_PREFIX_EXPR, KIND_RANGE_EXPR,
-    KIND_REAL_LITERAL, KIND_STRING_LITERAL,
+    KIND_MULTILINE_STRING_LITERAL, KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_NULL_LITERAL,
+    KIND_PREFIX_EXPR, KIND_RANGE_EXPR, KIND_REAL_LITERAL, KIND_SIMPLE_IDENT, KIND_STRING_LITERAL,
+    KIND_THIS_EXPR, KIND_TYPE_IDENT,
 };
 
 use super::deps::InferDeps;
@@ -57,6 +64,9 @@ pub(crate) fn infer_expr_type(
         KIND_BOOLEAN_LITERAL => Some("Boolean".to_owned()),
         KIND_NULL_LITERAL => Some("Nothing?".to_owned()),
         KIND_CHARACTER_LITERAL => Some("Char".to_owned()),
+        KIND_SIMPLE_IDENT | KIND_TYPE_IDENT => infer_ident_type(node, bytes, deps, uri),
+        k if k == KIND_THIS_EXPR => infer_this_expr_type(node, bytes, deps, uri),
+        k if k == KIND_NAV_EXPR => infer_navigation_expr_type(node, bytes, deps, uri),
         k if k == KIND_CALL_EXPR => infer_call_expr_type(node, bytes, deps, uri),
         k if k == KIND_CHECK_EXPR
             || k == KIND_COMPARISON_EXPR
@@ -93,6 +103,101 @@ fn infer_call_expr_type(
     uri: &Url,
 ) -> Option<String> {
     super::chain::resolve_call_expr_type(node, bytes, deps, uri)
+}
+
+/// Resolve the type of a `simple_identifier` or `type_identifier`.
+///
+/// Adapted from `semantic_tokens::resolve::identifier_type`.
+/// Consults contextual lambda-param inference first (handles `it` / `this` /
+/// named lambda params), then falls back to declared-variable type.
+///
+/// Note: the `has_type_definition` check from the original (which returns the
+/// name itself for class-level identifiers like companion objects) is omitted
+/// here — it depends on full index symbol scans that are not representable
+/// through `InferDeps`.  Constructor forms reach this code as `KIND_CALL_EXPR`
+/// and are handled by `infer_call_expr_type` instead.
+fn infer_ident_type(
+    node: Node<'_>,
+    bytes: &[u8],
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<String> {
+    let name = node.utf8_text_owned(bytes)?;
+    let start = node.start_position();
+    let col = crate::inlay_hints::ts_byte_col_to_utf16(bytes, &[], start.row, start.column);
+    if let Some(inferred) = deps.find_contextual_type(&name, uri, start.row, col) {
+        return Some(inferred);
+    }
+    deps.find_var_type(&name, uri)
+}
+
+/// Resolve the type of a `this_expression`.
+///
+/// Adapted from the `KIND_THIS_EXPR` arm of `semantic_tokens::resolve::expression_type`.
+/// Delegates to contextual lambda-receiver inference at the node's position.
+fn infer_this_expr_type(
+    node: Node<'_>,
+    bytes: &[u8],
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<String> {
+    let start = node.start_position();
+    let col = crate::inlay_hints::ts_byte_col_to_utf16(bytes, &[], start.row, start.column);
+    deps.find_contextual_type("this", uri, start.row, col)
+}
+
+/// Resolve the type of a `navigation_expression` node (e.g. `obj.field`).
+///
+/// Adapted from `semantic_tokens::resolve::navigation_expression_type`.
+/// Recursively resolves the receiver through `infer_expr_type`, then looks up
+/// the member as a field or (when the expression is a call callee) a method.
+fn infer_navigation_expr_type(
+    node: Node<'_>,
+    bytes: &[u8],
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<String> {
+    let receiver = nav_receiver_node(node)?;
+    let member = nav_member_ident(node)?.utf8_text_owned(bytes)?;
+    let receiver_type = infer_expr_type(receiver, bytes, deps, uri)?;
+
+    if nav_is_call_callee(node) {
+        return deps
+            .find_method_return_type_for_type(&receiver_type, &member)
+            .or_else(|| deps.find_fun_return_type_reachable(&member, uri))
+            .or_else(|| deps.find_fun_return_type(&member));
+    }
+
+    deps.find_field_type(&receiver_type, &member)
+}
+
+// ─── navigation tree-walking helpers ─────────────────────────────────────────
+
+/// Return the receiver sub-node of a `navigation_expression` (the part before
+/// the final `.`).  Equivalent to `semantic_tokens::helpers::navigation_receiver_node`.
+fn nav_receiver_node(node: Node<'_>) -> Option<Node<'_>> {
+    (0..node.child_count())
+        .filter_map(|i| node.child(i))
+        .find(|child| child.is_named() && child.kind() != KIND_NAV_SUFFIX)
+}
+
+/// Return the member identifier inside the `navigation_suffix` of a
+/// `navigation_expression`.  Equivalent to
+/// `semantic_tokens::helpers::navigation_member_ident`.
+fn nav_member_ident(node: Node<'_>) -> Option<Node<'_>> {
+    let suffix = node.first_child_of_kind(KIND_NAV_SUFFIX)?;
+    (0..suffix.child_count())
+        .filter_map(|i| suffix.child(i))
+        .find(|child| child.kind() == KIND_SIMPLE_IDENT || child.kind() == KIND_TYPE_IDENT)
+}
+
+/// Return `true` if `node` is the callee (first child) of a `call_expression`.
+/// Equivalent to `semantic_tokens::helpers::is_call_callee`.
+fn nav_is_call_callee(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    parent.kind() == KIND_CALL_EXPR && parent.child(0).map(|child| child.id()) == Some(node.id())
 }
 
 /// `!expr` → `Boolean`; other prefix operators (`-`, `+`) are arithmetic and

--- a/src/indexer/infer/expr_type_tests.rs
+++ b/src/indexer/infer/expr_type_tests.rs
@@ -30,6 +30,19 @@ fn infer(src: &str) -> Option<String> {
     infer_expr_type(expr, &bytes, &TestDeps::new(), &test_url())
 }
 
+/// Parse `fun f() = <expr>` and run `infer_expr_type` with explicit deps.
+fn infer_with_deps(src: &str, deps: &TestDeps) -> Option<String> {
+    let full = format!("fun f() = {src}");
+    let (tree, bytes) = fun_body_expr_node(&full);
+    let root = tree.root_node();
+    let fun_decl = root.child(0)?;
+    let body = (0..fun_decl.child_count())
+        .map(|i| fun_decl.child(i).unwrap())
+        .find(|n| n.kind() == KIND_FUN_BODY)?;
+    let expr = body.child(1)?;
+    infer_expr_type(expr, &bytes, deps, &test_url())
+}
+
 // ─── literals ─────────────────────────────────────────────────────────────────
 
 #[test]
@@ -221,4 +234,31 @@ fn remember_saveable_infers_lambda_result() {
 #[test]
 fn remember_empty_lambda_is_none() {
     assert_eq!(infer("remember { }"), None);
+}
+
+// ─── identifier / navigation / this kinds (new in Task 1) ─────────────────────
+
+#[test]
+fn infer_expr_type_resolves_simple_identifier() {
+    // `value` where `value: MyType` → "MyType"
+    let deps = TestDeps::new().with_var("file:///tmp/test.kt", "value", "MyType");
+    assert_eq!(infer_with_deps("value", &deps).as_deref(), Some("MyType"));
+}
+
+#[test]
+fn infer_expr_type_resolves_navigation_chain_receiver() {
+    // `data.field` where `data: Holder` and `Holder.field: Foo` → "Foo"
+    let deps = TestDeps::new()
+        .with_var("file:///tmp/test.kt", "data", "Holder")
+        .with_field("Holder", "field", "Foo");
+    assert_eq!(infer_with_deps("data.field", &deps).as_deref(), Some("Foo"));
+}
+
+#[test]
+fn unknown_identifier_returns_none() {
+    // An unregistered variable → no type known
+    assert_eq!(
+        infer_with_deps("unknown", &TestDeps::new()).as_deref(),
+        None
+    );
 }

--- a/src/indexer/infer/expr_type_tests.rs
+++ b/src/indexer/infer/expr_type_tests.rs
@@ -263,6 +263,40 @@ fn infer_expr_type_resolves_simple_identifier() {
     assert_eq!(infer_with_deps("value", &deps).as_deref(), Some("MyType"));
 }
 
+// ─── has_type_definition branch (Step 0 of Task 3) ───────────────────────────
+
+#[test]
+fn bare_uppercase_ident_with_type_definition_resolves_to_name() {
+    // `Foo` where `Foo` is a known type → "Foo" (companion / static access receiver)
+    let deps = TestDeps::new().with_type("Foo");
+    assert_eq!(infer_with_deps("Foo", &deps).as_deref(), Some("Foo"));
+}
+
+#[test]
+fn bare_uppercase_ident_without_type_definition_returns_none() {
+    // `Foo` where no type definition is registered → None (not a known type name)
+    let deps = TestDeps::new();
+    assert_eq!(infer_with_deps("Foo", &deps).as_deref(), None);
+}
+
+#[test]
+fn lowercase_ident_not_affected_by_has_type_definition() {
+    // `foo` is lowercase — the `has_type_definition` guard is never reached even if
+    // a type named "foo" were registered.
+    let deps = TestDeps::new().with_type("foo");
+    assert_eq!(infer_with_deps("foo", &deps).as_deref(), None);
+}
+
+#[test]
+fn var_type_takes_priority_over_type_definition() {
+    // When `Foo` is declared as a local variable *and* is a known type, the
+    // variable type wins (declared context is more specific).
+    let deps = TestDeps::new()
+        .with_var("file:///tmp/test.kt", "Foo", "Bar")
+        .with_type("Foo");
+    assert_eq!(infer_with_deps("Foo", &deps).as_deref(), Some("Bar"));
+}
+
 #[test]
 fn infer_expr_type_resolves_navigation_chain_receiver() {
     // `data.field` where `data: Holder` and `Holder.field: Foo` → "Foo"

--- a/src/indexer/infer/expr_type_tests.rs
+++ b/src/indexer/infer/expr_type_tests.rs
@@ -236,6 +236,24 @@ fn remember_empty_lambda_is_none() {
     assert_eq!(infer("remember { }"), None);
 }
 
+// ─── this_expression ──────────────────────────────────────────────────────────
+
+#[test]
+fn this_expr_empty_deps_returns_none() {
+    // No contextual type registered → infer_this_expr_type returns None without panicking.
+    assert_eq!(infer("this"), None);
+}
+
+#[test]
+fn this_expr_resolves_to_contextual_receiver_type() {
+    // `this` with a registered contextual type → resolves to the receiver class name.
+    let deps = TestDeps::new().with_contextual("file:///tmp/test.kt", "this", "MyReceiver");
+    assert_eq!(
+        infer_with_deps("this", &deps).as_deref(),
+        Some("MyReceiver")
+    );
+}
+
 // ─── identifier / navigation / this kinds (new in Task 1) ─────────────────────
 
 #[test]

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -1,6 +1,21 @@
 //! Type-inference helpers for the Kotlin indexer.
 //!
-//! Each submodule handles one class of inference:
+//! # Catalogue
+//!
+//! `mod.rs` is the catalogue: it re-exports the rich, self-documenting types and
+//! the `CstResolve` facade trait so callers import from a single place.
+//!
+//! ## Types produced (Phase 1)
+//!
+//! | Type              | Role                                                         |
+//! |-------------------|--------------------------------------------------------------|
+//! | `CstCtx`          | Per-request input: bytes + URI + IO policy                   |
+//! | `Fqn`             | Importable fully-qualified name (newtype over `String`)      |
+//! | `Resolution<T>`   | Three-way outcome: `Resolved(T)` / `Ambiguous(Vec<Fqn>)` / `Unresolved` |
+//! | `ResolvedType`    | A resolved expression type with its nullable flag            |
+//!
+//! ## Submodules
+//!
 //! - `deps`        — `InferDeps` trait + `TestDeps` stub for unit-testing leaf helpers
 //! - `lambda`      — decomposing lambda/function types (`(T) -> R`, receiver lambdas, etc.)
 //! - `sig`         — function signature extraction (pure string/slice functions)
@@ -24,3 +39,117 @@ pub(super) mod lambda_resolution;
 pub(super) mod receiver;
 pub(super) mod sig;
 pub(super) mod type_subst;
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;
+
+// ─── re-exports from resolver (IO policy) ─────────────────────────────────────
+
+pub(crate) use crate::resolver::resolve::ResolveIo;
+
+// ─── catalogue types ──────────────────────────────────────────────────────────
+
+use tower_lsp::lsp_types::Url;
+use tree_sitter::Node;
+
+use crate::StrExt as _;
+
+// Phase 1 types + trait: consumed only via tests now; Task 3 wires production
+// callers. Suppress dead-code lints for the seam until that slice lands.
+#[allow(dead_code)]
+/// Per-request CST resolution input: document bytes + URI + IO policy.
+pub(crate) struct CstCtx<'a> {
+    pub(crate) bytes: &'a [u8],
+    pub(crate) uri: &'a Url,
+    /// IO policy: carried now for the seam; later catalogue methods branch on it.
+    pub(crate) io: ResolveIo,
+}
+
+/// Importable fully-qualified name (newtype over the FQN string).
+#[allow(dead_code)] // produced by Ambiguous; consumed by later catalogue methods
+pub(crate) struct Fqn(pub(crate) String);
+
+/// Outcome of resolving something to `T`. Reused across the catalogue so an
+/// agent learns the three outcomes once and reads them off every signature.
+#[allow(dead_code)] // variants wired by Task 3+; all three present for completeness
+pub(crate) enum Resolution<T> {
+    Resolved(T),
+    /// Multiple candidates — callers may surface all or pick one heuristically.
+    /// Unused by `expr_type` in Phase 1; present for later catalogue methods.
+    Ambiguous(Vec<Fqn>),
+    Unresolved,
+}
+
+impl<T> Resolution<T> {
+    /// `Resolved(t) -> Some(t)`, else `None`.
+    /// Bridges callers not yet ambiguity-aware.
+    #[allow(dead_code)] // wired by Task 3; suppressed until then
+    pub(crate) fn resolved(self) -> Option<T> {
+        match self {
+            Resolution::Resolved(value) => Some(value),
+            Resolution::Ambiguous(_) | Resolution::Unresolved => None,
+        }
+    }
+
+    /// `Resolved(t) -> Some(&t)`, else `None`.
+    #[allow(dead_code)] // wiring seam; used by later catalogue methods
+    pub(crate) fn resolved_ref(&self) -> Option<&T> {
+        match self {
+            Resolution::Resolved(value) => Some(value),
+            Resolution::Ambiguous(_) | Resolution::Unresolved => None,
+        }
+    }
+}
+
+/// A resolved expression type. Phase 1: carries the inferred type *as-written*
+/// (no lossy normalization); the RawTypeName/TypeName split is slice 5.
+#[allow(dead_code)] // wired by Task 3; suppressed until then
+pub(crate) struct ResolvedType {
+    type_name: String,
+    nullable: bool,
+}
+
+impl ResolvedType {
+    /// Construct from an inferred type string.
+    /// Nullability is derived via `StrExt::is_nullable` (the canonical place).
+    pub(crate) fn from_inferred(raw: String) -> Self {
+        let nullable = raw.is_nullable();
+        ResolvedType {
+            type_name: raw,
+            nullable,
+        }
+    }
+
+    /// The type as-written (what the old `Option<String>` callers consumed).
+    #[allow(dead_code)] // wired by Task 3; suppressed until then
+    pub(crate) fn as_type_str(&self) -> &str {
+        &self.type_name
+    }
+
+    #[allow(dead_code)] // wired by Task 3; suppressed until then
+    pub(crate) fn is_nullable(&self) -> bool {
+        self.nullable
+    }
+}
+
+// ─── catalogue facade trait ───────────────────────────────────────────────────
+
+/// The catalogue of CST-driven type resolution. (Phase 1: `expr_type` only.)
+#[allow(dead_code)] // wired by Task 3; suppressed until then
+pub(crate) trait CstResolve {
+    /// Type of any expression node.
+    /// Covers ident / nav / call / literals / this / if / range.
+    fn expr_type(&self, node: Node, ctx: &CstCtx) -> Resolution<ResolvedType>;
+}
+
+// ─── impl for Indexer ─────────────────────────────────────────────────────────
+
+impl CstResolve for crate::indexer::Indexer {
+    fn expr_type(&self, node: Node, ctx: &CstCtx) -> Resolution<ResolvedType> {
+        match crate::indexer::infer::expr_type::infer_expr_type(node, ctx.bytes, self, ctx.uri) {
+            Some(raw) => Resolution::Resolved(ResolvedType::from_inferred(raw)),
+            None => Resolution::Unresolved,
+        }
+    }
+}

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -55,14 +55,12 @@ use tree_sitter::Node;
 
 use crate::StrExt as _;
 
-// Phase 1 types + trait: consumed only via tests now; Task 3 wires production
-// callers. Suppress dead-code lints for the seam until that slice lands.
-#[allow(dead_code)]
 /// Per-request CST resolution input: document bytes + URI + IO policy.
 pub(crate) struct CstCtx<'a> {
     pub(crate) bytes: &'a [u8],
     pub(crate) uri: &'a Url,
-    /// IO policy: carried now for the seam; later catalogue methods branch on it.
+    /// IO policy: carried for the seam; later catalogue methods branch on it.
+    #[allow(dead_code)]
     pub(crate) io: ResolveIo,
 }
 
@@ -72,11 +70,11 @@ pub(crate) struct Fqn(pub(crate) String);
 
 /// Outcome of resolving something to `T`. Reused across the catalogue so an
 /// agent learns the three outcomes once and reads them off every signature.
-#[allow(dead_code)] // variants wired by Task 3+; all three present for completeness
 pub(crate) enum Resolution<T> {
     Resolved(T),
     /// Multiple candidates — callers may surface all or pick one heuristically.
     /// Unused by `expr_type` in Phase 1; present for later catalogue methods.
+    #[allow(dead_code)] // present for completeness; consumed by later catalogue methods
     Ambiguous(Vec<Fqn>),
     Unresolved,
 }
@@ -84,7 +82,6 @@ pub(crate) enum Resolution<T> {
 impl<T> Resolution<T> {
     /// `Resolved(t) -> Some(t)`, else `None`.
     /// Bridges callers not yet ambiguity-aware.
-    #[allow(dead_code)] // wired by Task 3; suppressed until then
     pub(crate) fn resolved(self) -> Option<T> {
         match self {
             Resolution::Resolved(value) => Some(value),
@@ -104,7 +101,6 @@ impl<T> Resolution<T> {
 
 /// A resolved expression type. Phase 1: carries the inferred type *as-written*
 /// (no lossy normalization); the RawTypeName/TypeName split is slice 5.
-#[allow(dead_code)] // wired by Task 3; suppressed until then
 pub(crate) struct ResolvedType {
     type_name: String,
     nullable: bool,
@@ -122,12 +118,11 @@ impl ResolvedType {
     }
 
     /// The type as-written (what the old `Option<String>` callers consumed).
-    #[allow(dead_code)] // wired by Task 3; suppressed until then
     pub(crate) fn as_type_str(&self) -> &str {
         &self.type_name
     }
 
-    #[allow(dead_code)] // wired by Task 3; suppressed until then
+    #[allow(dead_code)] // not yet consumed; available for later catalogue methods
     pub(crate) fn is_nullable(&self) -> bool {
         self.nullable
     }
@@ -136,7 +131,6 @@ impl ResolvedType {
 // ─── catalogue facade trait ───────────────────────────────────────────────────
 
 /// The catalogue of CST-driven type resolution. (Phase 1: `expr_type` only.)
-#[allow(dead_code)] // wired by Task 3; suppressed until then
 pub(crate) trait CstResolve {
     /// Type of any expression node.
     /// Covers ident / nav / call / literals / this / if / range.

--- a/src/indexer/infer/mod_tests.rs
+++ b/src/indexer/infer/mod_tests.rs
@@ -1,0 +1,120 @@
+use tower_lsp::lsp_types::Url;
+use tree_sitter::Parser;
+
+use crate::indexer::infer::{CstCtx, CstResolve, ResolveIo};
+use crate::indexer::Indexer;
+use crate::queries::KIND_FUN_BODY;
+
+fn test_url(path: &str) -> Url {
+    Url::parse(&format!("file://{path}")).unwrap()
+}
+
+/// Parse `fun f() = <expr>` and return the expression node (and tree + bytes, to
+/// keep the tree alive).
+fn expr_node_for(src: &str) -> (tree_sitter::Tree, Vec<u8>) {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&tree_sitter_kotlin::language())
+        .unwrap();
+    let bytes = src.as_bytes().to_vec();
+    let tree = parser.parse(src, None).unwrap();
+    (tree, bytes)
+}
+
+fn first_expr_in_fun(tree: &tree_sitter::Tree) -> Option<tree_sitter::Node<'_>> {
+    let root = tree.root_node();
+    let fun_decl = root.child(0)?;
+    let body = (0..fun_decl.child_count())
+        .map(|i| fun_decl.child(i).unwrap())
+        .find(|n| n.kind() == KIND_FUN_BODY)?;
+    body.child(1)
+}
+
+#[test]
+fn cst_resolve_expr_type_resolves_int_literal() {
+    let source = "fun f() = 1\n";
+    let (tree, bytes) = expr_node_for(source);
+    let int_literal_node = first_expr_in_fun(&tree).expect("expr node");
+
+    let indexer = Indexer::new();
+    let uri = test_url("/A.kt");
+    indexer.index_content(&uri, source);
+
+    let ctx = CstCtx {
+        bytes: &bytes,
+        uri: &uri,
+        io: ResolveIo::IndexOnly,
+    };
+    let resolved = indexer.expr_type(int_literal_node, &ctx).resolved();
+    assert_eq!(
+        resolved.map(|t| t.as_type_str().to_owned()).as_deref(),
+        Some("Int")
+    );
+}
+
+#[test]
+fn cst_resolve_expr_type_unresolved_for_unknown_nav() {
+    let source = "fun f() = list.size\n";
+    let (tree, bytes) = expr_node_for(source);
+    let nav_expr_node = first_expr_in_fun(&tree).expect("expr node");
+
+    let indexer = Indexer::new();
+    let uri = test_url("/B.kt");
+    indexer.index_content(&uri, source);
+
+    let ctx = CstCtx {
+        bytes: &bytes,
+        uri: &uri,
+        io: ResolveIo::IndexOnly,
+    };
+    let resolved = indexer.expr_type(nav_expr_node, &ctx).resolved();
+    assert!(
+        resolved.is_none(),
+        "unresolvable nav expr should yield Unresolved"
+    );
+}
+
+#[test]
+fn resolved_type_nullable_flag() {
+    let source = "fun f() = null\n";
+    let (tree, bytes) = expr_node_for(source);
+    let null_node = first_expr_in_fun(&tree).expect("null expr node");
+
+    let indexer = Indexer::new();
+    let uri = test_url("/C.kt");
+    indexer.index_content(&uri, source);
+
+    let ctx = CstCtx {
+        bytes: &bytes,
+        uri: &uri,
+        io: ResolveIo::IndexOnly,
+    };
+    let resolution = indexer.expr_type(null_node, &ctx);
+    let resolved = resolution
+        .resolved()
+        .expect("null should resolve to Nothing?");
+    assert_eq!(resolved.as_type_str(), "Nothing?");
+    assert!(resolved.is_nullable(), "Nothing? should be nullable");
+}
+
+#[test]
+fn resolved_type_non_nullable() {
+    let source = "fun f() = 42\n";
+    let (tree, bytes) = expr_node_for(source);
+    let int_node = first_expr_in_fun(&tree).expect("expr node");
+
+    let indexer = Indexer::new();
+    let uri = test_url("/D.kt");
+    indexer.index_content(&uri, source);
+
+    let ctx = CstCtx {
+        bytes: &bytes,
+        uri: &uri,
+        io: ResolveIo::IndexOnly,
+    };
+    let resolved = indexer
+        .expr_type(int_node, &ctx)
+        .resolved()
+        .expect("Int should resolve");
+    assert!(!resolved.is_nullable(), "Int should not be nullable");
+}

--- a/src/semantic_tokens/helpers.rs
+++ b/src/semantic_tokens/helpers.rs
@@ -372,18 +372,6 @@ pub(super) fn navigation_member_ident(node: Node<'_>) -> Option<Node<'_>> {
         .find(|child| child.kind() == KIND_SIMPLE_IDENT || child.kind() == KIND_TYPE_IDENT)
 }
 
-pub(super) fn token_position(
-    bytes: &[u8],
-    starts: &[usize],
-    node: Node<'_>,
-) -> tower_lsp::lsp_types::Position {
-    let start = node.start_position();
-    tower_lsp::lsp_types::Position::new(
-        start.row as u32,
-        crate::inlay_hints::ts_byte_col_to_utf16(bytes, starts, start.row, start.column) as u32,
-    )
-}
-
 pub(super) fn is_call_callee(node: Node<'_>) -> bool {
     let Some(parent) = node.parent() else {
         return false;

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -8,20 +8,19 @@ use tree_sitter::Node;
 use crate::indexer::{
     find_it_element_type_in_lines, find_this_element_type_in_lines, Indexer, LiveDoc, NodeExt,
 };
+use crate::indexer::{CstCtx, CstResolve as _, ResolveIo};
 use crate::queries::{
-    KIND_CALL_EXPR, KIND_KW_AS, KIND_KW_BY, KIND_KW_CONSTRUCTOR, KIND_KW_GET, KIND_KW_IN,
-    KIND_KW_IS, KIND_KW_SET, KIND_KW_WHERE, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_NAV_EXPR,
-    KIND_SIMPLE_IDENT, KIND_THIS_EXPR, KIND_TYPE_IDENT, KIND_VAR_DECL,
+    KIND_KW_AS, KIND_KW_BY, KIND_KW_CONSTRUCTOR, KIND_KW_GET, KIND_KW_IN, KIND_KW_IS, KIND_KW_SET,
+    KIND_KW_WHERE, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_NAV_EXPR, KIND_SIMPLE_IDENT,
+    KIND_THIS_EXPR, KIND_TYPE_IDENT, KIND_VAR_DECL,
 };
-use crate::resolver::infer::{find_field_type_in_class, infer_variable_type};
-use crate::resolver::{Resolver, ReturnType};
+use crate::resolver::infer::find_field_type_in_class;
 use crate::Language;
 
 use super::helpers::{
     is_annotation_reference, is_call_callee, is_declaration_site, is_inside_lambda_parameters,
     is_named_argument_label, is_navigation_receiver, is_top_level_call_name, is_type_reference,
-    navigation_member_ident, navigation_receiver_node, node_text, push_token, token_position,
-    visit_tree,
+    navigation_member_ident, navigation_receiver_node, node_text, push_token, visit_tree,
 };
 use super::{modifier_bit, type_index, RawToken, Source};
 
@@ -158,7 +157,17 @@ fn resolve_member_access(
         };
         let is_call = is_call_callee(node);
         let resolved_type = navigation_receiver_node(node)
-            .and_then(|receiver| expression_type(receiver, doc, &src.line_starts, indexer, uri))
+            .and_then(|receiver| {
+                let ctx = CstCtx {
+                    bytes: &doc.bytes,
+                    uri,
+                    io: ResolveIo::IndexOnly,
+                };
+                indexer
+                    .expr_type(receiver, &ctx)
+                    .resolved()
+                    .map(|t| t.as_type_str().to_owned())
+            })
             .and_then(|receiver_type| {
                 member_token_type_for_receiver(indexer, &receiver_type, &member_name)
             });
@@ -286,95 +295,6 @@ fn resolve_lambda_params(
     tokens
 }
 
-// ─── Type inference helpers ──────────────────────────────────────────────────
-
-fn identifier_type(
-    node: Node<'_>,
-    doc: &LiveDoc,
-    starts: &[usize],
-    indexer: &Indexer,
-    uri: &Url,
-) -> Option<String> {
-    let name = node.utf8_text_owned(&doc.bytes)?;
-    if let Some(inferred) =
-        indexer.infer_lambda_param_type_at(&name, uri, token_position(&doc.bytes, starts, node))
-    {
-        return Some(inferred);
-    }
-    if let Some(inferred) = infer_variable_type(indexer, &name, uri) {
-        return Some(inferred);
-    }
-    if name.starts_with(char::is_uppercase) && has_type_definition(indexer, &name) {
-        return Some(name);
-    }
-    None
-}
-
-fn navigation_expression_type(
-    node: Node<'_>,
-    doc: &LiveDoc,
-    starts: &[usize],
-    indexer: &Indexer,
-    uri: &Url,
-) -> Option<String> {
-    let receiver = navigation_receiver_node(node)?;
-    let member = navigation_member_ident(node)?.utf8_text_owned(&doc.bytes)?;
-    let receiver_type = expression_type(receiver, doc, starts, indexer, uri)?;
-
-    if is_call_callee(node) {
-        return member_return_type(indexer, &receiver_type, &member, uri).or_else(|| {
-            indexer
-                .function_return_type(&member, uri)
-                .map(ReturnType::into_inner)
-        });
-    }
-
-    find_field_type_in_class(indexer, &receiver_type, &member)
-}
-
-fn call_expression_type(
-    node: Node<'_>,
-    doc: &LiveDoc,
-    starts: &[usize],
-    indexer: &Indexer,
-    uri: &Url,
-) -> Option<String> {
-    let (member, _) = node.call_fn_and_qualifier(&doc.bytes)?;
-    if let Some(callee) = node.child(0).filter(|child| child.kind() == KIND_NAV_EXPR) {
-        if let Some(receiver) = navigation_receiver_node(callee) {
-            if let Some(receiver_type) = expression_type(receiver, doc, starts, indexer, uri) {
-                if let Some(return_type) = member_return_type(indexer, &receiver_type, &member, uri)
-                {
-                    return Some(return_type);
-                }
-            }
-        }
-    }
-    indexer
-        .function_return_type(&member, uri)
-        .map(ReturnType::into_inner)
-}
-
-fn expression_type(
-    node: Node<'_>,
-    doc: &LiveDoc,
-    starts: &[usize],
-    indexer: &Indexer,
-    uri: &Url,
-) -> Option<String> {
-    match node.kind() {
-        KIND_SIMPLE_IDENT | KIND_TYPE_IDENT => identifier_type(node, doc, starts, indexer, uri),
-        KIND_THIS_EXPR => indexer.infer_lambda_param_type_at(
-            "this",
-            uri,
-            token_position(&doc.bytes, starts, node),
-        ),
-        KIND_NAV_EXPR => navigation_expression_type(node, doc, starts, indexer, uri),
-        KIND_CALL_EXPR => call_expression_type(node, doc, starts, indexer, uri),
-        _ => None,
-    }
-}
-
 // ─── Symbol resolution helpers ───────────────────────────────────────────────
 
 fn is_owner_type_symbol(kind: SymbolKind) -> bool {
@@ -422,21 +342,6 @@ fn range_within(inner: &Range, outer: &Range) -> bool {
         (inner.start.line, inner.start.character) >= (outer.start.line, outer.start.character);
     let end_ok = (inner.end.line, inner.end.character) <= (outer.end.line, outer.end.character);
     start_ok && end_ok
-}
-
-fn has_type_definition(indexer: &Indexer, name: &str) -> bool {
-    indexer.definition_locations(name).into_iter().any(|loc| {
-        indexer
-            .files
-            .get(loc.uri.as_str())
-            .map(|file_data| {
-                file_data
-                    .symbols
-                    .iter()
-                    .any(|symbol| symbol.name == name && is_type_symbol(symbol.kind))
-            })
-            .unwrap_or(false)
-    })
 }
 
 fn matches_receiver_type(extension_receiver: &str, receiver_type: &str) -> bool {
@@ -505,17 +410,6 @@ fn member_token_type_for_receiver(
             find_field_type_in_class(indexer, receiver_type, member_name)
                 .map(|_| type_index(&SemanticTokenType::PROPERTY))
         })
-}
-
-fn member_return_type(
-    indexer: &Indexer,
-    receiver_type: &str,
-    member_name: &str,
-    from_uri: &Url,
-) -> Option<String> {
-    indexer
-        .method_return_type(receiver_type, member_name, Some(from_uri))
-        .map(ReturnType::into_inner)
 }
 
 fn enum_entry_reference_token(

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -1567,3 +1567,30 @@ fn cross_package_same_name_type_uses_imported_kind() {
         "Widget at (4,11) must not be NAMESPACE (the b.Widget object), got: {tokens:?}"
     );
 }
+
+// --- Regression: generic-typed variable receiver must not drop member token ---
+
+#[test]
+fn ref_property_access_on_generic_typed_variable() {
+    // Regression guard: `val c: Container<String>` — the receiver type returned by
+    // `find_var_type` is "Container<String>" (with generics). If `infer_ident_type`
+    // passes that raw form into the member-classification path, `definition_locations`
+    // will not find "Container<String>" in its key map and the PROPERTY token is
+    // silently dropped. The fix strips generics before returning from `infer_ident_type`,
+    // so the lookup key is "Container" and the member is found.
+    let src = "class Container<T> { val data: Int = 0 }\nfun use(c: Container<String>) {\n    c.data\n}\n";
+    let uri = Url::parse("file:///ref_generic_prop.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    // "data" at line 2, col 6 ("    c." is 6 chars)
+    assert_token_at(
+        &tokens,
+        2,
+        6,
+        prop_type,
+        "PROPERTY access on generic-typed variable receiver",
+    );
+}


### PR DESCRIPTION
First slice of the **CST resolution unification** (design + Phase 1). Stacks on `refactor/unified-resolution`.

## Design (docs)
- `docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md` — the approved design: one `CstResolve` catalogue facade over `InferDeps`, `mod.rs`-as-catalogue, collapse the four parallel CST walks, type-driven correctness, CST-aware navigation for the symbol-identity family. Governing principle: **CST is the source of structure; string parsing is a mistake; keep only genuine heuristics** (e.g. `apply`/`run`/`with` → `ThisLambdaCtx::Receiver`). String path left untouched (it serves go-def/find-refs without a synced project).
- `docs/superpowers/plans/2026-06-30-cst-resolution-phase1-catalogue.md` — the bite-sized plan this PR executes.
- `docs/architecture/parse-to-lsp-paths.md` — reference map of every feature's parse→LSP path + string-vs-CST engine classification.

## Phase 1 (code)
1. **`infer_expr_type` now covers all expression kinds** — moved the ident/nav/`this` dispatch out of `semantic_tokens` so the canonical CST resolver is complete (literals/call/if/range ∪ ident/nav/this).
2. **`CstResolve` catalogue facade** in `indexer/infer/mod.rs`, over `InferDeps`, with the rich self-documenting surface: `expr_type(node, &CstCtx) -> Resolution<ResolvedType>` (`Resolution<T>` = Resolved/Ambiguous/Unresolved; `ResolvedType` carries the type + nullability). Returns are reachability-filtered + (later) subst-applied by construction.
3. **Routed `semantic_tokens` through the catalogue and DELETED its bespoke walk** — `expression_type`, `identifier_type`, `navigation_expression_type`, `call_expression_type` gone (plus `member_return_type`, `token_position` left caller-free). This is the deletion this refactor is about.
4. **`has_type_definition` moved behind `InferDeps`** (default false; real impl on `Indexer`) to keep highlighting behaviour-preserving for bare known-type identifiers.

## Review trail (subagent-driven, reviewed per task)
- Task 1 review: 3 fixes (missing `this` test, documented a fallback equivalence, style).
- Task 2 review: **Approved**.
- Task 3 review: caught a **Critical** regression — `infer_ident_type` returned `find_var_type`'s *generic-preserving* type (`"List<String>"`), missing the exact-key `definition_locations` lookup and silently dropping member tokens on generic-typed receivers. **Fixed** (strip via `dotted_ident_prefix` at the `infer_ident_type` return only — `find_var_type` stays raw for chain inference) + regression test.

## Verification
- `cargo test --bin kmp-lsp`: **1441 passed, 0 failed**.
- `cargo clippy --bin kmp-lsp` clean.
- Net code: semantic-tokens walk deleted; behaviour-preserving (highlighting output unchanged; regression test added for the one case that would have changed).

## Known follow-ups (tracked)
- Hot-path perf: `infer_ident_type` calls `ts_byte_col_to_utf16(&[])` per identifier (O(N) fallback) instead of threading precomputed line starts — correctness OK, perf follow-up.
- Slices 2–6 (route remaining CST consumers; collapse the lambda triad + chain walk; type-driven sweep; CST-aware navigation) are separate future plans per the design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)