### PR TITLE
refactor(infer): route completion 'it' typing through CST; delete find_it_element_type

### DIFF
--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -15,7 +15,7 @@ use tower_lsp::lsp_types::{
 use crate::indexer::resolution::{enrich_at_line, IndexRead, ResolveOptions, SubstitutionContext};
 use crate::indexer::Indexer;
 use crate::indexer::{
-    find_it_element_type, find_named_lambda_param_type, is_lambda_param, last_ident_in,
+    find_it_element_type_in_lines, find_named_lambda_param_type, is_lambda_param, last_ident_in,
 };
 use crate::resolver::complete::{
     complete_symbol, complete_symbol_with_context, is_annotation_context,
@@ -263,7 +263,7 @@ fn complete_lambda_dot(
         })
         .or_else(|| {
             (recv == IT)
-                .then(|| find_it_element_type(site.before, index, site.uri))
+                .then(|| resolve_it_element_type(index, site.position, site.uri))
                 .flatten()
         })
     else {
@@ -327,6 +327,23 @@ fn resolve_named_lambda_param_type(
             line: position.line as usize,
             utf16_col: position.character as usize,
         },
+    )
+}
+
+/// Resolve the element type of `it` at the completion site via the CST-first
+/// lambda resolver (same path used for hover/inlay `it` typing). Uses the real
+/// file lines and cursor position so multi-line lambdas resolve like they do on
+/// the hover path, rather than a same-line `rfind('{')` text scan.
+fn resolve_it_element_type(index: &Indexer, position: Position, uri: &Url) -> Option<String> {
+    let lines = index.lines_for(uri)?;
+    find_it_element_type_in_lines(
+        &lines,
+        CursorPos {
+            line: position.line as usize,
+            utf16_col: position.character as usize,
+        },
+        index,
+        uri,
     )
 }
 

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -166,6 +166,7 @@ pub(crate) fn run_completions(
                         before,
                         position,
                         uri,
+                        lines: lines.as_ref(),
                     },
                     snippets,
                     prefix,
@@ -240,6 +241,7 @@ struct CompletionSite<'a> {
     before: &'a str,
     position: Position,
     uri: &'a Url,
+    lines: &'a [String],
 }
 
 /// Run dot-completion for a lambda receiver (`it.`, `this.`, `this@label.`, or named param).
@@ -263,7 +265,7 @@ fn complete_lambda_dot(
         })
         .or_else(|| {
             (recv == IT)
-                .then(|| resolve_it_element_type(index, site.position, site.uri))
+                .then(|| resolve_it_element_type(index, &site))
                 .flatten()
         })
     else {
@@ -331,19 +333,19 @@ fn resolve_named_lambda_param_type(
 }
 
 /// Resolve the element type of `it` at the completion site via the CST-first
-/// lambda resolver (same path used for hover/inlay `it` typing). Uses the real
-/// file lines and cursor position so multi-line lambdas resolve like they do on
-/// the hover path, rather than a same-line `rfind('{')` text scan.
-fn resolve_it_element_type(index: &Indexer, position: Position, uri: &Url) -> Option<String> {
-    let lines = index.lines_for(uri)?;
+/// lambda resolver (same path used for hover/inlay `it` typing). Reuses the
+/// lines already fetched for this completion request and the real cursor
+/// position, so multi-line lambdas resolve like they do on the hover path
+/// rather than via a same-line `rfind('{')` text scan.
+fn resolve_it_element_type(index: &Indexer, site: &CompletionSite<'_>) -> Option<String> {
     find_it_element_type_in_lines(
-        &lines,
+        site.lines,
         CursorPos {
-            line: position.line as usize,
-            utf16_col: position.character as usize,
+            line: site.position.line as usize,
+            utf16_col: site.position.character as usize,
         },
         index,
-        uri,
+        site.uri,
     )
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -35,7 +35,7 @@ pub(crate) use self::infer::{
     deps::{CallableInfo, InferDeps},
     expr_type::infer_expr_type,
     it_this::{
-        find_it_element_type, find_it_element_type_in_lines, find_named_lambda_param_type,
+        find_it_element_type_in_lines, find_named_lambda_param_type,
         find_named_lambda_param_type_in_lines, find_this_context_in_lines,
         find_this_element_type_in_lines, is_lambda_param, lambda_brace_pos_for_param,
         lambda_param_position_on_line, line_has_lambda_param, ThisContext,

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -4,8 +4,7 @@
 //! no side effects beyond the on-demand file-indexing in `lambda_receiver_type_named_arg_ml`.
 //!
 //! Public surface (re-exported through `infer::mod`):
-//! - `find_it_element_type`            — single-line `it.` completion
-//! - `find_it_element_type_in_lines`   — multi-line hover `it.`
+//! - `find_it_element_type_in_lines`   — multi-line `it.` (hover + completion)
 //! - `find_this_element_type_in_lines` — multi-line hover `this.`
 //! - `find_named_lambda_param_type_in_lines` — hover on named lambda param
 //! - `find_named_lambda_param_type`    — completion for named lambda param
@@ -77,24 +76,7 @@ pub(super) enum LambdaParamKind {
 /// in the text-fallback path of `find_it_element_type_in_lines_impl`.
 pub(super) const IT_SCAN_BACK_LINES: usize = 15;
 
-/// Resolve the element type of `it` when inside a lambda.
-///
-/// Scans `before_cursor` (text from line start to cursor, ending with `it.`)
-/// backward to find the lambda opening `{`, then the callee before it
-/// (e.g. `users.forEach`), then the receiver (`users`).
-///
-/// Delegates to `lambda_receiver_type_from_context` for the actual inference.
-pub(crate) fn find_it_element_type(
-    before_cursor: &str,
-    idx: &Indexer,
-    uri: &Url,
-) -> Option<String> {
-    let brace_byte = before_cursor.rfind('{')?;
-    let before_brace = &before_cursor[..brace_byte];
-    concrete_or_none(lambda_receiver_type_from_context(before_brace, idx, uri))
-}
-
-/// Multi-line version of `find_it_element_type` for hover/goto-def contexts.
+/// Resolve the element type of `it` when inside a lambda (multi-line aware).
 ///
 /// When hovering over `it`, the cursor is ON `it` in the lambda body — which
 /// may be on a DIFFERENT line than the opening `{`.  The simple `rfind('{')` on

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -21,6 +21,18 @@ fn indexed(path: &str, src: &str) -> (Url, Indexer) {
     (u, idx)
 }
 
+/// Test shim for the former single-line `find_it_element_type`: routes
+/// `before_cursor` (text up to the cursor) through the production CST-first
+/// `find_it_element_type_in_lines` with the cursor at end of a one-line file.
+fn find_it_element_type(before_cursor: &str, idx: &Indexer, uri: &Url) -> Option<String> {
+    let lines = vec![before_cursor.to_owned()];
+    let pos = crate::types::CursorPos {
+        line: 0,
+        utf16_col: before_cursor.encode_utf16().count(),
+    };
+    find_it_element_type_in_lines(&lines, pos, idx, uri)
+}
+
 /// Index `sig_src` for signature lookup, plus store a live tree for `code_src`
 /// at the same URI (for CST fast-path tests).
 fn indexed_with_live(path: &str, sig_src: &str, code_src: &str) -> (Url, Indexer, Vec<String>) {

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -24,13 +24,13 @@ fn indexed(path: &str, src: &str) -> (Url, Indexer) {
 /// Test shim for the former single-line `find_it_element_type`: routes
 /// `before_cursor` (text up to the cursor) through the production CST-first
 /// `find_it_element_type_in_lines` with the cursor at end of a one-line file.
-fn find_it_element_type(before_cursor: &str, idx: &Indexer, uri: &Url) -> Option<String> {
+fn find_it_element_type(before_cursor: &str, indexer: &Indexer, uri: &Url) -> Option<String> {
     let lines = vec![before_cursor.to_owned()];
     let pos = crate::types::CursorPos {
         line: 0,
         utf16_col: before_cursor.encode_utf16().count(),
     };
-    find_it_element_type_in_lines(&lines, pos, idx, uri)
+    find_it_element_type_in_lines(&lines, pos, indexer, uri)
 }
 
 /// Index `sig_src` for signature lookup, plus store a live tree for `code_src`

--- a/src/indexer/scope_tests.rs
+++ b/src/indexer/scope_tests.rs
@@ -3,7 +3,7 @@
 use super::extract_class_decl_name;
 use crate::indexer::Indexer;
 use crate::indexer::{
-    find_it_element_type, find_named_lambda_param_type, is_lambda_param,
+    find_it_element_type_in_lines, find_named_lambda_param_type, is_lambda_param,
     lambda_brace_pos_for_param, line_has_lambda_param,
 };
 use crate::queries::KIND_LAMBDA_LIT;
@@ -18,6 +18,17 @@ fn indexed(path: &str, src: &str) -> (Url, Indexer) {
     let indexer = Indexer::new();
     indexer.index_content(&u, src);
     (u, indexer)
+}
+
+/// Test shim for the former single-line `find_it_element_type`: routes
+/// `before_cursor` through the production CST-first `find_it_element_type_in_lines`.
+fn find_it_element_type(before_cursor: &str, idx: &Indexer, uri: &Url) -> Option<String> {
+    let lines = vec![before_cursor.to_owned()];
+    let pos = crate::types::CursorPos {
+        line: 0,
+        utf16_col: before_cursor.encode_utf16().count(),
+    };
+    find_it_element_type_in_lines(&lines, pos, idx, uri)
 }
 
 // ── word_at ──────────────────────────────────────────────────────────────

--- a/src/indexer/scope_tests.rs
+++ b/src/indexer/scope_tests.rs
@@ -22,13 +22,13 @@ fn indexed(path: &str, src: &str) -> (Url, Indexer) {
 
 /// Test shim for the former single-line `find_it_element_type`: routes
 /// `before_cursor` through the production CST-first `find_it_element_type_in_lines`.
-fn find_it_element_type(before_cursor: &str, idx: &Indexer, uri: &Url) -> Option<String> {
+fn find_it_element_type(before_cursor: &str, indexer: &Indexer, uri: &Url) -> Option<String> {
     let lines = vec![before_cursor.to_owned()];
     let pos = crate::types::CursorPos {
         line: 0,
         utf16_col: before_cursor.encode_utf16().count(),
     };
-    find_it_element_type_in_lines(&lines, pos, idx, uri)
+    find_it_element_type_in_lines(&lines, pos, indexer, uri)
 }
 
 // ── word_at ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Step 3 of the CST lambda-triad collapse (`docs/superpowers/plans/2026-07-01-cst-lambda-triad-collapse.md`). Removes the last **pure-text** entry point for `it` type resolution.

`completion.rs` was the only production caller of `find_it_element_type` — a single-line `rfind('{')` scan with **no CST involvement** (Gap 3 in the triad map). It now routes through the CST-first `find_it_element_type_in_lines` via a small `resolve_it_element_type` helper that uses the real file lines + cursor position, exactly like the hover/inlay `it` path.

## Changes

- `features/completion.rs`: swap `find_it_element_type(site.before, …)` → `resolve_it_element_type(index, site.position, site.uri)` (CST-first, multi-line aware).
- `indexer/infer/it_this.rs`: delete `find_it_element_type` (3-line text scan) + its module-doc line; drop the `indexer.rs` re-export.
- Tests: the ~16 unit-test callers move to a per-test-file shim that routes single-line `before` strings through `find_it_element_type_in_lines` (same text fallback when no live tree) — behaviour-preserving coverage.

## Verification

- `cargo test --bin kmp-lsp` — **1441 passed**, 0 failed (unchanged count).
- `cargo clippy --bin kmp-lsp` — clean.

Stacked on #196 (merged into `refactor/unified-resolution`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)