### PR TITLE
refactor(infer): CST-resolve stdlib collection 'it' (close Gap 1); type the lambda walk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ kmp-lsp is a Kotlin Language Server Protocol implementation in Rust. The binary 
 
 ## Code Quality
 - **Rust types model behaviour** — code should be obvious in retrospect.
+- **Reach for a type before reaching for a comment.** When you feel the need to explain control flow — why a fallback exists, what a `None`/empty result means, which order branches run, whether a string is still a placeholder — first ask whether an enum, newtype, or struct would encode that meaning so the compiler carries it and the signature tells the story. Prefer `enum Outcome { Resolved(T), KeepWalking }` over `Option<T>` + a comment; prefer a `ResolvedType` that distinguishes concrete vs. generic over an `is_generic(&str)` sniff. Keep comments for irreducible domain knowledge (e.g. *why* `apply` means `this` = receiver), not for scaffolding the types should hold.
 - **No abbreviated names.** Never use single-letter or short variable names like `s`, `c`, `ty`, `rt`, `sym`, `loc`, `p`, `diags`. Use full words: `string`, `char`, `type`, `receiver`, `symbol`, `location`, `package`, `diagnostics`.
 - **Explicit over clever.** Split compound boolean expressions into named variables. Avoid chained combinators when a simple conditional is clearer.
 - **Every fix must include a test.** If a bug slips through, the test should have caught it.

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -266,12 +266,11 @@ pub(super) fn cst_forward_resolve_receiver_type(
     if SCOPE_FUNCTIONS.contains(&final_method.as_str()) {
         return Some(root_type);
     }
-    // For collection iteration functions (`forEach`/`map`/`filter`/…) that carry
-    // no indexed signature, `it` is the element type of the receiver collection
-    // (`items: List<Product>` → `Product`). This mirrors the text path's
-    // `inferred_receiver_lambda_type` collection branch, fed from the CST-resolved
-    // receiver type instead of a backward text scan. Returns `None` for
-    // non-collection receivers, preserving the previous behaviour there.
+    // Otherwise, when the receiver itself is a known collection type, `it` is its
+    // element type (`items: List<Product>` → `Product` for `forEach`/`map`/…).
+    // The decision is on the receiver *type*, not the method name — matching the
+    // text path's `extract_collection_element_type`, which likewise keys off the
+    // collection type. Non-collection receivers yield `None` (unchanged).
     extract_collection_element_type(&root_type)
 }
 

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -7,6 +7,7 @@ use crate::queries::{
     KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_CLASS_DECL, KIND_LAMBDA_LIT, KIND_NAV_EXPR,
     KIND_NAV_SUFFIX, KIND_OBJECT_DECL, KIND_SIMPLE_IDENT, KIND_STATEMENTS, KIND_TYPE_IDENT,
 };
+use crate::resolver::extract_collection_element_type;
 use crate::StrExt;
 
 use super::deps::InferDeps;
@@ -261,12 +262,17 @@ pub(super) fn cst_forward_resolve_receiver_type(
     //   root = "settings", segments = ["familyCreationDate", "let"]
     let (root_type, final_method) = resolve_callee_chain(callee, bytes, deps, uri)?;
 
-    // For scope functions, `it` type is the receiver type.
-    // For collection methods (map/filter/etc), we'd need more complex logic.
+    // For scope functions, `it` type IS the receiver type (`user.let { it }` → User).
     if SCOPE_FUNCTIONS.contains(&final_method.as_str()) {
         return Some(root_type);
     }
-    None
+    // For collection iteration functions (`forEach`/`map`/`filter`/…) that carry
+    // no indexed signature, `it` is the element type of the receiver collection
+    // (`items: List<Product>` → `Product`). This mirrors the text path's
+    // `inferred_receiver_lambda_type` collection branch, fed from the CST-resolved
+    // receiver type instead of a backward text scan. Returns `None` for
+    // non-collection receivers, preserving the previous behaviour there.
+    extract_collection_element_type(&root_type)
 }
 
 /// Resolve the receiver type that flows into a call expression's lambda.

--- a/src/indexer/infer/cst_lambda.rs
+++ b/src/indexer/infer/cst_lambda.rs
@@ -477,11 +477,10 @@ pub(super) fn cst_this_context(
     ThisContext::NotFound
 }
 
-/// Resolve `it`'s element/receiver type for one non-named lambda, in priority
-/// order: the indexed-function CST resolver, then the unindexed scope/collection
-/// receiver-chain walk, then the named-argument multi-line text heuristic. A
-/// generic placeholder from the text heuristic is concretized through the
-/// receiver chain here, so the caller receives only [`ItTypeAtLambda`].
+/// Resolve `it`'s element/receiver type for one non-named lambda. A generic
+/// placeholder from the trailing text heuristic is concretized through the
+/// receiver chain here, so the caller receives only a concrete type or
+/// [`ItTypeAtLambda::KeepWalking`] — never a bare type-parameter name.
 fn it_type_at_lambda(
     lambda: &tree_sitter::Node<'_>,
     doc: &crate::indexer::live_tree::LiveDoc,

--- a/src/indexer/infer/cst_lambda.rs
+++ b/src/indexer/infer/cst_lambda.rs
@@ -19,8 +19,7 @@ use super::it_this::IT_SCAN_BACK_LINES;
 use super::lambda::{lambda_type_nth_input, lambda_type_receiver, RECEIVER_THIS_FNS};
 use super::lambda_resolution::{ExtractedTypeKind, GenericParamSource, LambdaParamResolution};
 use super::receiver::{
-    fun_trailing_lambda_this_type, lambda_receiver_type_from_context,
-    lambda_receiver_type_named_arg_ml, resolve_call_params,
+    fun_trailing_lambda_this_type, lambda_receiver_type_named_arg_ml, resolve_call_params,
 };
 use super::sig::{last_fun_param_type_str, nth_fun_param_type_str, strip_trailing_call_args};
 use super::type_subst::{
@@ -61,6 +60,18 @@ impl CstParamResult {
             CstParamResult::TryFallback | CstParamResult::AuthoritativeNone => None,
         }
     }
+}
+
+/// Outcome of resolving `it`'s type at one lambda during the ancestor walk in
+/// [`cst_it_or_this_type`]. The variant *is* the walk decision, so the caller
+/// matches on it instead of re-inspecting the resolved string to decide whether
+/// to stop or keep climbing.
+enum ItTypeAtLambda {
+    /// Concrete type resolved at this lambda — stop the walk and return it.
+    Resolved(String),
+    /// Nothing usable here (no match, or only an unresolved generic placeholder
+    /// the receiver chain could not concretize) — climb to the enclosing lambda.
+    KeepWalking,
 }
 
 /// Tri-state result of classifying a lambda's `this`-receiver context.
@@ -466,6 +477,40 @@ pub(super) fn cst_this_context(
     ThisContext::NotFound
 }
 
+/// Resolve `it`'s element/receiver type for one non-named lambda, in priority
+/// order: the indexed-function CST resolver, then the unindexed scope/collection
+/// receiver-chain walk, then the named-argument multi-line text heuristic. A
+/// generic placeholder from the text heuristic is concretized through the
+/// receiver chain here, so the caller receives only [`ItTypeAtLambda`].
+fn it_type_at_lambda(
+    lambda: &tree_sitter::Node<'_>,
+    doc: &crate::indexer::live_tree::LiveDoc,
+    before_brace: &str,
+    lines: &[String],
+    line: usize,
+    idx: &Indexer,
+    uri: &Url,
+) -> ItTypeAtLambda {
+    if let Some(resolution) = locate_and_extract(lambda, doc, idx, uri, 0) {
+        if let Some(resolved) = finalize_resolution(resolution, &doc.bytes, idx, uri) {
+            return ItTypeAtLambda::Resolved(resolved);
+        }
+    }
+    if let Some(resolved) = cst_lambda_param_type_via_call(doc, lambda, idx, uri, 0).into_option() {
+        return ItTypeAtLambda::Resolved(resolved);
+    }
+    match lambda_receiver_type_named_arg_ml(before_brace, 0, lines, line, idx, uri) {
+        Some(placeholder) if is_generic_param(&placeholder) => {
+            match cst_forward_resolve_receiver_type(lambda, &doc.bytes, idx, uri) {
+                Some(concrete) => ItTypeAtLambda::Resolved(concrete),
+                None => ItTypeAtLambda::KeepWalking,
+            }
+        }
+        Some(resolved) => ItTypeAtLambda::Resolved(resolved),
+        None => ItTypeAtLambda::KeepWalking,
+    }
+}
+
 /// Walk ancestors from `start_node` looking for a `lambda_literal` without
 /// named params, then infer the `it`/`this` type for that lambda.
 ///
@@ -524,38 +569,9 @@ pub(super) fn cst_it_or_this_type(
                     ThisLambdaCtx::NotReceiver => {}
                 }
             } else {
-                // CST-first: use the unified resolver (no rg spawns, HashMap only).
-                log::trace!("cst_it_or_this_type: trying locate_and_extract");
-                if let Some(resolution) = locate_and_extract(&cur, doc, idx, uri, 0) {
-                    if let Some(resolved) = finalize_resolution(resolution, &doc.bytes, idx, uri) {
-                        log::trace!("cst_it_or_this_type: CST resolved to {resolved}");
-                        return Some(resolved);
-                    }
-                }
-                log::trace!("cst_it_or_this_type: CST resolver returned None, trying text fallback with before_brace={before_brace:?}");
-                // Text fallback for cases the CST resolver can't handle yet
-                // (function not indexed, no call_expression parent).
-                let result = lambda_receiver_type_from_context(&before_brace, idx, uri)
-                    .or_else(|| {
-                        lambda_receiver_type_named_arg_ml(&before_brace, 0, lines, ln, idx, uri)
-                    })
-                    .or_else(|| {
-                        cst_lambda_param_type_via_call(doc, &cur, idx, uri, 0).into_option()
-                    });
-                match result.as_deref() {
-                    Some(t) if is_generic_param(t) => {
-                        if let Some(concrete) =
-                            cst_forward_resolve_receiver_type(&cur, &doc.bytes, idx, uri)
-                        {
-                            return Some(concrete);
-                        }
-                        // Generic placeholder not resolvable — skip this lambda, keep walking
-                        let p = cur.parent()?;
-                        cur = p;
-                        continue;
-                    }
-                    Some(_) => return result,
-                    None => {}
+                match it_type_at_lambda(&cur, doc, &before_brace, lines, ln, idx, uri) {
+                    ItTypeAtLambda::Resolved(resolved) => return Some(resolved),
+                    ItTypeAtLambda::KeepWalking => {}
                 }
             }
         }

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -163,6 +163,27 @@ fn it_type_first_lambda_multiline_unindexed_inner() {
     );
 }
 
+/// Gap-1 closure: `items.forEach { it }` where `forEach` carries no indexed
+/// signature must resolve `it` to the receiver collection's element type through
+/// the CST receiver-chain walk — with a live tree present the CST path is
+/// exercised (not the text fallback), proving it is self-sufficient here.
+#[test]
+fn it_type_unindexed_foreach_resolves_collection_element_via_cst() {
+    let src = "val items: List<Product> = emptyList()\nitems.forEach { it }";
+    let (u, idx, lines) = indexed_with_live("/t.kt", src, src);
+    // Line 1: "items.forEach { it }" — `it` at col 17.
+    let pos = crate::types::CursorPos {
+        line: 1,
+        utf16_col: 17,
+    };
+    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    assert_eq!(
+        result.as_deref(),
+        Some("Product"),
+        "unindexed forEach on List<Product> should yield element type Product via CST"
+    );
+}
+
 // ── find_this_element_type_in_lines ─────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Step 2 of the CST lambda-triad collapse — the **keystone** that makes the CST `it` path self-sufficient, plus a type-driven remodel of the walk and an agent rule.

### Close Gap 1 — stdlib collection `it`
`items.forEach { it }` where `forEach` carries no indexed signature previously fell through the CST resolver to a backward **text scan**. `cst_forward_resolve_receiver_type` now extracts the receiver collection's element type (`items: List<Product>` → `Product`) from the CST-resolved receiver, mirroring the text path's `inferred_receiver_lambda_type` collection branch. Returns `None` for non-collection receivers (no behaviour change there).

### Type the walk outcome (your "types over comments" call)
With the CST path self-sufficient, the `it` branch of `cst_it_or_this_type` drops its `lambda_receiver_type_from_context` text fallback and is remodelled:

- `it_type_at_lambda(...) -> ItTypeAtLambda { Resolved(String) | KeepWalking }` folds the generic-placeholder forward-resolve inside.
- The caller matches the outcome instead of re-sniffing the resolved string (`is_generic_param`) and re-deriving whether to stop or climb.

The `.or_else(...).or_else(...)` + `match ... if is_generic_param` ladder (and its three explanatory comments) becomes a 3-line `match`.

### Agent rule
`AGENTS.md`: *reach for a type before reaching for a comment* — control-flow comments (why a fallback exists, what `None` means, branch order, placeholder-vs-concrete) are a weak-type smell; encode them in an enum/newtype. Comments stay for irreducible domain knowledge.

## Verification

- Decoy test `it_type_unindexed_foreach_resolves_collection_element_via_cst` — **fails without** the chain.rs enhancement, passes with it (proves the collection case resolves through the CST path with a live tree).
- `cargo test --bin kmp-lsp` — **1442 passed**, 0 failed.
- `cargo clippy --bin kmp-lsp` — clean.

Stacked on #198 (Step 3). Retarget to `refactor/unified-resolution` once #198 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)