### PR TITLE
refactor(completion): rewrite lambda scope-context onto the CST ancestor-walk

### DIFF
--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -143,14 +143,7 @@ pub(crate) fn run_completions(
 
     let annotation_only = is_annotation_context(before, prefix);
     let lines = index.lines_for(uri).unwrap_or_default();
-    let ctx = CompletionContext::analyse(
-        before_prefix,
-        position,
-        index,
-        uri,
-        lines.as_ref(),
-        annotation_only,
-    );
+    let ctx = CompletionContext::analyse(before_prefix, position, index, uri, annotation_only);
 
     if let Some(ref recv) = ctx.receiver {
         let recv_str = recv.as_str();

--- a/src/features/completion_context.rs
+++ b/src/features/completion_context.rs
@@ -3,15 +3,13 @@ use tower_lsp::lsp_types::{Position, Url};
 use crate::features::completion::param_names_from_sig;
 use crate::features::traits::{LiveTreeAccess, SignatureIndex};
 use crate::indexer::{
-    lambda_receiver_type_from_context, last_ident_in, split_params_at_depth_zero,
-    strip_trailing_call_args, Indexer,
+    cursor_node_at, split_params_at_depth_zero, CstQuery, Indexer, LambdaScopeInfo, ResolveIo,
 };
 use crate::resolver::complete::ReceiverExpr;
-use crate::StrExt;
+use crate::types::CursorPos;
 
 const IT: &str = "it";
 const THIS: &str = "this";
-const SCOPE_SCAN_BACK_LINES: usize = 50;
 
 pub(crate) struct LambdaScope {
     /// Type of the implicit `it` parameter (if single-param lambda).
@@ -21,6 +19,16 @@ pub(crate) struct LambdaScope {
     /// Lambda label — the call name just before `{`, e.g. `forEach { }` → `"forEach"`.
     /// Used to resolve `this@forEach` / `this@label` references.
     pub label: Option<String>,
+}
+
+impl From<LambdaScopeInfo> for LambdaScope {
+    fn from(info: LambdaScopeInfo) -> Self {
+        Self {
+            it_type: info.it_type,
+            named_params: info.named_params,
+            label: info.label,
+        }
+    }
 }
 
 pub(crate) struct ScopeContext {
@@ -62,10 +70,9 @@ impl CompletionContext {
         position: Position,
         index: &Indexer,
         uri: &Url,
-        lines: &[String],
         annotation_only: bool,
     ) -> Self {
-        let scope = ScopeContext::build(lines, position.line, position.character, index, uri);
+        let scope = ScopeContext::build(position, index, uri);
         let call_info = build_call_info(position, index, uri);
         Self {
             receiver: ReceiverExpr::parse(before_prefix),
@@ -107,30 +114,17 @@ fn param_type_at(raw: &str, idx: usize) -> Option<String> {
 
 impl ScopeContext {
     /// Build scope context from the current cursor position.
-    pub(crate) fn build(
-        lines: &[String],
-        cursor_line: u32,
-        cursor_col: u32,
-        index: &Indexer,
-        uri: &Url,
-    ) -> Self {
-        let position = Position::new(cursor_line, cursor_col);
-        let enclosing_class = index.enclosing_class_at(uri, cursor_line);
+    pub(crate) fn build(position: Position, index: &Indexer, uri: &Url) -> Self {
+        let cursor_line = position.line as usize;
+        let cursor_col = position.character as usize;
+        let enclosing_class = index.enclosing_class_at(uri, position.line);
         let bare_this_type = index
             .infer_lambda_param_type_at(THIS, uri, position)
             .or_else(|| enclosing_class.clone());
-        let mut lambda_scopes = collect_lambda_scopes(
-            lines,
-            cursor_line as usize,
-            cursor_col as usize,
-            index,
-            uri,
-            position,
-        );
-        let mut param_names =
-            index.lambda_params_at_col(uri, cursor_line as usize, cursor_col as usize);
+        let mut lambda_scopes = collect_lambda_scopes(index, uri, position);
+        let mut param_names = index.lambda_params_at_col(uri, cursor_line, cursor_col);
         if param_names.is_empty() {
-            param_names = index.lambda_params_at(uri, cursor_line as usize);
+            param_names = index.lambda_params_at(uri, cursor_line);
         }
         merge_named_params(&mut lambda_scopes, param_names, index, uri, position);
         if let Some(innermost_scope) = lambda_scopes.last_mut() {
@@ -199,52 +193,27 @@ fn resolve_labeled_receiver<'a>(scope: &'a ScopeContext, expr: &str) -> Option<&
         })
 }
 
-fn collect_lambda_scopes(
-    lines: &[String],
-    cursor_line: usize,
-    cursor_col: usize,
-    index: &Indexer,
-    uri: &Url,
-    position: Position,
-) -> Vec<LambdaScope> {
-    if lines.is_empty() {
+/// Build the scope stack for every lambda enclosing the cursor via the CST
+/// ancestor-walk (`CstQuery::lambda_scope`), outermost first.
+///
+/// The tree comes from `live_doc_or_parse`: the live tree for open files, a
+/// transient parse otherwise — completion works the same either way.
+fn collect_lambda_scopes(index: &Indexer, uri: &Url, position: Position) -> Vec<LambdaScope> {
+    let Some(doc) = index.live_doc_or_parse(uri) else {
         return Vec::new();
-    }
-
-    let scan_start = cursor_line.saturating_sub(SCOPE_SCAN_BACK_LINES);
-    let mut depth = 0i32;
-    let mut scopes = Vec::new();
-
-    for line_index in (scan_start..=cursor_line).rev() {
-        let Some(line) = lines.get(line_index) else {
-            continue;
-        };
-        let scan_slice = line_before_cursor(line, line_index, cursor_line, cursor_col);
-        for (byte_index, ch) in scan_slice.char_indices().rev() {
-            match ch {
-                '}' => depth += 1,
-                '{' => {
-                    depth -= 1;
-                    if depth >= 0 || scan_slice[..byte_index].ends_with('$') {
-                        if scan_slice[..byte_index].ends_with('$') {
-                            depth = 0;
-                        }
-                        continue;
-                    }
-                    if let Some(scope) =
-                        build_lambda_scope(scan_slice, byte_index, index, uri, position)
-                    {
-                        scopes.push(scope);
-                    }
-                    depth = 0;
-                }
-                _ => {}
-            }
-        }
-    }
-
-    scopes.reverse();
-    scopes
+    };
+    let cursor = CursorPos {
+        line: position.line as usize,
+        utf16_col: position.character as usize,
+    };
+    let Some(node) = cursor_node_at(&doc, cursor) else {
+        return Vec::new();
+    };
+    CstQuery::new(node, &doc, index, uri, ResolveIo::NoRg)
+        .lambda_scope()
+        .into_iter()
+        .map(LambdaScope::from)
+        .collect()
 }
 
 fn merge_named_params(
@@ -282,82 +251,6 @@ fn merge_named_params(
             .unwrap_or_default();
         innermost_scope.named_params.push((param_name, param_type));
     }
-}
-
-fn build_lambda_scope(
-    scan_slice: &str,
-    brace_byte: usize,
-    index: &Indexer,
-    uri: &Url,
-    position: Position,
-) -> Option<LambdaScope> {
-    let before_brace = &scan_slice[..brace_byte];
-    let named_params = parse_named_params(&scan_slice[brace_byte + 1..], index, uri, position);
-    let it_type = lambda_receiver_type_from_context(before_brace, index, uri);
-    if named_params.is_empty() && it_type.is_none() {
-        return None;
-    }
-    Some(LambdaScope {
-        it_type,
-        named_params,
-        label: lambda_label(before_brace),
-    })
-}
-
-fn parse_named_params(
-    after_brace: &str,
-    index: &Indexer,
-    uri: &Url,
-    position: Position,
-) -> Vec<(String, String)> {
-    let trimmed = after_brace.trim_start();
-    let Some((names, _)) = trimmed.split_once("->") else {
-        return Vec::new();
-    };
-
-    let mut named_params = Vec::new();
-    for token in names.split(',') {
-        let name = token.trim().ident_prefix();
-        if should_collect_named_param(&name, &named_params) {
-            let param_type = index
-                .infer_lambda_param_type_at(&name, uri, position)
-                .unwrap_or_default();
-            named_params.push((name, param_type));
-        }
-    }
-    named_params
-}
-
-fn should_collect_named_param(name: &str, named_params: &[(String, String)]) -> bool {
-    !name.is_empty()
-        && name != IT
-        && name != "_"
-        && name.starts_with_lowercase()
-        && !named_params
-            .iter()
-            .any(|(existing_name, _)| existing_name == name)
-}
-
-fn lambda_label(before_brace: &str) -> Option<String> {
-    let callee = strip_trailing_call_args(before_brace)
-        .replace("?.", ".")
-        .trim()
-        .to_owned();
-    let label = last_ident_in(&callee);
-    (!label.is_empty()).then(|| label.to_owned())
-}
-
-fn line_before_cursor(
-    line: &str,
-    line_index: usize,
-    cursor_line: usize,
-    cursor_col: usize,
-) -> &str {
-    if line_index != cursor_line {
-        return line;
-    }
-    let byte_end = crate::indexer::live_tree::utf16_col_to_byte(line, cursor_col);
-    &line[..byte_end]
 }
 
 #[cfg(test)]

--- a/src/features/completion_context_tests.rs
+++ b/src/features/completion_context_tests.rs
@@ -77,15 +77,39 @@ fn call_paren_col(src: &str, line_no: usize, fn_name: &str) -> u32 {
 }
 
 #[test]
+fn lambda_scope_found_beyond_backward_scan_window() {
+    // The enclosing lambda opens more than 50 lines above the cursor: a
+    // bounded backward text-scan never sees it, while the CST ancestor-walk
+    // finds every enclosing lambda regardless of distance.
+    let mut src = String::from(
+        "package com.example\n\
+         class Item { val price: Int = 0 }\n\
+         fun main() {\n\
+         \x20   val items: List<Item> = listOf()\n\
+         \x20   items.forEach {\n",
+    );
+    for filler in 0..60 {
+        src.push_str(&format!("        val filler{filler} = {filler}\n"));
+    }
+    src.push_str("        \n    }\n}\n");
+    let (uri, index) = indexed_with_live("/FarLambda.kt", &src);
+    let cursor_line = 65u32; // the blank body line, 61 lines below the `{`
+
+    let scope = ScopeContext::build(Position::new(cursor_line, 8), &index, &uri);
+
+    assert_eq!(scope.resolve_receiver("it"), Some("Item"));
+    assert_eq!(scope.resolve_receiver("this@forEach"), Some("Item"));
+}
+
+#[test]
 fn call_info_expected_name_at_first_arg() {
     let src =
         "package com.example\nfun greet(name: String, age: Int) {}\nfun main() {\n    greet()\n}\n";
     let (uri, index) = indexed_with_live("/CallInfo.kt", src);
     let position = Position::new(3, call_paren_col(src, 3, "greet"));
-    let lines: Vec<String> = src.lines().map(str::to_owned).collect();
     let before_prefix = src.lines().nth(3).unwrap()[..position.character as usize].to_owned();
 
-    let ctx = CompletionContext::analyse(&before_prefix, position, &index, &uri, &lines, false);
+    let ctx = CompletionContext::analyse(&before_prefix, position, &index, &uri, false);
 
     let call_info = ctx.call_info.expect("call_info should be populated");
     assert_eq!(call_info.callee, "greet");
@@ -99,10 +123,9 @@ fn call_info_expected_name_none_when_not_in_call() {
     let src = "package com.example\nfun main() {\n    val value = 1\n    value\n}\n";
     let (uri, index) = indexed_with_live("/NoCallInfo.kt", src);
     let position = Position::new(3, 9);
-    let lines: Vec<String> = src.lines().map(str::to_owned).collect();
     let before_prefix = src.lines().nth(3).unwrap()[..position.character as usize].to_owned();
 
-    let ctx = CompletionContext::analyse(&before_prefix, position, &index, &uri, &lines, false);
+    let ctx = CompletionContext::analyse(&before_prefix, position, &index, &uri, false);
 
     assert!(
         ctx.call_info.is_none(),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -32,6 +32,7 @@ pub(crate) use self::infer::{
         find_named_param_type_in_sig, has_named_params_not_it,
     },
     cst_cursor::{cst_call_info, cst_cursor_is_local_var, cst_outer_call_info, CallInfo},
+    cst_lambda::{cursor_node_at, LambdaScopeInfo},
     deps::{CallableInfo, InferDeps, OuterScopedParams},
     expr_type::infer_expr_type,
     it_this::{

--- a/src/indexer/infer/cst_lambda.rs
+++ b/src/indexer/infer/cst_lambda.rs
@@ -19,7 +19,8 @@ use super::it_this::IT_SCAN_BACK_LINES;
 use super::lambda::{lambda_type_nth_input, lambda_type_receiver, RECEIVER_THIS_FNS};
 use super::lambda_resolution::{ExtractedTypeKind, GenericParamSource, LambdaParamResolution};
 use super::receiver::{
-    fun_trailing_lambda_this_type, lambda_receiver_type_named_arg_ml, resolve_call_params,
+    fun_trailing_lambda_this_type, lambda_receiver_type_from_context,
+    lambda_receiver_type_named_arg_ml, resolve_call_params,
 };
 use super::sig::{last_fun_param_type_str, nth_fun_param_type_str, strip_trailing_call_args};
 use super::type_subst::{
@@ -349,7 +350,7 @@ pub(crate) fn is_inside_receiver_lambda(
     false
 }
 
-pub(super) fn cursor_node_at(
+pub(crate) fn cursor_node_at(
     doc: &crate::indexer::live_tree::LiveDoc,
     pos: CursorPos,
 ) -> Option<tree_sitter::Node<'_>> {
@@ -401,15 +402,7 @@ pub(super) fn cst_named_lambda_param_type(
     };
     while let Some(lambda) = cur.enclosing_lambda_literal() {
         if let Some(param_pos) = lambda.lambda_param_position(param_name, &doc.bytes) {
-            // Try the full substitution path (handles generic extension fns like
-            // forEachIndexed where the param type is a type parameter of the receiver).
-            if let Some(result) = locate_and_extract(&lambda, doc, idx, uri, param_pos)
-                .and_then(|res| finalize_resolution(res, &doc.bytes, idx, uri))
-            {
-                return CstParamResult::Resolved(result);
-            }
-            // Fallback: scope functions, non-generic, or unresolvable chains.
-            return cst_lambda_param_type_via_call(doc, &lambda, idx, uri, param_pos);
+            return cst_lambda_param_type_at(&lambda, doc, idx, uri, param_pos);
         }
         let Some(parent) = lambda.parent() else {
             break;
@@ -417,6 +410,140 @@ pub(super) fn cst_named_lambda_param_type(
         cur = parent;
     }
     CstParamResult::Unresolved
+}
+
+/// Resolve the type of the parameter at `param_pos` for a single
+/// `lambda_literal` node.
+///
+/// Tries the full substitution path first (handles generic extension fns like
+/// `forEachIndexed`, where the param type is a type parameter of the receiver),
+/// then the structural call fallback (scope functions, non-generic, or
+/// unresolvable chains).
+fn cst_lambda_param_type_at(
+    lambda: &tree_sitter::Node<'_>,
+    doc: &crate::indexer::live_tree::LiveDoc,
+    deps: &impl InferDeps,
+    uri: &Url,
+    param_pos: usize,
+) -> CstParamResult {
+    if let Some(resolved) = locate_and_extract(lambda, doc, deps, uri, param_pos)
+        .and_then(|resolution| finalize_resolution(resolution, &doc.bytes, deps, uri))
+    {
+        return CstParamResult::Resolved(resolved);
+    }
+    cst_lambda_param_type_via_call(doc, lambda, deps, uri, param_pos)
+}
+
+/// Completion-scope facts for one enclosing lambda, produced by the CST
+/// ancestor walk in [`cst_lambda_scopes`].
+///
+/// Field-compatible with the completion feature's `LambdaScope`; the feature
+/// converts each entry without re-deriving anything.
+pub(crate) struct LambdaScopeInfo {
+    /// Type of the implicit `it` parameter, when the enclosing call gives one.
+    pub it_type: Option<String>,
+    /// Named lambda parameters in declaration order: `(name, type)`.
+    pub named_params: Vec<(String, String)>,
+    /// Lambda label — the call name just before `{` (`forEach { }` → `forEach`),
+    /// used to resolve `this@forEach` / `this@label` references.
+    pub label: Option<String>,
+}
+
+/// Walk the CST ancestor chain from `start_node`, building a scope for every
+/// enclosing `lambda_literal`. The result is ordered outermost-first,
+/// innermost-last — the order the completion scope stack consumes.
+///
+/// This subsumes the old bounded backward brace-scan: ancestor walking finds
+/// every enclosing lambda regardless of distance or intervening sibling
+/// lambdas, and never mis-balances braces inside strings or comments.
+pub(super) fn cst_lambda_scopes(
+    start_node: tree_sitter::Node<'_>,
+    doc: &crate::indexer::live_tree::LiveDoc,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Vec<LambdaScopeInfo> {
+    let mut scopes = Vec::new();
+    let mut cur = start_node;
+    loop {
+        if cur.kind() == KIND_LAMBDA_LIT {
+            if let Some(scope) = lambda_scope_info(cur, doc, deps, uri) {
+                scopes.push(scope);
+            }
+        }
+        let Some(parent) = cur.parent() else { break };
+        cur = parent;
+    }
+    scopes.reverse();
+    scopes
+}
+
+/// Build the completion scope for a single `lambda_literal`, or `None` when it
+/// contributes neither an `it` type nor any usable named parameter.
+fn lambda_scope_info(
+    lambda: tree_sitter::Node<'_>,
+    doc: &crate::indexer::live_tree::LiveDoc,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<LambdaScopeInfo> {
+    let (before_brace, _row) = lambda_before_brace_context(lambda, doc)?;
+    let named_params = lambda_named_param_types(lambda, doc, deps, uri);
+    let it_type = lambda_receiver_type_from_context(&before_brace, deps, uri);
+    if named_params.is_empty() && it_type.is_none() {
+        return None;
+    }
+    Some(LambdaScopeInfo {
+        it_type,
+        named_params,
+        label: lambda_label(&before_brace),
+    })
+}
+
+/// Type every collectable named parameter of `lambda` against its declared
+/// position in the lambda's parameter list.
+fn lambda_named_param_types(
+    lambda: tree_sitter::Node<'_>,
+    doc: &crate::indexer::live_tree::LiveDoc,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Vec<(String, String)> {
+    let mut named = Vec::new();
+    for (position, name) in lambda
+        .lambda_param_names(&doc.bytes)
+        .into_iter()
+        .enumerate()
+    {
+        if !is_collectable_named_param(&name, &named) {
+            continue;
+        }
+        let param_type = cst_lambda_param_type_at(&lambda, doc, deps, uri, position)
+            .into_option()
+            .unwrap_or_default();
+        named.push((name, param_type));
+    }
+    named
+}
+
+/// A lambda parameter contributes to the completion scope only when it is a
+/// real user-named binding: non-empty, not the implicit `it`, not the `_`
+/// discard, lowercase-led (types never lead a param name), and not already
+/// collected for this lambda.
+fn is_collectable_named_param(name: &str, collected: &[(String, String)]) -> bool {
+    !name.is_empty()
+        && name != "it"
+        && name != "_"
+        && name.starts_with_lowercase()
+        && !collected.iter().any(|(existing, _)| existing == name)
+}
+
+/// The lambda label: the trailing identifier of the call that opens the lambda
+/// (`items.forEach {` → `forEach`), used to resolve `this@label`.
+fn lambda_label(before_brace: &str) -> Option<String> {
+    let callee = strip_trailing_call_args(before_brace)
+        .replace("?.", ".")
+        .trim()
+        .to_owned();
+    let label = last_ident_in(&callee);
+    (!label.is_empty()).then(|| label.to_owned())
 }
 
 fn cst_with_receiver_ctx(

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -171,6 +171,16 @@ impl<'a, D: InferDeps> CstQuery<'a, D> {
         Self { node, ..*self }
     }
 
+    /// Build the completion scope for every lambda enclosing the bound node.
+    ///
+    /// Walks the CST ancestor chain from the node, producing one
+    /// [`cst_lambda::LambdaScopeInfo`] per enclosing `lambda_literal` that
+    /// contributes an `it` type or named parameters — ordered outermost first,
+    /// innermost last (the order the completion scope stack consumes).
+    pub(crate) fn lambda_scope(&self) -> Vec<cst_lambda::LambdaScopeInfo> {
+        cst_lambda::cst_lambda_scopes(self.node, self.doc, self.deps, self.uri)
+    }
+
     /// Infer the type of the bound expression node.
     ///
     /// Covers literals, identifiers, navigation expressions, call expressions,


### PR DESCRIPTION
## Summary

Task 7 of the CST lambda-triad collapse — the hardest step: the completion scope-context builder (`build_lambda_scope`) was the last *architectural* text scan, assembling `LambdaScope` for ALL enclosing lambdas via a 50-line backward line-walk. It is now a CST ancestor-walk.

- New `cst_lambda_scopes` walk in the catalogue, exposed as `CstQuery::lambda_scope` (generic over `D: InferDeps` — TestDeps keeps driving the engine); tree via `Indexer::live_doc_or_parse` (universal CST path).
- `completion_context.rs` consumes the walk; the direct `lambda_receiver_type_from_context` call and import are gone from this module (the function itself stays until Tasks 6/9 remove its remaining callers).
- Deleted: the old `collect_lambda_scopes`/`build_lambda_scope` text bodies, `parse_named_params`, `should_collect_named_param`, `lambda_label` (relocated into the catalogue), `line_before_cursor`, `SCOPE_SCAN_BACK_LINES`.
- Extracted `cst_lambda_param_type_at`, shared between the named-param resolver and the walk.

## Behavior

Verified subsumption, not just claimed: the scope-name consumers (`resolve_receiver`, `named_param_type`) iterate innermost-first, so every previously-answered input keeps its answer. The walk additionally covers what the 50-line cap and single-line lambda-header parsing missed (decoy test: lambda opening 61 lines up — old path `None`, new path resolves). Known pre-existing quirk now more visible: `resolve_labeled_receiver` iterates outermost-first; duplicate `this@label` collisions spanning >50 lines can differ (follow-up noted in the ledger).

## Verification

- `cargo test --bin kmp-lsp` — **1441 passed**, 0 failed (baseline 1438 + 2 named-arg decoys from the s5 base + 1 scope-walk decoy).
- `cargo clippy --bin kmp-lsp` — clean. Decoy test RED→GREEN evidence in the task report.
- Task-scoped review (spec + quality): Approved, no Critical/Important findings.

Stacked on #200 (`refactor/cst-resolution-s5`). Remaining plan steps: Task 6 (`it` text-body deletion), Task 8 (receiver.rs deletion), Task 9 (dead helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJsyQ1UgF8uJYR4HgpxEBB