### PR TITLE
fix(completion): offer implicit receiver members in bare completion

### DIFF
--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -186,6 +186,11 @@ pub(crate) fn run_completions(
     );
 
     if ctx.receiver.is_none() {
+        if !ctx.annotation_only {
+            add_implicit_receiver_member_completions(
+                &mut items, index, &ctx.scope, prefix, uri, snippets, position,
+            );
+        }
         add_lambda_param_completions(&mut items, &ctx.scope, prefix);
         add_named_arg_completions(index, &mut items, uri, prefix, ctx.call_info.as_ref());
     }
@@ -328,6 +333,34 @@ fn resolve_named_lambda_param_type(
             utf16_col: position.character as usize,
         },
     )
+}
+
+/// Append members of the implicit receiver inside `with` / `apply` / `run` lambdas.
+fn add_implicit_receiver_member_completions(
+    items: &mut Vec<CompletionItem>,
+    index: &Indexer,
+    scope: &ScopeContext,
+    prefix: &str,
+    uri: &Url,
+    snippets: bool,
+    position: Position,
+) {
+    let Some(receiver_type) = scope.lambda_this_type.as_deref() else {
+        return;
+    };
+    let (receiver_items, _) = complete_symbol(
+        index,
+        prefix,
+        Some(receiver_type),
+        uri,
+        snippets,
+        Some(position.line),
+    );
+    for item in receiver_items {
+        if !items.iter().any(|existing| existing.label == item.label) {
+            items.push(item);
+        }
+    }
 }
 
 /// Appends lambda-parameter completions for bare-word (non-dot) completion.

--- a/src/features/completion_context.rs
+++ b/src/features/completion_context.rs
@@ -3,10 +3,11 @@ use tower_lsp::lsp_types::{Position, Url};
 use crate::features::completion::param_names_from_sig;
 use crate::features::traits::{LiveTreeAccess, SignatureIndex};
 use crate::indexer::{
-    lambda_receiver_type_from_context, last_ident_in, split_params_at_depth_zero,
-    strip_trailing_call_args, Indexer,
+    find_this_context_in_lines, lambda_receiver_type_from_context, last_ident_in,
+    split_params_at_depth_zero, strip_trailing_call_args, Indexer, ThisContext,
 };
 use crate::resolver::complete::ReceiverExpr;
+use crate::types::CursorPos;
 use crate::StrExt;
 
 const IT: &str = "it";
@@ -28,6 +29,9 @@ pub(crate) struct ScopeContext {
     pub enclosing_class: Option<String>,
     /// Lambda scopes, outermost first, innermost last.
     pub lambda_scopes: Vec<LambdaScope>,
+    /// Resolved implicit-receiver type inside a receiver lambda (`with`, `apply`, `run`, …).
+    /// Does not include the enclosing-class fallback used for plain `this` in methods.
+    pub lambda_this_type: Option<String>,
     bare_this_type: Option<String>,
 }
 
@@ -116,6 +120,7 @@ impl ScopeContext {
     ) -> Self {
         let position = Position::new(cursor_line, cursor_col);
         let enclosing_class = index.enclosing_class_at(uri, cursor_line);
+        let lambda_this_type = resolve_lambda_this_type(lines, cursor_line, cursor_col, index, uri);
         let bare_this_type = index
             .infer_lambda_param_type_at(THIS, uri, position)
             .or_else(|| enclosing_class.clone());
@@ -139,6 +144,7 @@ impl ScopeContext {
         Self {
             enclosing_class,
             lambda_scopes,
+            lambda_this_type,
             bare_this_type,
         }
     }
@@ -180,6 +186,28 @@ impl ScopeContext {
             || expr
                 .strip_prefix("this@")
                 .is_some_and(|label| !label.is_empty())
+    }
+}
+
+/// Receiver type for bare completion inside `with` / `apply` / `run` lambdas.
+///
+/// Only returns a type when the cursor is in a receiver lambda and the receiver
+/// type is known. Does not fall back to the enclosing class — that would
+/// duplicate locals and wrongly offer class members in `forEach { }` blocks.
+fn resolve_lambda_this_type(
+    lines: &[String],
+    cursor_line: u32,
+    cursor_col: u32,
+    index: &Indexer,
+    uri: &Url,
+) -> Option<String> {
+    let position = CursorPos {
+        line: cursor_line as usize,
+        utf16_col: cursor_col as usize,
+    };
+    match find_this_context_in_lines(lines, position, index, uri) {
+        ThisContext::Resolved(resolved_type) => Some(resolved_type),
+        ThisContext::InsideReceiver | ThisContext::NotFound => None,
     }
 }
 

--- a/src/features/completion_context_tests.rs
+++ b/src/features/completion_context_tests.rs
@@ -18,6 +18,7 @@ fn scope_resolve_it_returns_innermost_it_type() {
                 label: Some("forEach".into()),
             },
         ],
+        lambda_this_type: None,
         bare_this_type: None,
     };
 
@@ -33,6 +34,7 @@ fn scope_resolve_this_at_label() {
             named_params: vec![],
             label: Some("forEach".into()),
         }],
+        lambda_this_type: None,
         bare_this_type: Some("MyClass".into()),
     };
 
@@ -45,6 +47,7 @@ fn scope_is_scope_receiver() {
     let scope = ScopeContext {
         enclosing_class: None,
         lambda_scopes: vec![],
+        lambda_this_type: None,
         bare_this_type: None,
     };
 

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -172,6 +172,121 @@ fn dot_completion_with_prefix() {
 }
 
 #[test]
+fn bare_completion_with_implicit_receiver() {
+    let user_uri = uri("/User.kt");
+    let demo_uri = uri("/WithDemo.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &user_uri,
+        "package com.pkg\nclass User {\n  fun greet() {}\n}",
+    );
+    idx.index_content(
+        &demo_uri,
+        "package com.pkg\nfun demo(user: User) {\n  with(user) { gre\n}",
+    );
+
+    let line = "  with(user) { gre";
+    let col = line.len() as u32;
+    let (items, _) = idx.completions(&demo_uri, Position::new(2, col), false);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"greet"),
+        "User.greet missing in with() bare completion; got: {labels:?}"
+    );
+}
+
+#[test]
+fn bare_completion_apply_implicit_receiver() {
+    let config_uri = uri("/Config.kt");
+    let demo_uri = uri("/ApplyDemo.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &config_uri,
+        "package com.pkg\nclass Config {\n  val title: String = \"\"\n}",
+    );
+    idx.index_content(
+        &demo_uri,
+        "package com.pkg\nfun demo(config: Config) {\n  config.apply { tit\n}",
+    );
+
+    let line = "  config.apply { tit";
+    let col = line.len() as u32;
+    let (items, _) = idx.completions(&demo_uri, Position::new(2, col), false);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"title"),
+        "Config.title missing in apply block bare completion; got: {labels:?}"
+    );
+}
+
+#[test]
+fn bare_completion_run_implicit_receiver() {
+    let service_uri = uri("/Service.kt");
+    let demo_uri = uri("/RunDemo.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &service_uri,
+        "package com.pkg\nclass Service {\n  fun execute() {}\n}",
+    );
+    idx.index_content(
+        &demo_uri,
+        "package com.pkg\nfun demo(service: Service) {\n  service.run { exe\n}",
+    );
+
+    let line = "  service.run { exe";
+    let col = line.len() as u32;
+    let (items, _) = idx.completions(&demo_uri, Position::new(2, col), false);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"execute"),
+        "Service.execute missing in run block bare completion; got: {labels:?}"
+    );
+}
+
+#[test]
+fn bare_completion_for_each_does_not_offer_element_members() {
+    let demo_uri = uri("/ForEachDemo.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &demo_uri,
+        "package com.pkg\nclass Vm {\n  fun go() {\n    listOf(\"hello\").forEach { subs\n  }\n}",
+    );
+
+    let line = "    listOf(\"hello\").forEach { subs";
+    let col = line.len() as u32;
+    let (items, _) = idx.completions(&demo_uri, Position::new(3, col), false);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        !labels.contains(&"substring"),
+        "String.substring must not appear via implicit receiver in forEach; got: {labels:?}"
+    );
+}
+
+#[test]
+fn dot_completion_this_in_with_still_works() {
+    let user_uri = uri("/UserThis.kt");
+    let demo_uri = uri("/WithThisDemo.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &user_uri,
+        "package com.pkg\nclass User {\n  fun greet() {}\n}",
+    );
+    idx.index_content(
+        &demo_uri,
+        "package com.pkg\nfun demo(user: User) {\n  with(user) { this.\n}",
+    );
+
+    let line = "  with(user) { this.";
+    let col = line.len() as u32;
+    let (items, _) = idx.completions(&demo_uri, Position::new(2, col), false);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"greet"),
+        "this. completion in with() broken; got: {labels:?}"
+    );
+}
+
+#[test]
 fn dot_completion_qualified_nested_type() {
     // Typing `DPSCoordinator.Kind.` — receiver is "DPSCoordinator.Kind".
     // Should show enum cases (victory, defeat), NOT members of DPSCoordinator.


### PR DESCRIPTION
Problem: Inside `with(x) { }`, `x.apply { }`, or `x.run { }`, bare identifier completion didn’t offer receiver members - only `this.` did.

Fix: Infer the implicit receiver type in those lambdas and merge its members into bare completion.