### PR TITLE
perf(index): file interning — qualified drops 242k per-entry Urls for 20-byte SymbolLocs

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, RwLock};
 use dashmap::{DashMap, DashSet};
 use tower_lsp::lsp_types::*;
 
-use crate::types::FileData;
+use crate::types::{FileData, FileTable};
 
 // Re-export rg-module items that existing callers reach via `crate::indexer::`.
 pub(crate) use self::scan::{NoopReporter, ProgressReporter};
@@ -151,6 +151,10 @@ pub(crate) struct Indexer {
     pub(crate) definitions: DashMap<String, Vec<Location>>,
     /// Fully-qualified name → location   (e.g. "com.example.Foo" → …).
     pub(crate) qualified: DashMap<String, Location>,
+    /// Interns each indexed file's URI to a [`FileId`], so index maps can store
+    /// 4-byte handles instead of duplicating the parsed `Url` per symbol.
+    /// Append-only for the Indexer's lifetime (see [`crate::types::FileTable`]).
+    pub(crate) file_table: FileTable,
     /// Package name → vec of URI strings (for same-package resolution).
     pub(crate) packages: DashMap<String, Vec<String>>,
     /// Workspace root path + monotonic staleness generation.
@@ -534,6 +538,7 @@ impl Indexer {
             files: DashMap::new(),
             definitions: DashMap::new(),
             qualified: DashMap::new(),
+            file_table: FileTable::new(),
             packages: DashMap::new(),
             workspace_root: WorkspaceRoot::new(),
             content_hashes: DashMap::new(),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, RwLock};
 use dashmap::{DashMap, DashSet};
 use tower_lsp::lsp_types::*;
 
-use crate::types::{FileData, FileTable};
+use crate::types::{FileData, FileTable, SymbolLoc};
 
 // Re-export rg-module items that existing callers reach via `crate::indexer::`.
 pub(crate) use self::scan::{NoopReporter, ProgressReporter};
@@ -149,8 +149,12 @@ pub(crate) struct Indexer {
     pub(crate) files: DashMap<String, Arc<FileData>>,
     /// Short name → definition locations  (fast first-pass lookup).
     pub(crate) definitions: DashMap<String, Vec<Location>>,
-    /// Fully-qualified name → location   (e.g. "com.example.Foo" → …).
-    pub(crate) qualified: DashMap<String, Location>,
+    /// Fully-qualified name → interned location (e.g. "com.example.Foo" → …).
+    /// Values are [`SymbolLoc`] (a 4-byte `FileId` + range), not `Location`: the
+    /// file's URI lives once in [`Indexer::file_table`] instead of once per
+    /// symbol. Convert to a `Location` only at the LSP boundary via
+    /// [`crate::types::FileTable::location`].
+    pub(crate) qualified: DashMap<String, SymbolLoc>,
     /// Interns each indexed file's URI to a [`FileId`], so index maps can store
     /// 4-byte handles instead of duplicating the parsed `Url` per symbol.
     /// Append-only for the Indexer's lifetime (see [`crate::types::FileTable`]).
@@ -645,8 +649,11 @@ impl Indexer {
             locs.retain(|l| is_library(l.uri.as_str()));
             !locs.is_empty()
         });
-        self.qualified
-            .retain(|_fqn, loc| is_library(loc.uri.as_str()));
+        self.qualified.retain(|_fqn, loc| {
+            self.file_table
+                .url(loc.file)
+                .is_some_and(|url| is_library(url.as_str()))
+        });
         self.packages.retain(|_pkg, uris| {
             uris.retain(|u| is_library(u));
             !uris.is_empty()

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -28,7 +28,8 @@ use crate::parser::parse_by_extension;
 use crate::path_util::to_forward_slash;
 use crate::resolver::symbols_from_uri_as_completions_pub;
 use crate::types::{
-    ExtensionEntry, FileData, FileIndexResult, SourceSet, Visibility, WorkspaceIndexResult,
+    ExtensionEntry, FileData, FileIndexResult, SourceSet, SymbolLoc, Visibility,
+    WorkspaceIndexResult,
 };
 use crate::StrExt;
 
@@ -467,7 +468,7 @@ impl LibraryBatch {
             indexer.definitions.entry(name).or_default().extend(locs);
         }
         for (key, loc) in self.qualified {
-            indexer.qualified.insert(key, loc);
+            indexer.qualified.insert(key, indexer.intern_location(&loc));
         }
         for (pkg, uris) in self.packages {
             indexer.packages.entry(pkg).or_default().extend(uris);
@@ -517,6 +518,14 @@ impl Indexer {
         if let Ok(uri) = Url::parse(uri_str) {
             self.file_table.intern(&uri);
         }
+    }
+
+    /// Compact a `Location` into the [`SymbolLoc`] stored in `qualified`, interning
+    /// its URI. Idempotent: files already registered at insert time reuse their
+    /// `FileId`, so this is a lookup for workspace/library files and only allocates
+    /// for a not-yet-seen URI (e.g. a JAR symbol interned before its file lands).
+    pub(crate) fn intern_location(&self, loc: &Location) -> SymbolLoc {
+        SymbolLoc::new(self.file_table.intern(&loc.uri), loc.range)
     }
 
     /// Parse a single file via tree-sitter and extract symbols, supertypes, and a
@@ -653,7 +662,7 @@ impl Indexer {
         }
 
         for (key, loc) in contrib.qualified {
-            self.qualified.insert(key, loc);
+            self.qualified.insert(key, self.intern_location(&loc));
         }
 
         for (pkg, uris) in contrib.packages {
@@ -966,7 +975,7 @@ impl Indexer {
         }
 
         for (key, loc) in contrib.qualified {
-            self.qualified.insert(key, loc);
+            self.qualified.insert(key, self.intern_location(&loc));
         }
 
         for (pkg, uris) in contrib.packages {

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -460,6 +460,7 @@ impl LibraryBatch {
         }
         for (k, v) in self.files {
             let file_data = indexer.with_classified_source_set(&k, v);
+            indexer.register_file_uri(&k);
             indexer.files.insert(k, file_data);
         }
         for (name, locs) in self.definitions {
@@ -506,6 +507,16 @@ impl Indexer {
         let mut file_data = (*file_data).clone();
         file_data.source_set = source_set;
         Arc::new(file_data)
+    }
+
+    /// Intern `uri_str` into [`Indexer::file_table`] so index maps can reference
+    /// the file by its `FileId` instead of duplicating the parsed `Url`. Called
+    /// wherever a file enters `files` / `jar_files`. Idempotent; a URI that fails
+    /// to parse is skipped (it can never surface in the maps as a `Location`).
+    pub(crate) fn register_file_uri(&self, uri_str: &str) {
+        if let Ok(uri) = Url::parse(uri_str) {
+            self.file_table.intern(&uri);
+        }
     }
 
     /// Parse a single file via tree-sitter and extract symbols, supertypes, and a
@@ -633,6 +644,7 @@ impl Indexer {
         let file_data = self.with_classified_source_set(&uri_str, file_data);
 
         self.content_hashes.insert(hash_key, hash_val);
+        self.register_file_uri(&uri_str);
         self.files.insert(uri_str.clone(), file_data);
 
         for (name, locs) in contrib.definitions {
@@ -938,6 +950,7 @@ impl Indexer {
         let file_data = self.with_classified_source_set(&uri_str, file_data);
 
         self.content_hashes.insert(hash_key, hash_val);
+        self.register_file_uri(&uri_str);
         self.files.insert(uri_str.clone(), file_data);
 
         for (name, locs) in contrib.definitions {

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -342,6 +342,7 @@ fn apply_contribution_to_index(indexer: &crate::indexer::Indexer, contrib: FileC
         });
     }
     indexer.content_hashes.insert(hash_key, hash_val);
+    indexer.register_file_uri(&uri_str);
     indexer.files.insert(uri_str.clone(), file_data);
 
     for (name, locs) in contrib.definitions {
@@ -845,6 +846,7 @@ fn build_jar_file_data(
             });
     }
 
+    indexer.register_file_uri(fake_uri_str);
     indexer.jar_files.insert(
         fake_uri_str.to_owned(),
         Arc::new(FileData {

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -350,7 +350,7 @@ fn apply_contribution_to_index(indexer: &crate::indexer::Indexer, contrib: FileC
         entry.extend(locs);
     }
     for (key, loc) in contrib.qualified {
-        indexer.qualified.insert(key, loc);
+        indexer.qualified.insert(key, indexer.intern_location(&loc));
     }
     for (pkg, uris) in contrib.packages {
         let mut entry = indexer.packages.entry(pkg).or_default();
@@ -818,10 +818,7 @@ fn build_jar_file_data(
         };
         indexer.qualified.insert(
             fqn,
-            tower_lsp::lsp_types::Location {
-                uri: fake_uri.clone(),
-                range: symbols[i].range,
-            },
+            crate::types::SymbolLoc::new(indexer.file_table.intern(fake_uri), symbols[i].range),
         );
     }
 

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -913,11 +913,14 @@ fn jar_pipeline_order_sources_wins_over_compiled() {
 
     // Compiled path should have written a synthetic qualified entry.
     let compiled_uri = format!("jar:file://{}", compiled_jar_path);
-    let compiled_loc = indexer
+    let compiled_sym_loc = *indexer
         .qualified
         .get("com.example.shared.Core")
-        .expect("compiled-JAR should have populated qualified[com.example.shared.Core]")
-        .clone();
+        .expect("compiled-JAR should have populated qualified[com.example.shared.Core]");
+    let compiled_loc = indexer
+        .file_table
+        .location(compiled_sym_loc)
+        .expect("file_table must resolve the interned qualified entry");
     assert_eq!(
         compiled_loc.uri.as_str(),
         compiled_uri,
@@ -941,11 +944,14 @@ fn jar_pipeline_order_sources_wins_over_compiled() {
     );
 
     // Sources-JAR must have OVERWRITTEN the qualified entry.
-    let sources_loc = indexer
+    let sources_sym_loc = *indexer
         .qualified
         .get("com.example.shared.Core")
-        .expect("qualified[com.example.shared.Core] must still exist after sources run")
-        .clone();
+        .expect("qualified[com.example.shared.Core] must still exist after sources run");
+    let sources_loc = indexer
+        .file_table
+        .location(sources_sym_loc)
+        .expect("file_table must resolve the interned qualified entry");
     assert!(
         sources_loc.uri.as_str().contains("!/"),
         "qualified entry must now point to a sources-JAR entry URI (with !/); got: {}",

--- a/src/indexer/memory_probe_tests.rs
+++ b/src/indexer/memory_probe_tests.rs
@@ -16,12 +16,15 @@
 //! `pub(super)` items already reachable from inside the crate.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use tower_lsp::lsp_types::{Location, Url};
 
 use super::cache::{cache_entry_to_file_result, IndexCache};
 use super::Indexer;
-use crate::types::{FileData, FileIndexResult, IndexStats, SymbolEntry, WorkspaceIndexResult};
+use crate::types::{
+    FileData, FileIndexResult, IndexStats, SymbolEntry, SymbolLoc, WorkspaceIndexResult,
+};
 
 // ─── Sizing constants ──────────────────────────────────────────────────────
 // 64-bit targets. `String`/`Vec` headers are ptr+len+cap = 24 bytes and live
@@ -355,12 +358,44 @@ fn memory_retainer_profile() {
         }
     }
 
-    // qualified: DashMap<String, Location>
+    // qualified: DashMap<String, SymbolLoc>
+    // The value is now an interned `SymbolLoc` (FileId + Range), stored inline in
+    // the DashMap node with NO per-entry heap — the file URI lives once in
+    // `file_table` (accounted separately below), not once per symbol. We charge
+    // the inline struct size here so the row reflects the new per-entry cost.
     let mut qual_keys = Split::default();
     let mut qual_locs = Split::default();
     for e in indexer.qualified.iter() {
         qual_keys.ws += STRING_HDR + str_bytes(e.key());
-        qual_locs.add(is_lib(e.value().uri.as_str()), location_bytes(e.value()));
+        let is_library = indexer
+            .file_table
+            .url(e.value().file)
+            .is_some_and(|url| is_lib(url.as_str()));
+        qual_locs.add(is_library, std::mem::size_of::<SymbolLoc>());
+    }
+
+    // file_table: one Arc<Url> per interned file (by_id Vec) + the reverse
+    // DashMap<String, FileId> (by_uri). This is where the per-FILE URI heap now
+    // lives — previously duplicated per-SYMBOL across `qualified` (and, in later
+    // migration steps, `definitions`/`subtypes`).
+    let mut file_table_split = Split::default();
+    let interned_urls = indexer.file_table.urls_snapshot();
+    let interned_file_count = interned_urls.len();
+    // by_id Vec buffer: one Arc pointer slot per file.
+    file_table_split.ws += VEC_HDR + interned_file_count * std::mem::size_of::<Arc<Url>>();
+    for url in &interned_urls {
+        let uri = url.as_str();
+        let library = is_lib(uri);
+        // The Arc<Url> allocation: control block + the Url struct + its heap string.
+        file_table_split.add(
+            library,
+            ARC_CTL + std::mem::size_of::<Url>() + uri.len() + URL_STR_SLOP,
+        );
+        // by_uri entry: owned key String (dup of the URI) + the FileId value.
+        file_table_split.add(
+            library,
+            STRING_HDR + uri.len() + std::mem::size_of::<crate::types::FileId>(),
+        );
     }
 
     // subtypes: DashMap<String, Vec<Location>>
@@ -531,10 +566,16 @@ fn memory_retainer_profile() {
             lib: qual_keys.lib,
         },
         Row {
-            name: "qualified: Location URIs",
+            name: "qualified: SymbolLocs",
             entries: indexer.qualified.len(),
             ws: qual_locs.ws,
             lib: qual_locs.lib,
+        },
+        Row {
+            name: "file_table: interned URIs",
+            entries: interned_file_count,
+            ws: file_table_split.ws,
+            lib: file_table_split.lib,
         },
         Row {
             name: "subtypes: keys",

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -3065,10 +3065,10 @@ fn jar_symbol_resolved_via_import() {
     // Populate qualified index — mirrors build_jar_file_data.
     idx.qualified.insert(
         "androidx.lifecycle.ViewModel".into(),
-        Location {
+        idx.intern_location(&Location {
             uri: jar_uri.clone(),
             range: viewmodel_symbol.range,
-        },
+        }),
     );
 
     // JAR definitions

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -792,9 +792,13 @@ fn resolve_via_imports(indexer: &Indexer, name: &str, uri: &Url, allow_fd: bool)
     };
 
     for imp in imports.iter().filter(|i| i.local_name == name) {
-        // i) qualified index — exact FQN (works for top-level classes)
-        if let Some(loc) = indexer.qualified.get(&imp.full_path) {
-            return vec![loc.clone()];
+        // i) qualified index — exact FQN (works for top-level classes).
+        //    `qualified` stores an interned `SymbolLoc`; reconstitute the
+        //    `Location` here, at the return boundary.
+        if let Some(sym_loc) = indexer.qualified.get(&imp.full_path) {
+            if let Some(loc) = indexer.file_table.location(*sym_loc) {
+                return vec![loc];
+            }
         }
 
         // ii) short-name index filtered to the expected package.

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -796,8 +796,17 @@ fn resolve_via_imports(indexer: &Indexer, name: &str, uri: &Url, allow_fd: bool)
         //    `qualified` stores an interned `SymbolLoc`; reconstitute the
         //    `Location` here, at the return boundary.
         if let Some(sym_loc) = indexer.qualified.get(&imp.full_path) {
-            if let Some(loc) = indexer.file_table.location(*sym_loc) {
-                return vec![loc];
+            match indexer.file_table.location(*sym_loc) {
+                Some(loc) => return vec![loc],
+                // Unreachable by construction: every SymbolLoc in `qualified`
+                // was interned before insert and FileIds are never reused.
+                // Loud in dev builds; release degrades to the fallback ladder
+                // below rather than mis-resolving.
+                None => debug_assert!(
+                    false,
+                    "qualified SymbolLoc has no file_table entry for {}",
+                    imp.full_path
+                ),
             }
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -483,6 +483,12 @@ impl FileTable {
         if let Some(existing) = self.by_uri.get(uri.as_str()) {
             return *existing;
         }
+        // Fail fast rather than wrap: a truncated id would alias an existing
+        // file and silently corrupt every lookup keyed on it.
+        assert!(
+            u32::try_from(ids.len()).is_ok(),
+            "FileTable overflow: more than u32::MAX distinct files interned"
+        );
         let id = FileId(ids.len() as u32);
         ids.push(Arc::new(uri.clone()));
         self.by_uri.insert(uri.as_str().to_string(), id);

--- a/src/types.rs
+++ b/src/types.rs
@@ -417,6 +417,107 @@ pub(crate) struct WorkspaceIndexResult {
     pub complete_scan: bool,
 }
 
+// ─── File interning ───────────────────────────────────────────────────────────
+
+/// Index of a file's URI inside a [`FileTable`]. A 4-byte handle that replaces a
+/// per-entry `tower_lsp::Location`'s heap-allocated `Url` in the index maps: the
+/// same file's URI is stored once (in the table) instead of once per symbol.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(crate) struct FileId(u32);
+
+/// A symbol's location expressed as an interned [`FileId`] plus its range —
+/// 20 bytes, no owned heap — instead of a full `Location` (104 B inline + the
+/// `Url` string on the heap). Convert to a `Location` **only at the LSP
+/// boundary** via [`FileTable::location`]; never store a `Location` back into an
+/// index map.
+// `dead_code` allowed until the `qualified` migration (Step 2) consumes it.
+#[allow(dead_code)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) struct SymbolLoc {
+    pub(crate) file: FileId,
+    pub(crate) range: Range,
+}
+
+impl SymbolLoc {
+    #[allow(dead_code)]
+    pub(crate) fn new(file: FileId, range: Range) -> Self {
+        Self { file, range }
+    }
+}
+
+/// Append-only interning table mapping file URIs to [`FileId`]s and back.
+///
+/// `by_id[FileId] == Arc<Url>` for that file; `by_uri[uri] == FileId`. The table
+/// is append-only for the lifetime of an [`crate::indexer::Indexer`]: re-indexing
+/// the same URI returns its existing `FileId` (idempotent), so already-interned
+/// `SymbolLoc`s stay valid across `reset_index_state` (which *retains* library
+/// entries rather than clearing). Growth is bounded by the number of distinct
+/// files seen in a session, so no rebuild/clear is needed — the append-only
+/// invariant is what keeps retained library `SymbolLoc`s from dangling.
+pub(crate) struct FileTable {
+    by_id: std::sync::RwLock<Vec<Arc<tower_lsp::lsp_types::Url>>>,
+    by_uri: dashmap::DashMap<String, FileId>,
+}
+
+impl Default for FileTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FileTable {
+    pub(crate) fn new() -> Self {
+        Self {
+            by_id: std::sync::RwLock::new(Vec::new()),
+            by_uri: dashmap::DashMap::new(),
+        }
+    }
+
+    /// Intern `uri`, returning its stable [`FileId`]. Idempotent: the same URI
+    /// always maps to the same id for the table's lifetime.
+    pub(crate) fn intern(&self, uri: &tower_lsp::lsp_types::Url) -> FileId {
+        if let Some(existing) = self.by_uri.get(uri.as_str()) {
+            return *existing;
+        }
+        // Serialize appends under the id-vec write lock; re-check inside the
+        // critical section so a racing interner cannot allocate a second id for
+        // the same URI.
+        let mut ids = self.by_id.write().unwrap_or_else(|e| e.into_inner());
+        if let Some(existing) = self.by_uri.get(uri.as_str()) {
+            return *existing;
+        }
+        let id = FileId(ids.len() as u32);
+        ids.push(Arc::new(uri.clone()));
+        self.by_uri.insert(uri.as_str().to_string(), id);
+        id
+    }
+
+    /// The interned `Url` for `id`, or `None` if `id` is not from this table.
+    // `dead_code` allowed until Step 2 wires readers through it.
+    #[allow(dead_code)]
+    pub(crate) fn url(&self, id: FileId) -> Option<Arc<tower_lsp::lsp_types::Url>> {
+        self.by_id
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(id.0 as usize)
+            .cloned()
+    }
+
+    /// Build a `tower_lsp::Location` from a [`SymbolLoc`]. This is the ONLY place
+    /// a `Location` is reconstituted from interned index data — the LSP boundary.
+    /// Returns `None` if the [`FileId`] is unknown (should not happen for ids the
+    /// table itself produced).
+    // `dead_code` allowed until Step 2 wires readers through it.
+    #[allow(dead_code)]
+    pub(crate) fn location(&self, loc: SymbolLoc) -> Option<tower_lsp::lsp_types::Location> {
+        self.url(loc.file)
+            .map(|url| tower_lsp::lsp_types::Location {
+                uri: (*url).clone(),
+                range: loc.range,
+            })
+    }
+}
+
 #[cfg(test)]
 #[path = "types_tests.rs"]
 mod tests;

--- a/src/types.rs
+++ b/src/types.rs
@@ -430,8 +430,6 @@ pub(crate) struct FileId(u32);
 /// `Url` string on the heap). Convert to a `Location` **only at the LSP
 /// boundary** via [`FileTable::location`]; never store a `Location` back into an
 /// index map.
-// `dead_code` allowed until the `qualified` migration (Step 2) consumes it.
-#[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) struct SymbolLoc {
     pub(crate) file: FileId,
@@ -439,7 +437,6 @@ pub(crate) struct SymbolLoc {
 }
 
 impl SymbolLoc {
-    #[allow(dead_code)]
     pub(crate) fn new(file: FileId, range: Range) -> Self {
         Self { file, range }
     }
@@ -493,8 +490,6 @@ impl FileTable {
     }
 
     /// The interned `Url` for `id`, or `None` if `id` is not from this table.
-    // `dead_code` allowed until Step 2 wires readers through it.
-    #[allow(dead_code)]
     pub(crate) fn url(&self, id: FileId) -> Option<Arc<tower_lsp::lsp_types::Url>> {
         self.by_id
             .read()
@@ -507,14 +502,19 @@ impl FileTable {
     /// a `Location` is reconstituted from interned index data — the LSP boundary.
     /// Returns `None` if the [`FileId`] is unknown (should not happen for ids the
     /// table itself produced).
-    // `dead_code` allowed until Step 2 wires readers through it.
-    #[allow(dead_code)]
     pub(crate) fn location(&self, loc: SymbolLoc) -> Option<tower_lsp::lsp_types::Location> {
         self.url(loc.file)
             .map(|url| tower_lsp::lsp_types::Location {
                 uri: (*url).clone(),
                 range: loc.range,
             })
+    }
+
+    /// Snapshot of all interned `Url`s (cheap `Arc` clones). Used by the memory
+    /// probe to attribute the table's bytes; not on any production path.
+    #[cfg(test)]
+    pub(crate) fn urls_snapshot(&self) -> Vec<Arc<tower_lsp::lsp_types::Url>> {
+        self.by_id.read().unwrap_or_else(|e| e.into_inner()).clone()
     }
 }
 


### PR DESCRIPTION
## Summary

F3 steps 1–2 of the memory plan (design: docs/superpowers/plans/2026-07-05-post-fable-roadmap-refinements.md §1): introduce `FileId(u32)` + `FileTable` (one interned `Arc<Url>` per file, race-safe double-checked intern) and migrate `qualified` from `DashMap<String, Location>` to `DashMap<String, SymbolLoc { file: FileId, range }>` — 20 bytes inline instead of 104 bytes + a heap Url per entry.

- **Boundary rule:** a `tower_lsp::Location` is reconstructed from a `SymbolLoc` in exactly one place (`FileTable::location`, used by the sole surfacing reader `resolve_via_imports`); other readers are key-existence/removal and never materialize a Url.
- **No cache bump:** `qualified` is never serialized — it's rebuilt at apply time from each entry's own URI + `qualified_keys`; the existing v29 cache loads unchanged.
- **FileTable is append-only by invariant, not convention:** `reset_index_state` retains library entries, so their `SymbolLoc`s must stay resolvable; `FileId`s are stable and never reused, growth is bounded by distinct files per session.
- Probe updated to measure the new shape (`qualified: SymbolLocs` + `file_table` rows).

## Measured (probe, same 117 MB / 242,467-entry corpus)

| | before | after |
|---|---|---|
| qualified value storage | 36.04 MB (per-entry Urls) | 4.62 MB SymbolLocs + 5.36 MB shared FileTable |
| RSS apply peak | 408 MB | **333 MB** |

Cumulative since the plan started: warm-load peak **487 → 333 MB**. Next targets: `definitions` (33.6 MB Vec buffers + 23.1 MB Urls), then `subtypes`/`packages`.

1440 tests green, clippy `-D warnings` clean, per commit. Task-scoped review: Approved — intern atomicity, consumer census (grep + `cargo check --tests`), URL-identity semantics, and probe honesty all independently verified; no Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJsyQ1UgF8uJYR4HgpxEBB