### PR TITLE
perf(index): definitions + subtypes store SymbolLoc — drop 173k per-entry Urls

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -148,7 +148,11 @@ pub(crate) struct Indexer {
     /// URI string → parsed file data.
     pub(crate) files: DashMap<String, Arc<FileData>>,
     /// Short name → definition locations  (fast first-pass lookup).
-    pub(crate) definitions: DashMap<String, Vec<Location>>,
+    /// Values are [`SymbolLoc`]s (a 4-byte `FileId` + range), not `Location`: each
+    /// file's URI lives once in [`Indexer::file_table`] instead of once per symbol.
+    /// Convert to a `Location` only at the LSP boundary via
+    /// [`crate::types::FileTable::location`].
+    pub(crate) definitions: DashMap<String, Vec<SymbolLoc>>,
     /// Fully-qualified name → interned location (e.g. "com.example.Foo" → …).
     /// Values are [`SymbolLoc`] (a 4-byte `FileId` + range), not `Location`: the
     /// file's URI lives once in [`Indexer::file_table`] instead of once per
@@ -343,7 +347,10 @@ impl InferDeps for Indexer {
             return Vec::new();
         };
         for loc in locations.iter() {
-            if let Some(file_data) = self.files.get(loc.uri.as_str()) {
+            let Some(url) = self.file_table.url(loc.file) else {
+                continue;
+            };
+            if let Some(file_data) = self.files.get(url.as_str()) {
                 if let Some(sym) = file_data
                     .symbols
                     .iter()
@@ -474,7 +481,10 @@ fn is_enum_class(indexer: &Indexer, class_name: &str) -> bool {
         return false;
     };
     for loc in locs.iter() {
-        if let Some(fd) = indexer.files.get(loc.uri.as_str()) {
+        let Some(url) = indexer.file_table.url(loc.file) else {
+            continue;
+        };
+        if let Some(fd) = indexer.files.get(url.as_str()) {
             if fd
                 .symbols
                 .iter()
@@ -646,7 +656,11 @@ impl Indexer {
         // Per-file maps: keep only library entries.
         self.files.retain(|uri, _| is_library(uri));
         self.definitions.retain(|_name, locs| {
-            locs.retain(|l| is_library(l.uri.as_str()));
+            locs.retain(|l| {
+                self.file_table
+                    .url(l.file)
+                    .is_some_and(|url| is_library(url.as_str()))
+            });
             !locs.is_empty()
         });
         self.qualified.retain(|_fqn, loc| {
@@ -828,10 +842,15 @@ impl Indexer {
     ///
     /// Prefer this over `self.definitions.get(name)` anywhere JAR symbols should be visible.
     pub(crate) fn lookup_definitions(&self, name: &str) -> Vec<tower_lsp::lsp_types::Location> {
+        // Reconstitute each interned `SymbolLoc` into a `Location` at this LSP boundary.
         let mut locs: Vec<tower_lsp::lsp_types::Location> = self
             .definitions
             .get(name)
-            .map(|r| r.clone())
+            .map(|r| {
+                r.iter()
+                    .filter_map(|sym_loc| self.file_table.location(*sym_loc))
+                    .collect()
+            })
             .unwrap_or_default();
         if let Some(jar_locs) = self.jar_definitions.get(name) {
             locs.extend(jar_locs.iter().cloned());
@@ -859,13 +878,23 @@ impl Indexer {
         name: &str,
         f: impl FnMut(&Location) -> Option<T>,
     ) -> Option<T> {
+        // Reconstitute each candidate `SymbolLoc` into a `Location` at this boundary,
+        // filtering out library files by their interned URI first.
         let candidates: Vec<Location> = self
             .definitions
             .get(name)?
             .iter()
-            .filter(|loc| !self.library_uris.contains(loc.uri.as_str()))
+            .filter_map(|sym_loc| {
+                let url = self.file_table.url(sym_loc.file)?;
+                if self.library_uris.contains(url.as_str()) {
+                    return None;
+                }
+                Some(Location {
+                    uri: (*url).clone(),
+                    range: sym_loc.range,
+                })
+            })
             .take(MAX_BY_NAME_DEFS)
-            .cloned()
             .collect();
         candidates.iter().find_map(f)
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -186,7 +186,9 @@ pub(crate) struct Indexer {
     pub(crate) live_lines: DashMap<String, Arc<Vec<String>>>,
     /// Reverse supertype index: supertype name → locations of implementing/extending classes.
     /// Populated during `index_content()` for fast `goToImplementation` lookups.
-    pub(crate) subtypes: DashMap<String, Vec<Location>>,
+    /// Values are interned [`SymbolLoc`]s (see [`Indexer::definitions`] /
+    /// [`Indexer::file_table`]); convert to a `Location` only at the LSP boundary.
+    pub(crate) subtypes: DashMap<String, Vec<SymbolLoc>>,
     /// Cached sorted list of all project class/symbol names for bare-word completion.
     /// Rebuilt after each file index; avoids iterating `definitions` on every keystroke.
     pub(crate) bare_name_cache: std::sync::RwLock<Vec<String>>,
@@ -673,7 +675,11 @@ impl Indexer {
             !uris.is_empty()
         });
         self.subtypes.retain(|_super, locs| {
-            locs.retain(|l| is_library(l.uri.as_str()));
+            locs.retain(|l| {
+                self.file_table
+                    .url(l.file)
+                    .is_some_and(|url| is_library(url.as_str()))
+            });
             !locs.is_empty()
         });
         self.content_hashes.retain(|uri, _| is_library(uri));
@@ -785,9 +791,15 @@ impl Indexer {
 
     /// Returns all known direct subtypes of `name` (empty if none).
     pub(crate) fn subtypes_of(&self, name: &str) -> Vec<Location> {
+        // Reconstitute each interned `SymbolLoc` into a `Location` at this LSP boundary.
         self.subtypes
             .get(name)
-            .map(|r| r.value().clone())
+            .map(|r| {
+                r.value()
+                    .iter()
+                    .filter_map(|sym_loc| self.file_table.location(*sym_loc))
+                    .collect()
+            })
             .unwrap_or_default()
     }
 

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -478,7 +478,11 @@ impl LibraryBatch {
             indexer.packages.entry(pkg).or_default().extend(uris);
         }
         for (super_name, locs) in self.subtypes {
-            indexer.subtypes.entry(super_name).or_default().extend(locs);
+            indexer
+                .subtypes
+                .entry(super_name)
+                .or_default()
+                .extend(locs.iter().map(|loc| indexer.intern_location(loc)));
         }
         for (receiver, new_entries) in self.extensions {
             let new_uris: std::collections::HashSet<String> =
@@ -597,7 +601,7 @@ impl Indexer {
             }
         }
         for mut entry in self.subtypes.iter_mut() {
-            entry.value_mut().retain(|l| l.uri.as_str() != uri_str);
+            entry.value_mut().retain(|l| l.file != stale_id);
         }
         for mut entry in self.extension_by_receiver.iter_mut() {
             entry.value_mut().retain(|e| e.file_uri != uri_str);
@@ -684,8 +688,11 @@ impl Indexer {
         }
 
         for (super_name, locs) in contrib.subtypes {
+            // Intern before taking the shard guard: `file_table` is a separate lock.
+            let interned: Vec<SymbolLoc> =
+                locs.iter().map(|loc| self.intern_location(loc)).collect();
             let mut entry = self.subtypes.entry(super_name).or_default();
-            entry.extend(locs);
+            entry.extend(interned);
         }
 
         for (receiver, new_entries) in contrib.extensions {
@@ -1001,13 +1008,13 @@ impl Indexer {
         }
 
         for (super_name, locs) in contrib.subtypes {
+            // Intern before taking the shard guard: `file_table` is a separate lock.
+            let interned: Vec<SymbolLoc> =
+                locs.iter().map(|loc| self.intern_location(loc)).collect();
             let mut entry = self.subtypes.entry(super_name).or_default();
-            for loc in locs {
-                if !entry
-                    .iter()
-                    .any(|l| l.uri == loc.uri && l.range == loc.range)
-                {
-                    entry.push(loc);
+            for sym_loc in interned {
+                if !entry.contains(&sym_loc) {
+                    entry.push(sym_loc);
                 }
             }
         }

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -465,7 +465,11 @@ impl LibraryBatch {
             indexer.files.insert(k, file_data);
         }
         for (name, locs) in self.definitions {
-            indexer.definitions.entry(name).or_default().extend(locs);
+            indexer
+                .definitions
+                .entry(name)
+                .or_default()
+                .extend(locs.iter().map(|loc| indexer.intern_location(loc)));
         }
         for (key, loc) in self.qualified {
             indexer.qualified.insert(key, indexer.intern_location(&loc));
@@ -573,9 +577,15 @@ impl Indexer {
         };
         let stale = stale_keys_for(&uri, &old);
 
+        // `uri` is already indexed (we fetched `old` above), so it is already
+        // interned; `intern` returns its existing `FileId`. Comparing that single
+        // `FileId` against each stored `SymbolLoc.file` — both from this Indexer's
+        // one `file_table` — is a same-source, idempotent match, not a cross-source
+        // URI-string compare.
+        let stale_id = self.file_table.intern(&uri);
         for name in &stale.definition_names {
             if let Some(mut locs) = self.definitions.get_mut(name) {
-                locs.retain(|l| l.uri.as_str() != uri_str);
+                locs.retain(|l| l.file != stale_id);
             }
         }
         for key in &stale.qualified_keys {
@@ -657,8 +667,11 @@ impl Indexer {
         self.files.insert(uri_str.clone(), file_data);
 
         for (name, locs) in contrib.definitions {
+            // Intern before taking the shard guard: `file_table` is a separate lock.
+            let interned: Vec<SymbolLoc> =
+                locs.iter().map(|loc| self.intern_location(loc)).collect();
             let mut entry = self.definitions.entry(name).or_default();
-            entry.extend(locs);
+            entry.extend(interned);
         }
 
         for (key, loc) in contrib.qualified {
@@ -963,13 +976,13 @@ impl Indexer {
         self.files.insert(uri_str.clone(), file_data);
 
         for (name, locs) in contrib.definitions {
+            // Intern before taking the shard guard: `file_table` is a separate lock.
+            let interned: Vec<SymbolLoc> =
+                locs.iter().map(|loc| self.intern_location(loc)).collect();
             let mut entry = self.definitions.entry(name).or_default();
-            for loc in locs {
-                if !entry
-                    .iter()
-                    .any(|l| l.uri == loc.uri && l.range == loc.range)
-                {
-                    entry.push(loc);
+            for sym_loc in interned {
+                if !entry.contains(&sym_loc) {
+                    entry.push(sym_loc);
                 }
             }
         }

--- a/src/indexer/apply_tests.rs
+++ b/src/indexer/apply_tests.rs
@@ -102,7 +102,7 @@ fn apply_file_result_updates_index_issue_apply() {
     );
     let locs = idx.definitions.get("TestClass").unwrap();
     assert_eq!(locs.len(), 1);
-    assert_eq!(locs[0].uri, u);
+    assert_eq!(idx.file_table.location(locs[0]).unwrap().uri, u);
 }
 
 /// Re-indexing the same file with new content must remove the old symbol.

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -670,7 +670,10 @@ pub(crate) fn find_method_params_in_class(
     };
     let locations = idx.definitions.get(type_base)?;
     for loc in locations.iter() {
-        let Some(file_data) = idx.files.get(loc.uri.as_str()) else {
+        let Some(url) = idx.file_table.url(loc.file) else {
+            continue;
+        };
+        let Some(file_data) = idx.files.get(url.as_str()) else {
             continue;
         };
         // Verify the class exists (and if qualified, check its own container).
@@ -897,7 +900,11 @@ fn resolve_qualified(call: &CallSite<'_>, qualifier: &str, idx: &Indexer) -> Sig
     {
         let mut locations: Vec<tower_lsp::lsp_types::Location> = Vec::new();
         if let Some(locs) = idx.definitions.get(call.name) {
-            locations.extend(locs.iter().cloned());
+            // Reconstitute interned `SymbolLoc`s at this boundary.
+            locations.extend(
+                locs.iter()
+                    .filter_map(|sym_loc| idx.file_table.location(*sym_loc)),
+            );
         }
         if let Some(locs) = idx.jar_definitions.get(call.name) {
             locations.extend(locs.iter().cloned());
@@ -978,7 +985,11 @@ fn resolve_unqualified(call: &CallSite<'_>, idx: &Indexer) -> SignatureResult {
     let mut all: Vec<(String, (u8, u8))> = Vec::new();
     let mut locations: Vec<tower_lsp::lsp_types::Location> = Vec::new();
     if let Some(locs) = idx.definitions.get(call.name) {
-        locations.extend(locs.iter().cloned());
+        // Reconstitute interned `SymbolLoc`s at this boundary.
+        locations.extend(
+            locs.iter()
+                .filter_map(|sym_loc| idx.file_table.location(*sym_loc)),
+        );
     }
     if let Some(locs) = idx.jar_definitions.get(call.name) {
         locations.extend(locs.iter().cloned());

--- a/src/indexer/infer/sig_tests.rs
+++ b/src/indexer/infer/sig_tests.rs
@@ -397,7 +397,10 @@ fn resolve_unqualified_bails_on_ubiquitous_name() {
             range: Range::default(),
         })
         .collect();
-    idx.definitions.insert("create".to_owned(), many);
+    idx.definitions.insert(
+        "create".to_owned(),
+        many.iter().map(|l| idx.intern_location(l)).collect(),
+    );
 
     let call = CallSite {
         name: "create",
@@ -547,7 +550,10 @@ fn resolve_qualified_bails_on_ubiquitous_name_even_with_receiver_extension() {
             range: Range::default(),
         })
         .collect();
-    idx.definitions.insert("loadData".to_owned(), many);
+    idx.definitions.insert(
+        "loadData".to_owned(),
+        many.iter().map(|l| idx.intern_location(l)).collect(),
+    );
 
     // A 1-arg JAR extension on Repository (Phase 2 — receiver-scoped, always runs).
     let jar_symbol = SymbolEntry {

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -346,8 +346,12 @@ fn apply_contribution_to_index(indexer: &crate::indexer::Indexer, contrib: FileC
     indexer.files.insert(uri_str.clone(), file_data);
 
     for (name, locs) in contrib.definitions {
+        let interned: Vec<crate::types::SymbolLoc> = locs
+            .iter()
+            .map(|loc| indexer.intern_location(loc))
+            .collect();
         let mut entry = indexer.definitions.entry(name).or_default();
-        entry.extend(locs);
+        entry.extend(interned);
     }
     for (key, loc) in contrib.qualified {
         indexer.qualified.insert(key, indexer.intern_location(&loc));

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -361,8 +361,12 @@ fn apply_contribution_to_index(indexer: &crate::indexer::Indexer, contrib: FileC
         entry.extend(uris);
     }
     for (super_name, locs) in contrib.subtypes {
+        let interned: Vec<crate::types::SymbolLoc> = locs
+            .iter()
+            .map(|loc| indexer.intern_location(loc))
+            .collect();
         let mut entry = indexer.subtypes.entry(super_name).or_default();
-        entry.extend(locs);
+        entry.extend(interned);
     }
     for (receiver, new_entries) in contrib.extensions {
         let mut slot = indexer.extension_by_receiver.entry(receiver).or_default();

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -682,7 +682,7 @@ fn sources_jar_auto_mount_indexes_kotlin_files() {
     );
 
     // Verify the URI scheme is jar:file://
-    let core_loc = &core_locs_vec[0];
+    let core_loc = indexer.file_table.location(core_locs_vec[0]).unwrap();
     assert!(
         core_loc.uri.as_str().starts_with("jar:file://"),
         "Core URI should be jar:file:// scheme; got: {}",

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -22,7 +22,10 @@ impl Indexer {
     pub(crate) fn is_declared_in(&self, uri: &Url, name: &str) -> bool {
         self.definitions
             .get(name)
-            .map(|locs| locs.iter().any(|l| l.uri == *uri))
+            .map(|locs| {
+                locs.iter()
+                    .any(|l| self.file_table.url(l.file).is_some_and(|url| *url == *uri))
+            })
             .unwrap_or(false)
     }
 
@@ -150,8 +153,11 @@ impl Indexer {
         let locs = self.definitions.get(name)?;
         // Prefer the declaration in the current file (mirrors declared_parent_class_of).
         for loc in locs.iter() {
-            if loc.uri == *preferred_uri {
-                if let Some(f) = self.files.get(loc.uri.as_str()) {
+            let Some(url) = self.file_table.url(loc.file) else {
+                continue;
+            };
+            if *url == *preferred_uri {
+                if let Some(f) = self.files.get(url.as_str()) {
                     if let Some(pkg) = &f.package {
                         return Some(pkg.clone());
                     }
@@ -160,7 +166,10 @@ impl Indexer {
         }
         // Fall back to first definition in any file.
         for loc in locs.iter() {
-            if let Some(f) = self.files.get(loc.uri.as_str()) {
+            let Some(url) = self.file_table.url(loc.file) else {
+                continue;
+            };
+            if let Some(f) = self.files.get(url.as_str()) {
                 if let Some(pkg) = &f.package {
                     return Some(pkg.clone());
                 }
@@ -180,13 +189,19 @@ impl Indexer {
         let locs = self.definitions.get(name)?;
         // Try declaration in the preferred (current) file first.
         for loc in locs.iter() {
-            if loc.uri == *preferred_uri {
-                return self.enclosing_class_at(&loc.uri, loc.range.start.line);
+            let Some(url) = self.file_table.url(loc.file) else {
+                continue;
+            };
+            if *url == *preferred_uri {
+                return self.enclosing_class_at(&url, loc.range.start.line);
             }
         }
         // Fall back to first definition in any file.
         for loc in locs.iter() {
-            if let Some(parent) = self.enclosing_class_at(&loc.uri, loc.range.start.line) {
+            let Some(url) = self.file_table.url(loc.file) else {
+                continue;
+            };
+            if let Some(parent) = self.enclosing_class_at(&url, loc.range.start.line) {
                 return Some(parent);
             }
         }
@@ -232,13 +247,18 @@ impl Indexer {
                 if maybe_parent.starts_with_uppercase() {
                     // Check if `name` is actually declared inside `maybe_parent`.
                     let decl_uri = self.definitions.get(name).and_then(|locs| {
-                        locs.iter()
-                            .find(|loc| {
-                                self.enclosing_class_at(&loc.uri, loc.range.start.line)
-                                    .as_deref()
-                                    == Some(maybe_parent)
-                            })
-                            .map(|loc| loc.uri.clone())
+                        locs.iter().find_map(|loc| {
+                            let url = self.file_table.url(loc.file)?;
+                            if self
+                                .enclosing_class_at(&url, loc.range.start.line)
+                                .as_deref()
+                                == Some(maybe_parent)
+                            {
+                                Some((*url).clone())
+                            } else {
+                                None
+                            }
+                        })
                     });
                     if let Some(decl_uri) = decl_uri {
                         let pkg = self

--- a/src/indexer/memory_probe_tests.rs
+++ b/src/indexer/memory_probe_tests.rs
@@ -343,18 +343,28 @@ fn memory_retainer_profile() {
         account_file(&mut ft, e.key(), is_lib(e.key()), e.value());
     }
 
-    // definitions: DashMap<String, Vec<Location>>
+    // definitions: DashMap<String, Vec<SymbolLoc>>
+    // Values are interned `SymbolLoc`s stored inline in the Vec buffer (20 B each,
+    // no per-loc heap — each file's URI lives once in `file_table`, accounted below).
+    // "SymbolLocs" charges the live inline entries (with ws/lib split via
+    // `file_table`); "Vec buffers" charges only the Vec header + spare-capacity slack,
+    // so the two rows sum to the full buffer allocation with no double-count.
     let mut def_keys = Split::default();
     let mut def_vec = Split::default();
     let mut def_locs = Split::default();
     let mut def_loc_count = 0usize;
     for e in indexer.definitions.iter() {
-        // A definitions bucket can hold both ws + lib locations; split per-loc.
         def_keys.ws += STRING_HDR + str_bytes(e.key());
-        def_vec.ws += VEC_HDR + e.value().capacity() * std::mem::size_of::<Location>();
-        for loc in e.value() {
+        let vec = e.value();
+        def_vec.ws +=
+            VEC_HDR + vec.capacity().saturating_sub(vec.len()) * std::mem::size_of::<SymbolLoc>();
+        for loc in vec.iter() {
             def_loc_count += 1;
-            def_locs.add(is_lib(loc.uri.as_str()), location_bytes(loc));
+            let is_library = indexer
+                .file_table
+                .url(loc.file)
+                .is_some_and(|url| is_lib(url.as_str()));
+            def_locs.add(is_library, std::mem::size_of::<SymbolLoc>());
         }
     }
 
@@ -554,7 +564,7 @@ fn memory_retainer_profile() {
             lib: def_vec.lib,
         },
         Row {
-            name: "definitions: Location URIs",
+            name: "definitions: SymbolLocs",
             entries: def_loc_count,
             ws: def_locs.ws,
             lib: def_locs.lib,

--- a/src/indexer/memory_probe_tests.rs
+++ b/src/indexer/memory_probe_tests.rs
@@ -408,17 +408,25 @@ fn memory_retainer_profile() {
         );
     }
 
-    // subtypes: DashMap<String, Vec<Location>>
+    // subtypes: DashMap<String, Vec<SymbolLoc>>
+    // Same interned shape as `definitions` (see that block): "SymbolLocs" charges
+    // the live inline entries, "Vec buffers" the header + spare-capacity slack.
     let mut sub_keys = Split::default();
     let mut sub_vec = Split::default();
     let mut sub_locs = Split::default();
     let mut sub_loc_count = 0usize;
     for e in indexer.subtypes.iter() {
         sub_keys.ws += STRING_HDR + str_bytes(e.key());
-        sub_vec.ws += VEC_HDR + e.value().capacity() * std::mem::size_of::<Location>();
-        for loc in e.value() {
+        let vec = e.value();
+        sub_vec.ws +=
+            VEC_HDR + vec.capacity().saturating_sub(vec.len()) * std::mem::size_of::<SymbolLoc>();
+        for loc in vec.iter() {
             sub_loc_count += 1;
-            sub_locs.add(is_lib(loc.uri.as_str()), location_bytes(loc));
+            let is_library = indexer
+                .file_table
+                .url(loc.file)
+                .is_some_and(|url| is_lib(url.as_str()));
+            sub_locs.add(is_library, std::mem::size_of::<SymbolLoc>());
         }
     }
 
@@ -600,7 +608,7 @@ fn memory_retainer_profile() {
             lib: sub_vec.lib,
         },
         Row {
-            name: "subtypes: Location URIs",
+            name: "subtypes: SymbolLocs",
             entries: sub_loc_count,
             ws: sub_locs.ws,
             lib: sub_locs.lib,

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -649,10 +649,15 @@ fn build_enclosing_class_subst_impl<I: IndexRead>(
 // but this enables unit tests to use a TestIndex stub.
 impl IndexRead for super::Indexer {
     fn get_definitions(&self, name: &str) -> Option<Vec<Location>> {
+        // Reconstitute each interned `SymbolLoc` into a `Location` at this boundary.
         let mut locs: Vec<Location> = self
             .definitions
             .get(name)
-            .map(|rf| rf.clone())
+            .map(|rf| {
+                rf.iter()
+                    .filter_map(|sym_loc| self.file_table.location(*sym_loc))
+                    .collect()
+            })
             .unwrap_or_default();
         if let Some(jar_locs) = self.jar_definitions.get(name) {
             locs.extend(jar_locs.iter().cloned());

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -25,7 +25,8 @@ fn sorted_subtype_names(idx: &Indexer, supertype: &str) -> Vec<String> {
         .map(|v| {
             v.iter()
                 .filter_map(|loc| {
-                    loc.uri
+                    idx.file_table
+                        .url(loc.file)?
                         .to_file_path()
                         .ok()?
                         .file_stem()
@@ -1172,7 +1173,10 @@ fn subtypes_index_basic() {
         .subtypes
         .get("IAnimal")
         .expect("should have subtypes for IAnimal");
-    let sub_uris: Vec<_> = subs.iter().map(|l| l.uri.to_string()).collect();
+    let sub_uris: Vec<_> = subs
+        .iter()
+        .filter_map(|l| idx.file_table.url(l.file).map(|u| u.to_string()))
+        .collect();
     assert!(
         sub_uris.contains(&dog_uri.to_string()),
         "Dog should be a subtype"
@@ -1231,12 +1235,15 @@ class Bar : Beta {\n}",
         let names: Vec<_> = alpha
             .iter()
             .filter_map(|l| {
-                idx.files.get(l.uri.as_str()).and_then(|f| {
-                    f.symbols
-                        .iter()
-                        .find(|s| s.selection_range == l.range)
-                        .map(|s| s.name.clone())
-                })
+                idx.file_table
+                    .url(l.file)
+                    .and_then(|url| idx.files.get(url.as_str()))
+                    .and_then(|f| {
+                        f.symbols
+                            .iter()
+                            .find(|s| s.selection_range == l.range)
+                            .map(|s| s.name.clone())
+                    })
             })
             .collect();
         assert!(
@@ -1270,12 +1277,15 @@ data class Error(val msg: String) : StoreState()
     let names: Vec<String> = subs
         .iter()
         .filter_map(|l| {
-            idx.files.get(l.uri.as_str()).and_then(|f| {
-                f.symbols
-                    .iter()
-                    .find(|s| s.selection_range == l.range)
-                    .map(|s| s.name.clone())
-            })
+            idx.file_table
+                .url(l.file)
+                .and_then(|url| idx.files.get(url.as_str()))
+                .and_then(|f| {
+                    f.symbols
+                        .iter()
+                        .find(|s| s.selection_range == l.range)
+                        .map(|s| s.name.clone())
+                })
         })
         .collect();
     assert!(
@@ -1358,12 +1368,15 @@ data class Error(val error: Throwable) : StoreState<Nothing>()
     let names: Vec<String> = subs
         .iter()
         .filter_map(|l| {
-            idx.files.get(l.uri.as_str()).and_then(|f| {
-                f.symbols
-                    .iter()
-                    .find(|s| s.selection_range == l.range)
-                    .map(|s| s.name.clone())
-            })
+            idx.file_table
+                .url(l.file)
+                .and_then(|url| idx.files.get(url.as_str()))
+                .and_then(|f| {
+                    f.symbols
+                        .iter()
+                        .find(|s| s.selection_range == l.range)
+                        .map(|s| s.name.clone())
+                })
         })
         .collect();
     assert!(
@@ -1560,12 +1573,15 @@ return when (this) {
     let names: Vec<String> = subs
         .iter()
         .filter_map(|l| {
-            idx.files.get(l.uri.as_str()).and_then(|f| {
-                f.symbols
-                    .iter()
-                    .find(|s| s.selection_range == l.range)
-                    .map(|s| s.name.clone())
-            })
+            idx.file_table
+                .url(l.file)
+                .and_then(|url| idx.files.get(url.as_str()))
+                .and_then(|f| {
+                    f.symbols
+                        .iter()
+                        .find(|s| s.selection_range == l.range)
+                        .map(|s| s.name.clone())
+                })
         })
         .collect();
     assert!(

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -411,7 +411,8 @@ super.doIt()
         .map(|v| v.clone())
         .unwrap_or_default();
     assert!(!locs.is_empty(), "Foo must be in definitions");
-    let file = idx.files.get(locs[0].uri.as_str()).unwrap();
+    let foo_uri = idx.file_table.url(locs[0].file).unwrap();
+    let file = idx.files.get(foo_uri.as_str()).unwrap();
     let start_line = locs[0].range.start.line;
     let supers: Vec<String> = file
         .supers
@@ -2263,7 +2264,8 @@ fn lambda_param_dotted_nested_class_chain() {
         .get("Success")
         .and_then(|locs| {
             for loc in locs.iter() {
-                if let Some(data) = idx.files.get(loc.uri.as_str()) {
+                let url = idx.file_table.url(loc.file)?;
+                if let Some(data) = idx.files.get(url.as_str()) {
                     if let Some(sym) = data.symbols.iter().find(|s| s.name == "Success") {
                         return Some(sym.type_params.clone());
                     }
@@ -2280,7 +2282,8 @@ fn lambda_param_dotted_nested_class_chain() {
         .get("Optional")
         .and_then(|locs| {
             for loc in locs.iter() {
-                if let Some(data) = idx.files.get(loc.uri.as_str()) {
+                let url = idx.file_table.url(loc.file)?;
+                if let Some(data) = idx.files.get(url.as_str()) {
                     if let Some(sym) = data.symbols.iter().find(|s| s.name == "Optional") {
                         return Some(sym.type_params.clone());
                     }
@@ -3243,8 +3246,13 @@ fn find_in_workspace_defs_invariants() {
     let lib = uri("/lib/Lib.kt");
     let ws = uri("/ws/Ws.kt");
     idx.library_uris.insert(lib.as_str().to_owned());
-    idx.definitions
-        .insert("create".to_owned(), vec![mk(&lib), mk(&ws)]);
+    idx.definitions.insert(
+        "create".to_owned(),
+        [mk(&lib), mk(&ws)]
+            .iter()
+            .map(|l| idx.intern_location(l))
+            .collect(),
+    );
     let mut seen: Vec<String> = Vec::new();
     let _: Option<()> = idx.find_in_workspace_defs("create", |loc| {
         seen.push(loc.uri.to_string());
@@ -3260,7 +3268,10 @@ fn find_in_workspace_defs_invariants() {
     let many: Vec<Location> = (0..(MAX_BY_NAME_DEFS + 25))
         .map(|i| mk(&uri(&format!("/ws/F{i}.kt"))))
         .collect();
-    idx.definitions.insert("many".to_owned(), many);
+    idx.definitions.insert(
+        "many".to_owned(),
+        many.iter().map(|l| idx.intern_location(l)).collect(),
+    );
     let mut count = 0usize;
     let _: Option<()> = idx.find_in_workspace_defs("many", |_| {
         count += 1;

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -240,7 +240,11 @@ fn resolve_chain(
         && name.starts_with_uppercase()
     {
         if let Some(locs_ref) = indexer.definitions.get(name) {
-            let locs: Vec<Location> = locs_ref.clone();
+            // Reconstitute interned `SymbolLoc`s at this boundary before filtering.
+            let locs: Vec<Location> = locs_ref
+                .iter()
+                .filter_map(|sym_loc| indexer.file_table.location(*sym_loc))
+                .collect();
             // Prefer definitions from .swift files when available.
             let swift_locs: Vec<Location> = locs
                 .iter()
@@ -824,7 +828,11 @@ fn resolve_via_imports(indexer: &Indexer, name: &str, uri: &Url, allow_fd: bool)
         let expected_chain = import_container_chain(&imp.full_path, short);
         let mut all_locations: Vec<tower_lsp::lsp_types::Location> = Vec::new();
         if let Some(locs) = indexer.definitions.get(short) {
-            all_locations.extend(locs.iter().cloned());
+            // Reconstitute interned `SymbolLoc`s at this boundary.
+            all_locations.extend(
+                locs.iter()
+                    .filter_map(|sym_loc| indexer.file_table.location(*sym_loc)),
+            );
         }
         if let Some(locs) = indexer.jar_definitions.get(short) {
             all_locations.extend(locs.iter().cloned());


### PR DESCRIPTION
## Summary

F3 step 3: migrates `definitions` (the primary short-name lookup, 155,909 entries) and `subtypes` (16,801 entries) from `DashMap<String, Vec<Location>>` to `Vec<SymbolLoc>` — the same interning pattern PR #208 landed for `qualified` (`FileId`/`FileTable`, `Location` reconstituted only via `FileTable::location` at return boundaries).

- **Census-first:** ~15 production readers found and converted (completion, go-def, references, resolver, jar enrichment); `bare_name_cache` rebuild is key-only and needed no change. Writers intern before taking the DashMap entry guard, matching #208's lock-ordering.
- **Dedup semantics preserved exactly:** the old `l.uri==loc.uri && l.range==loc.range` check is byte-equivalent to `SymbolLoc{file,range}` equality since `file` is interned from the same table — two distinct symbols at different ranges in the same file both survive.
- **`remove_stale_for_uri`'s file-filtering compare is same-source/idempotent** (interns the target URI, compares against already-interned entries) — the same ruling #208's review made for the analogous case, re-verified here.
- **Cache unchanged:** `definitions`/`subtypes` were never serialized — rebuilt at apply from `file_data.symbols`/`supers` — so CACHE_VERSION stays 29 and the existing on-disk cache loads unmodified.
- Probe updated to the new shape; arithmetic reconciles (`size_of::<SymbolLoc>() = 20 B` × entry count).

## Measured (same 117 MB / 12,621-file corpus)

| | before | after |
|---|---|---|
| definitions | 58.9 MB | 9.5 MB |
| subtypes | 5.2 MB | 0.6 MB |
| accounted total | 243.6 MB | 189.6 MB |
| **RSS apply peak** | 331 MB | **274 MB** |

Cumulative since the plan started: warm-load peak **487 → 274 MB (−44%)**.

1440 tests green, clippy `-D warnings` clean, per commit. Task-scoped review: Approved — census independently verified complete by grep across all of `src/`, order/dedup semantics for the multi-hit map confirmed unchanged, no Critical/Important findings (one stylistic boundary-purity nit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJsyQ1UgF8uJYR4HgpxEBB