### PR TITLE
perf(index): packages stores FileId — drop duplicated URI strings

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, RwLock};
 use dashmap::{DashMap, DashSet};
 use tower_lsp::lsp_types::*;
 
-use crate::types::{FileData, FileTable, SymbolLoc};
+use crate::types::{FileData, FileId, FileTable, SymbolLoc};
 
 // Re-export rg-module items that existing callers reach via `crate::indexer::`.
 pub(crate) use self::scan::{NoopReporter, ProgressReporter};
@@ -163,8 +163,11 @@ pub(crate) struct Indexer {
     /// 4-byte handles instead of duplicating the parsed `Url` per symbol.
     /// Append-only for the Indexer's lifetime (see [`crate::types::FileTable`]).
     pub(crate) file_table: FileTable,
-    /// Package name → vec of URI strings (for same-package resolution).
-    pub(crate) packages: DashMap<String, Vec<String>>,
+    /// Package name → vec of interned [`FileId`]s of the files declaring it (for
+    /// same-package resolution). Stores 4-byte handles instead of duplicating each
+    /// file's URI string; convert to a `Url` at the read boundary via
+    /// [`crate::types::FileTable::url`].
+    pub(crate) packages: DashMap<String, Vec<FileId>>,
     /// Workspace root path + monotonic staleness generation.
     /// The only write path is [`WorkspaceRoot::set`], which always bumps the
     /// generation — coupling enforced by the type, not by convention.
@@ -670,9 +673,13 @@ impl Indexer {
                 .url(loc.file)
                 .is_some_and(|url| is_library(url.as_str()))
         });
-        self.packages.retain(|_pkg, uris| {
-            uris.retain(|u| is_library(u));
-            !uris.is_empty()
+        self.packages.retain(|_pkg, file_ids| {
+            file_ids.retain(|file_id| {
+                self.file_table
+                    .url(*file_id)
+                    .is_some_and(|url| is_library(url.as_str()))
+            });
+            !file_ids.is_empty()
         });
         self.subtypes.retain(|_super, locs| {
             locs.retain(|l| {

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -482,11 +482,11 @@ impl LibraryBatch {
             indexer.qualified.insert(key, indexer.intern_location(&loc));
         }
         for (pkg, uris) in self.packages {
-            indexer
-                .packages
-                .entry(pkg)
-                .or_default()
-                .extend(uris.iter().filter_map(|uri| indexer.intern_uri_str(uri)));
+            let interned: Vec<crate::types::FileId> = uris
+                .iter()
+                .filter_map(|uri| indexer.intern_uri_str(uri))
+                .collect();
+            indexer.packages.entry(pkg).or_default().extend(interned);
         }
         for (super_name, locs) in self.subtypes {
             let interned: Vec<SymbolLoc> = locs

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -482,7 +482,11 @@ impl LibraryBatch {
             indexer.qualified.insert(key, indexer.intern_location(&loc));
         }
         for (pkg, uris) in self.packages {
-            indexer.packages.entry(pkg).or_default().extend(uris);
+            indexer
+                .packages
+                .entry(pkg)
+                .or_default()
+                .extend(uris.iter().filter_map(|uri| indexer.intern_uri_str(uri)));
         }
         for (super_name, locs) in self.subtypes {
             let interned: Vec<SymbolLoc> = locs
@@ -537,6 +541,16 @@ impl Indexer {
         if let Ok(uri) = Url::parse(uri_str) {
             self.file_table.intern(&uri);
         }
+    }
+
+    /// Intern `uri_str` and return its [`FileId`], or `None` if the string does
+    /// not parse as a `Url` (mirrors [`Indexer::register_file_uri`], which
+    /// silently skips such URIs). Used to compact the `packages` index onto
+    /// interned file handles instead of duplicated URI strings.
+    pub(crate) fn intern_uri_str(&self, uri_str: &str) -> Option<crate::types::FileId> {
+        Url::parse(uri_str)
+            .ok()
+            .map(|uri| self.file_table.intern(&uri))
     }
 
     /// Compact a `Location` into the [`SymbolLoc`] stored in `qualified`, interning
@@ -607,8 +621,8 @@ impl Indexer {
             self.qualified.remove(key);
         }
         if let Some(ref pkg) = stale.package {
-            if let Some(mut uris) = self.packages.get_mut(pkg) {
-                uris.retain(|u| u != uri_str);
+            if let Some(mut file_ids) = self.packages.get_mut(pkg) {
+                file_ids.retain(|file_id| *file_id != stale_id);
             }
         }
         for mut entry in self.subtypes.iter_mut() {
@@ -694,8 +708,13 @@ impl Indexer {
         }
 
         for (pkg, uris) in contrib.packages {
+            // Intern before taking the shard guard: `file_table` is a separate lock.
+            let file_ids: Vec<crate::types::FileId> = uris
+                .iter()
+                .filter_map(|uri| self.intern_uri_str(uri))
+                .collect();
             let mut entry = self.packages.entry(pkg).or_default();
-            entry.extend(uris);
+            entry.extend(file_ids);
         }
 
         for (super_name, locs) in contrib.subtypes {
@@ -1010,10 +1029,15 @@ impl Indexer {
         }
 
         for (pkg, uris) in contrib.packages {
+            // Intern before taking the shard guard: `file_table` is a separate lock.
+            let file_ids: Vec<crate::types::FileId> = uris
+                .iter()
+                .filter_map(|uri| self.intern_uri_str(uri))
+                .collect();
             let mut entry = self.packages.entry(pkg).or_default();
-            for u in uris {
-                if !entry.contains(&u) {
-                    entry.push(u);
+            for file_id in file_ids {
+                if !entry.contains(&file_id) {
+                    entry.push(file_id);
                 }
             }
         }

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -357,8 +357,13 @@ fn apply_contribution_to_index(indexer: &crate::indexer::Indexer, contrib: FileC
         indexer.qualified.insert(key, indexer.intern_location(&loc));
     }
     for (pkg, uris) in contrib.packages {
+        // Intern before taking the shard guard: `file_table` is a separate lock.
+        let file_ids: Vec<crate::types::FileId> = uris
+            .iter()
+            .filter_map(|uri| indexer.intern_uri_str(uri))
+            .collect();
         let mut entry = indexer.packages.entry(pkg).or_default();
-        entry.extend(uris);
+        entry.extend(file_ids);
     }
     for (super_name, locs) in contrib.subtypes {
         let interned: Vec<crate::types::SymbolLoc> = locs

--- a/src/indexer/memory_probe_tests.rs
+++ b/src/indexer/memory_probe_tests.rs
@@ -430,10 +430,14 @@ fn memory_retainer_profile() {
         }
     }
 
-    // packages: DashMap<String, Vec<String>>
+    // packages: DashMap<String, Vec<FileId>> — values are 4-byte interned handles
+    // (the file URIs live once in `file_table`), not duplicated URI strings.
     let mut pkg_bytes = 0usize;
     for e in indexer.packages.iter() {
-        pkg_bytes += STRING_HDR + str_bytes(e.key()) + vec_string_bytes(e.value());
+        pkg_bytes += STRING_HDR
+            + str_bytes(e.key())
+            + VEC_HDR
+            + e.value().len() * std::mem::size_of::<crate::types::FileId>();
     }
 
     // content_hashes: DashMap<String, u64>

--- a/src/indexer/memory_probe_tests.rs
+++ b/src/indexer/memory_probe_tests.rs
@@ -437,7 +437,7 @@ fn memory_retainer_profile() {
         pkg_bytes += STRING_HDR
             + str_bytes(e.key())
             + VEC_HDR
-            + e.value().len() * std::mem::size_of::<crate::types::FileId>();
+            + e.value().capacity() * std::mem::size_of::<crate::types::FileId>();
     }
 
     // content_hashes: DashMap<String, u64>

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -86,8 +86,8 @@ fn qualified_removed_on_reindex() {
 #[test]
 fn packages_map_populated() {
     let (u, idx) = indexed("/t.kt", "package com.example\nclass Foo");
-    let uris = idx.packages.get("com.example").unwrap();
-    assert!(uris.contains(&u.to_string()));
+    let file_ids = idx.packages.get("com.example").unwrap();
+    assert!(file_ids.contains(&idx.file_table.intern(&u)));
 }
 
 // ── parse_count: verify deduplication ───────────────────────────────────

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -1297,7 +1297,7 @@ impl<'a> BareCompletionWalk<'a> {
         let Some(package_name) = self.current_package_name() else {
             return;
         };
-        let Some(package_uris) = self.indexer.packages.get(&package_name) else {
+        let Some(package_ids) = self.indexer.packages.get(&package_name) else {
             return;
         };
         let caller_source_set = self
@@ -1307,11 +1307,15 @@ impl<'a> BareCompletionWalk<'a> {
             .map(|file| file.source_set)
             .unwrap_or_default();
 
-        for package_uri in package_uris.iter() {
+        for package_id in package_ids.iter() {
+            let Some(package_url) = self.indexer.file_table.url(*package_id) else {
+                continue;
+            };
+            let package_uri = package_url.as_str();
             if package_uri == self.from_uri.as_str() {
                 continue;
             }
-            let Some(file) = self.indexer.files.get(package_uri.as_str()) else {
+            let Some(file) = self.indexer.files.get(package_uri) else {
                 continue;
             };
             if file.source_set == SourceSet::Test && caller_source_set != SourceSet::Test {
@@ -1324,7 +1328,7 @@ impl<'a> BareCompletionWalk<'a> {
                     1,
                     self.prefix,
                     &symbol.detail,
-                    Some(serde_json::json!({DATA_URI: package_uri.as_str(), DATA_LINE: symbol.selection_start(), DATA_COL: symbol.selection_range.start.character})),
+                    Some(serde_json::json!({DATA_URI: package_uri, DATA_LINE: symbol.selection_start(), DATA_COL: symbol.selection_range.start.character})),
                 );
             }
         }
@@ -1373,14 +1377,17 @@ impl<'a> BareCompletionWalk<'a> {
             if !import.is_star {
                 continue;
             }
-            let Some(pkg_uris) = self.indexer.packages.get(&import.full_path) else {
+            let Some(pkg_ids) = self.indexer.packages.get(&import.full_path) else {
                 continue;
             };
-            for pkg_uri in pkg_uris.iter() {
-                if pkg_uri.as_str() == self.from_uri.as_str() {
+            for pkg_id in pkg_ids.iter() {
+                let Some(pkg_url) = self.indexer.file_table.url(*pkg_id) else {
+                    continue;
+                };
+                if pkg_url.as_str() == self.from_uri.as_str() {
                     continue; // already covered by collect_local_file
                 }
-                let Some(file) = self.indexer.files.get(pkg_uri.as_str()) else {
+                let Some(file) = self.indexer.files.get(pkg_url.as_str()) else {
                     continue;
                 };
                 if file.source_set == crate::types::SourceSet::Test
@@ -1408,7 +1415,7 @@ impl<'a> BareCompletionWalk<'a> {
                         self.prefix,
                         &symbol.detail,
                         Some(serde_json::json!({
-                            DATA_URI: pkg_uri.as_str(),
+                            DATA_URI: pkg_url.as_str(),
                             DATA_LINE: symbol.selection_start(),
                             DATA_COL: symbol.selection_range.start.character
                         })),

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -923,24 +923,26 @@ fn resolve_same_package(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Locatio
         None => return vec![],
     };
 
-    let peer_uris: Vec<String> = match indexer.packages.get(&pkg) {
-        Some(u) => u.clone(),
+    let peer_ids: Vec<crate::types::FileId> = match indexer.packages.get(&pkg) {
+        Some(ids) => ids.clone(),
         None => return vec![],
     };
 
     let self_str = uri.as_str();
-    for peer_uri_str in &peer_uris {
+    for peer_id in &peer_ids {
+        let Some(peer_url) = indexer.file_table.url(*peer_id) else {
+            continue;
+        };
+        let peer_uri_str = peer_url.as_str();
         if peer_uri_str == self_str {
             continue;
         }
         if let Some(f) = indexer.files.get(peer_uri_str) {
-            for sym in f.symbols.iter().filter(|s| s.name == name) {
-                if let Ok(u) = Url::parse(peer_uri_str) {
-                    return vec![Location {
-                        uri: u,
-                        range: sym.selection_range,
-                    }];
-                }
+            if let Some(sym) = f.symbols.iter().find(|s| s.name == name) {
+                return vec![Location {
+                    uri: (*peer_url).clone(),
+                    range: sym.selection_range,
+                }];
             }
         }
     }
@@ -967,20 +969,21 @@ fn symbols_in_package(indexer: &Indexer, name: &str, pkg: &str) -> Vec<Location>
 
 /// Scan all indexed files in `pkg` for the first symbol named `name`.
 fn find_symbol_in_package(indexer: &Indexer, name: &str, pkg: &str) -> Option<Location> {
-    let peer_uris: Vec<String> = indexer
+    let peer_ids: Vec<crate::types::FileId> = indexer
         .packages
         .get(pkg)
-        .map(|u| u.clone())
+        .map(|ids| ids.clone())
         .unwrap_or_default();
-    for peer_uri_str in peer_uris {
-        if let Some(f) = indexer.files.get(&peer_uri_str) {
-            for sym in f.symbols.iter().filter(|s| s.name == name) {
-                if let Ok(u) = Url::parse(&peer_uri_str) {
-                    return Some(Location {
-                        uri: u,
-                        range: sym.selection_range,
-                    });
-                }
+    for peer_id in peer_ids {
+        let Some(peer_url) = indexer.file_table.url(peer_id) else {
+            continue;
+        };
+        if let Some(f) = indexer.files.get(peer_url.as_str()) {
+            if let Some(sym) = f.symbols.iter().find(|s| s.name == name) {
+                return Some(Location {
+                    uri: (*peer_url).clone(),
+                    range: sym.selection_range,
+                });
             }
         }
     }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -178,7 +178,7 @@ fn resolve_does_not_cross_packages_without_import() {
     assert!(
         idx.packages
             .get("com.example.pkg2")
-            .map(|u| !u.contains(&a_uri.to_string()))
+            .map(|ids| !ids.contains(&idx.file_table.intern(&a_uri)))
             .unwrap_or(true),
         "pkg1 URI leaked into pkg2 packages map"
     );


### PR DESCRIPTION
## Summary

F3 step 4, completing the interning migration series (#206 `qualified`, #209 `definitions`+`subtypes`): `packages: DashMap<String, Vec<String>>` (package name → declaring-file URI strings) now stores `Vec<FileId>`. Unlike the prior three maps, `packages` has no per-entry range, so the target is a bare `FileId` rather than `SymbolLoc`.

- **Census:** 4 production readers (same-package resolution in resolve.rs/complete.rs) + 6 write sites, all converted following the #208/#209 pattern.
- **Same-package resolution semantics preserved exactly:** every reader's self-skip check stays a string comparison (`FileId → url.as_str()`, then compared) — none was converted to FileId equality, so no cross-source-normalization risk was introduced. The only FileId-equality sites are same-source (dedup on write, stale-uri removal via `file_table.intern` on the same table the stored ids came from) — the same rule #208/#209 established.
- **Cache unchanged:** `packages` was never serialized — rebuilt at apply from `file_data.package` — so CACHE_VERSION stays 29.

## Measured (same 117 MB corpus)

| | before | after |
|---|---|---|
| packages | 2.58 MB | 0.55 MB |
| accounted total | 189.74 MB | 187.69 MB |
| **RSS apply peak** | 274.0 MB | **270.5 MB** |

**This closes the F3 interning series.** Cumulative since the plan started: warm-load peak **487 → 270.5 MB (−44.5%)**, four PRs, every number probe-verified.

1440 tests green, clippy `-D warnings` clean. Task-scoped review: Approved — census independently verified complete, the one novel risk this step adds (same-package resolution semantics, since this map — unlike the prior three — exists specifically for "which files share package X" lookups) traced end-to-end and confirmed unchanged, cache claim verified at code level. No Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJsyQ1UgF8uJYR4HgpxEBB