### PR TITLE
perf(index): stream-deserialize the jar-symbols cache instead of buffering it whole

### DIFF
--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -70,10 +70,10 @@ fn cache_path() -> std::path::PathBuf {
 pub(crate) fn load_jar_cache() -> HashMap<String, JarCacheEntry> {
     let path = cache_path();
     // Stream-deserialize rather than std::fs::read + deserialize-from-buffer:
-    // the latter holds the full raw file AND the deserialized map at once
-    // (~280 MB + ~570 MB on a real corpus) — the same transient-peak shape
-    // F0 fixed on the workspace apply path. `load_sources_jar_cache` already
-    // streams via BufReader; this brings the sibling loader in line.
+    // the latter holds the full raw file AND the deserialized map in memory
+    // simultaneously — the same transient-peak shape the workspace apply path
+    // was fixed to avoid. `load_sources_jar_cache` already streams via
+    // BufReader; this brings the sibling loader in line.
     let Ok(file) = std::fs::File::open(&path) else {
         return HashMap::new();
     };

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -69,11 +69,16 @@ fn cache_path() -> std::path::PathBuf {
 /// Load the global JAR symbol cache.  Returns an empty map on any error.
 pub(crate) fn load_jar_cache() -> HashMap<String, JarCacheEntry> {
     let path = cache_path();
-    let bytes = match std::fs::read(&path) {
-        Ok(b) => b,
-        Err(_) => return HashMap::new(),
+    // Stream-deserialize rather than std::fs::read + deserialize-from-buffer:
+    // the latter holds the full raw file AND the deserialized map at once
+    // (~280 MB + ~570 MB on a real corpus) — the same transient-peak shape
+    // F0 fixed on the workspace apply path. `load_sources_jar_cache` already
+    // streams via BufReader; this brings the sibling loader in line.
+    let Ok(file) = std::fs::File::open(&path) else {
+        return HashMap::new();
     };
-    match bincode::deserialize::<JarCache>(&bytes) {
+    let reader = std::io::BufReader::new(file);
+    match bincode::deserialize_from::<_, JarCache>(reader) {
         Ok(c) if c.version == JAR_CACHE_VERSION => {
             log::debug!("jar_cache: loaded {} entries", c.entries.len());
             c.entries


### PR DESCRIPTION
## Summary

`load_jar_cache` read the full 281 MB file into a `Vec<u8>` before deserializing — holding the raw bytes and the deserialized ~618 MB map simultaneously, the same shape F0 fixed on the workspace apply path. The sibling `load_sources_jar_cache` already streams via `BufReader`; this brings `load_jar_cache` in line.

## Measured, not assumed — and the result is a null one

Re-ran the base PR's `library_jar_cache_footprint` probe after this change: RSS after load is **569.8 MB**, essentially unchanged from the pre-fix 561–570 MB (within run-to-run noise). The 281 MB raw buffer is evidently freed quickly enough relative to the 617.8 MB structure's incremental growth during deserialization that it doesn't add a separate persistent peak — unlike the workspace-side F0 case, where the double-copy genuinely was the dominant cost.

**Keeping the fix anyway**: it removes an unnecessary large allocation, brings the two loaders into a consistent pattern, and costs nothing. But it means the real cost here is the deserialized data itself — 1.45M `SidecarSymbol` structs (224 B each = ~325 MB in fixed struct cost alone) plus their String payloads — not the loading strategy. A `SidecarSymbol` layout diet (same measure-then-box discipline as the `SymbolEntry` work) is the more promising next lever, not further loader-side changes.

1440 tests green, clippy `-D warnings` clean. Stacked on #213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJsyQ1UgF8uJYR4HgpxEBB