### PR TITLE
fix(jar): post-ship fix waves — chain completion, import promotion, non-Gradle gate

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -141,7 +141,13 @@ impl LanguageServer for Backend {
         // immediately. The process stays alive until the `exit` notification
         // arrives, giving the write enough time to complete for typical caches.
         let idx = Arc::clone(&self.indexer);
-        tokio::task::spawn_blocking(move || idx.save_cache_to_disk(false));
+        tokio::task::spawn_blocking(move || {
+            idx.save_cache_to_disk(false);
+            // Persist any jar-cache entries the save throttle suppressed —
+            // without this, a session's last few promoted JARs would be
+            // re-fetched from the sidecar next session.
+            crate::indexer::jar_cache::flush_pending_jar_cache_save(&idx);
+        });
         Ok(())
     }
 

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -143,7 +143,13 @@ pub(crate) fn run_completions(
 
     let annotation_only = is_annotation_context(before, prefix);
     let lines = index.lines_for(uri).unwrap_or_default();
-    let ctx = CompletionContext::analyse(before_prefix, position, index, uri, annotation_only);
+    // A fluent-chain CONTINUATION line (`    .padd…`) carries no receiver of
+    // its own — the chain's head and earlier segments live on the lines
+    // above (the standard Compose modifier idiom). Reconstruct the full
+    // chain text so receiver analysis sees one line's worth of expression.
+    let joined_chain = join_fluent_chain_continuation(lines.as_ref(), position.line, before_prefix);
+    let receiver_source: &str = joined_chain.as_deref().unwrap_or(before_prefix);
+    let ctx = CompletionContext::analyse(receiver_source, position, index, uri, annotation_only);
 
     if let Some(ref recv) = ctx.receiver {
         let recv_str = recv.as_str();
@@ -478,6 +484,68 @@ fn split_prefix(before: &str) -> (&str, &str) {
     let prefix = last_ident_in(before);
     let before_prefix = &before[..before.len() - prefix.len()];
     (prefix, before_prefix)
+}
+
+/// How many lines above the cursor a fluent chain may span before the
+/// upward walk gives up — bounds the work on pathological inputs.
+const MAX_FLUENT_CHAIN_LINES: usize = 32;
+
+/// Reconstruct a multiline fluent chain for a CONTINUATION line.
+///
+/// When the text before the cursor's prefix is just indentation and a `.`
+/// (optionally with earlier segments, e.g. `    .padding(x).`), the chain's
+/// receiver lives on the lines ABOVE — the standard Compose modifier idiom:
+///
+/// ```text
+/// modifier = Modifier
+///     .fillMaxSize()
+///     .verticalScroll(rememberScrollState())
+///     .padd|          ← completion here
+/// ```
+///
+/// Returns the concatenation of the head line, every intermediate
+/// continuation line, and `before_prefix` itself (all trimmed), e.g.
+/// `"modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState())."`
+/// — which `ReceiverExpr::parse`'s backward chain scanner then resolves like
+/// any single-line chain. Returns `None` when the cursor line is not a
+/// chain continuation (the common case) or no head line is found.
+fn join_fluent_chain_continuation(
+    lines: &[String],
+    cursor_line: u32,
+    before_prefix: &str,
+) -> Option<String> {
+    let continuation = before_prefix.trim_start();
+    if !continuation.starts_with('.') && !continuation.starts_with("?.") {
+        return None;
+    }
+    let cursor_line = cursor_line as usize;
+    if cursor_line == 0 || cursor_line > lines.len() {
+        return None;
+    }
+
+    // Walk upward: chain segment lines (starting with `.`), then the head.
+    let mut collected_above: Vec<&str> = Vec::new();
+    for line in lines[..cursor_line].iter().rev().take(MAX_FLUENT_CHAIN_LINES) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("//") {
+            continue;
+        }
+        if trimmed.starts_with('.') || trimmed.starts_with("?.") {
+            collected_above.push(trimmed);
+            continue;
+        }
+        // Head line (e.g. `modifier = Modifier`): the chain scanner stops at
+        // the first non-identifier character on its own, so the whole
+        // trimmed line can be prepended verbatim.
+        collected_above.push(trimmed);
+        let mut joined = String::new();
+        for piece in collected_above.iter().rev() {
+            joined.push_str(piece);
+        }
+        joined.push_str(continuation);
+        return Some(joined);
+    }
+    None
 }
 
 #[cfg(test)]

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -524,10 +524,24 @@ fn join_fluent_chain_continuation(
     }
 
     // Walk upward: chain segment lines (starting with `.`), then the head.
+    // Trailing line comments are stripped from every piece — fused into the
+    // joined text, `"base.first() // grab it."` backward-scans to the
+    // comment word `it` and resolves a wrong (lambda-scope) receiver. The
+    // scan is string-literal-naive, parity with the chain scanner itself.
+    fn strip_line_comment(piece: &str) -> &str {
+        match piece.find("//") {
+            Some(comment_start) => piece[..comment_start].trim_end(),
+            None => piece,
+        }
+    }
     let mut collected_above: Vec<&str> = Vec::new();
-    for line in lines[..cursor_line].iter().rev().take(MAX_FLUENT_CHAIN_LINES) {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with("//") {
+    for line in lines[..cursor_line]
+        .iter()
+        .rev()
+        .take(MAX_FLUENT_CHAIN_LINES)
+    {
+        let trimmed = strip_line_comment(line.trim());
+        if trimmed.is_empty() {
             continue;
         }
         if trimmed.starts_with('.') || trimmed.starts_with("?.") {

--- a/src/features/completion_tests.rs
+++ b/src/features/completion_tests.rs
@@ -288,3 +288,18 @@ fn join_skips_blank_and_comment_lines_inside_the_chain() {
     let joined = super::join_fluent_chain_continuation(&lines, 4, "    .");
     assert_eq!(joined.as_deref(), Some("val chained = base.first()."));
 }
+
+/// Review M1: a trailing line comment on a chain segment (or the head) must
+/// not be fused into the joined receiver — `"base.first() // grab it."`
+/// backward-scans to the comment word `it` and resolves a lambda-scope
+/// receiver instead of the chain.
+#[test]
+fn join_strips_trailing_line_comments_from_chain_pieces() {
+    let lines = kt_lines(concat!(
+        "val x = base // the root\n",
+        "    .first() // grab it\n",
+        "    .padd\n",
+    ));
+    let joined = super::join_fluent_chain_continuation(&lines, 2, "    .");
+    assert_eq!(joined.as_deref(), Some("val x = base.first()."));
+}

--- a/src/features/completion_tests.rs
+++ b/src/features/completion_tests.rs
@@ -211,3 +211,80 @@ fn param_names_empty() {
     let result = param_names_from_sig("");
     assert!(result.is_empty());
 }
+
+// ── multi-call chains and continuation lines (wave 7d) ──────────────────────
+
+/// The real Compose idiom is a chain of several CALLS. The backward scanner
+/// must skip every balanced argument list, not just the trailing one, and
+/// normalize inner calls to `name()` segments so the dotted-chain resolver
+/// (`resolve_dotted_receiver_type`, which strips `()` per segment) can walk
+/// the return types.
+#[test]
+fn parse_chain_with_multiple_call_segments() {
+    assert_eq!(
+        ReceiverExpr::parse("    Modifier.fillMaxSize().verticalScroll(rememberScrollState())."),
+        recv("Modifier.fillMaxSize().verticalScroll", true),
+    );
+}
+
+#[test]
+fn parse_chain_with_three_call_segments_and_nested_args() {
+    assert_eq!(
+        ReceiverExpr::parse("m = Modifier.a().b(f(x), g.h(y)).c(z)."),
+        recv("Modifier.a().b().c", true),
+    );
+}
+
+#[test]
+fn parse_multi_call_chain_ending_without_call() {
+    assert_eq!(
+        ReceiverExpr::parse("Modifier.padding(x).value."),
+        recv("Modifier.padding().value", false),
+    );
+}
+
+fn kt_lines(text: &str) -> Vec<String> {
+    text.lines().map(str::to_owned).collect()
+}
+
+#[test]
+fn join_reconstructs_a_multiline_modifier_chain() {
+    let lines = kt_lines(concat!(
+        "fun screen() {\n",
+        "    Column(\n",
+        "        modifier = Modifier\n",
+        "            .fillMaxSize()\n",
+        "            .verticalScroll(rememberScrollState())\n",
+        "            .padd\n",
+        "    )\n",
+        "}\n",
+    ));
+    let joined = super::join_fluent_chain_continuation(&lines, 5, "            .");
+    assert_eq!(
+        joined.as_deref(),
+        Some("modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState())."),
+    );
+}
+
+#[test]
+fn join_is_a_no_op_for_ordinary_lines() {
+    let lines = kt_lines("fun screen() {\n    Modifier.padd\n}\n");
+    assert_eq!(
+        super::join_fluent_chain_continuation(&lines, 1, "    Modifier."),
+        None,
+        "a line that carries its own receiver must not be rewritten"
+    );
+}
+
+#[test]
+fn join_skips_blank_and_comment_lines_inside_the_chain() {
+    let lines = kt_lines(concat!(
+        "val chained = base\n",
+        "    .first()\n",
+        "    // keep scrolling\n",
+        "\n",
+        "    .padd\n",
+    ));
+    let joined = super::join_fluent_chain_continuation(&lines, 4, "    .");
+    assert_eq!(joined.as_deref(), Some("val chained = base.first()."));
+}

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -370,6 +370,12 @@ pub(crate) struct Indexer {
     /// before one.
     pub(crate) jar_symbol_cache:
         std::sync::Mutex<Option<HashMap<String, crate::indexer::jar_cache::JarCacheEntry>>>,
+    /// Save-throttle state for the on-demand promotion path (see
+    /// `jar_cache::maybe_save_jar_cache_throttled`). Lock order: nests
+    /// INSIDE `jar_symbol_cache` — never take `jar_symbol_cache` while
+    /// holding this.
+    pub(crate) jar_cache_save_throttle:
+        std::sync::Mutex<crate::indexer::jar_cache::JarCacheSaveThrottle>,
 }
 
 /// Cap on how many same-named definitions a receiver-less by-name inference lookup
@@ -671,6 +677,9 @@ impl Indexer {
             materialization_failed: dashmap::DashSet::new(),
             extension_by_receiver: DashMap::new(),
             jar_symbol_cache: std::sync::Mutex::new(None),
+            jar_cache_save_throttle: std::sync::Mutex::new(
+                crate::indexer::jar_cache::JarCacheSaveThrottle::default(),
+            ),
         }
     }
 

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -126,7 +126,11 @@ const GRADLE_MARKERS: [&str; 6] = [
 /// pure waste (observed live: a Swift/Xcode repo paid a 1.28M-name Tier-1
 /// manifest over 755 JARs plus 1.66M sources-JAR symbols).
 pub(crate) fn workspace_has_gradle_markers(root: &Path) -> bool {
-    let marker_in = |dir: &Path| GRADLE_MARKERS.iter().any(|marker| dir.join(marker).exists());
+    let marker_in = |dir: &Path| {
+        GRADLE_MARKERS
+            .iter()
+            .any(|marker| dir.join(marker).exists())
+    };
     if marker_in(root) {
         return true;
     }
@@ -591,6 +595,7 @@ pub(crate) fn index_jars(
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     if jar_symbol_cache_guard.is_none() {
         *jar_symbol_cache_guard = Some(super::jar_cache::load_jar_cache());
+        super::jar_cache::note_jar_cache_loaded(indexer);
     }
     let Some(jar_cache) = jar_symbol_cache_guard.as_mut() else {
         // Unreachable: the branch above always populates `Some` when `None`.
@@ -1205,6 +1210,7 @@ fn jar_symbol_cache_is_fresh_for(
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     if jar_symbol_cache_guard.is_none() {
         *jar_symbol_cache_guard = Some(super::jar_cache::load_jar_cache());
+        super::jar_cache::note_jar_cache_loaded(indexer);
     }
     let Some(jar_cache) = jar_symbol_cache_guard.as_ref() else {
         return false;

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -565,7 +565,7 @@ pub(crate) fn index_jars(
 
     let mut total = 0usize;
     let mut cache_hits = 0usize;
-    let mut cache_dirty = false;
+    let mut newly_cached_entries = 0usize;
     let mut missed: Vec<(PathBuf, String)> = Vec::new();
 
     for path in paths {
@@ -596,7 +596,7 @@ pub(crate) fn index_jars(
                         total += count;
                         if let Some(entry) = super::jar_cache::make_cache_entry(&path, symbols) {
                             jar_cache.insert(path_key, entry);
-                            cache_dirty = true;
+                            newly_cached_entries += 1;
                         }
                     }
                 }
@@ -608,8 +608,11 @@ pub(crate) fn index_jars(
         }
     }
 
-    if cache_dirty {
-        super::jar_cache::save_jar_cache(jar_cache);
+    if newly_cached_entries > 0 {
+        // Throttled: on-demand promotion calls this once per cold JAR, and an
+        // unthrottled whole-map save per JAR was the wave-7 completion-timeout
+        // amplifier (see `maybe_save_jar_cache_throttled`).
+        super::jar_cache::maybe_save_jar_cache_throttled(indexer, jar_cache, newly_cached_entries);
     }
 
     if total > 0 {
@@ -877,21 +880,25 @@ fn build_jar_file_data(
         // name-keyed hover kept working. Overwrite only entries that are
         // themselves synthetic (not backed by `files`), which also lets a
         // re-materialization of the same JAR refresh its own entries.
+        // Copy the existing entry out and DROP the shard guard before touching
+        // `file_table` or `files`: holding a `qualified` shard guard while
+        // acquiring those locks inverts the documented lock order (see the
+        // interning comment in `apply.rs`) against `remove_stale_for_uri`,
+        // which holds a `files` guard across `qualified` writes — a real
+        // deadlock cycle under shard collision. The check-then-insert gap this
+        // opens (another thread inserting a parsed entry in between would be
+        // overwritten) is the same order race the crawl already tolerates.
         let synthetic_loc =
             crate::types::SymbolLoc::new(indexer.file_table.intern(fake_uri), symbols[i].range);
-        match indexer.qualified.entry(fqn) {
-            dashmap::mapref::entry::Entry::Occupied(mut occupied) => {
-                let existing_is_parsed = indexer
-                    .file_table
-                    .location(*occupied.get())
-                    .is_some_and(|existing| indexer.files.contains_key(existing.uri.as_str()));
-                if !existing_is_parsed {
-                    occupied.insert(synthetic_loc);
-                }
-            }
-            dashmap::mapref::entry::Entry::Vacant(vacant) => {
-                vacant.insert(synthetic_loc);
-            }
+        let existing_loc = indexer.qualified.get(&fqn).map(|entry| *entry.value());
+        let existing_is_parsed = existing_loc.is_some_and(|existing_loc| {
+            indexer
+                .file_table
+                .location(existing_loc)
+                .is_some_and(|existing| indexer.files.contains_key(existing.uri.as_str()))
+        });
+        if !existing_is_parsed {
+            indexer.qualified.insert(fqn, synthetic_loc);
         }
     }
 

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -105,6 +105,40 @@ pub(crate) fn scan_gradle_jars(gradle_home: Option<&Path>) -> Vec<PathBuf> {
     scan_gradle_jars_split(gradle_home).0
 }
 
+/// Gradle build files that mark a workspace as a Gradle project — the gate
+/// for the global `~/.gradle/caches` JAR pipeline. Deliberately Gradle-only
+/// (no `pom.xml`/`Cargo.toml`): the pipeline reads GRADLE's cache, which is
+/// only meaningful for a Gradle build; Maven/Bazel/manual JVM projects use
+/// the explicitly configured `jarPaths` instead.
+const GRADLE_MARKERS: [&str; 6] = [
+    "settings.gradle",
+    "settings.gradle.kts",
+    "build.gradle",
+    "build.gradle.kts",
+    "gradlew",
+    "gradle.properties",
+];
+
+/// True when the workspace root (or any directory one level below it, for
+/// monorepo layouts like `repo/{android,ios}` opened at `repo/`) contains a
+/// Gradle build file. Without one, the workspace cannot reference anything
+/// in the Gradle cache, and the compiled-JAR + sources-JAR pipelines are
+/// pure waste (observed live: a Swift/Xcode repo paid a 1.28M-name Tier-1
+/// manifest over 755 JARs plus 1.66M sources-JAR symbols).
+pub(crate) fn workspace_has_gradle_markers(root: &Path) -> bool {
+    let marker_in = |dir: &Path| GRADLE_MARKERS.iter().any(|marker| dir.join(marker).exists());
+    if marker_in(root) {
+        return true;
+    }
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return false;
+    };
+    entries
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .any(|entry| marker_in(&entry.path()))
+}
+
 /// Scan for sources JARs only.
 fn scan_gradle_sources_jars(gradle_home: Option<&Path>) -> Vec<PathBuf> {
     scan_gradle_jars_split(gradle_home).1

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -871,7 +871,17 @@ fn build_jar_file_data(
                 .chars()
                 .next()
                 .is_some_and(|c| c.is_ascii_uppercase());
-            if is_type_name && !candidate.is_empty() {
+            // ... and the candidate's LAST segment must start lowercase, the
+            // package-name convention. A package-less NESTED class detail
+            // ("class ContextualFlowColumnOverflow.Visible") otherwise
+            // parses as `pkg.Type` and poisons the whole jar's fallback
+            // package with an outer class name.
+            let candidate_is_package_like = candidate
+                .rsplit('.')
+                .next()
+                .and_then(|segment| segment.chars().next())
+                .is_some_and(|c| c.is_ascii_lowercase());
+            if is_type_name && candidate_is_package_like {
                 Some(candidate.to_owned())
             } else {
                 None
@@ -936,11 +946,28 @@ fn build_jar_file_data(
         }
     }
 
-    // Populate extension_by_receiver.
-    for sym in &symbols {
+    // Populate extension_by_receiver. `symbols` is index-aligned with
+    // `sidecar_symbols` (the qualified loop above already relies on it).
+    //
+    // The entry's package MUST be the sidecar's real per-symbol `pkg`, not
+    // the per-jar inferred `package`: a multi-package jar has no single
+    // package, and the inference can be outright garbage — in the real
+    // foundation-layout AAR its first dotted class-like detail is the
+    // package-less nested `class ContextualFlowColumnOverflow.Visible`, so
+    // every extension in the jar carried package
+    // "ContextualFlowColumnOverflow" and `extension_is_in_scope` rejected
+    // the user's explicitly imported `padding` — chained-call completion
+    // (`Modifier.padding().padd…`) returned nothing. The per-jar package
+    // remains only as a fallback for pre-v8 sidecars that emit no `pkg`.
+    for (i, sym) in symbols.iter().enumerate() {
         if sym.extension_receiver().is_empty() {
             continue;
         }
+        let symbol_package = sidecar_symbols
+            .get(i)
+            .filter(|sidecar_symbol| !sidecar_symbol.pkg.is_empty())
+            .map(|sidecar_symbol| sidecar_symbol.pkg.clone())
+            .or_else(|| package.clone());
         indexer
             .extension_by_receiver
             .entry(sym.extension_receiver().to_owned())
@@ -951,7 +978,7 @@ fn build_jar_file_data(
                 kind: sym.kind,
                 detail: sym.detail.clone(),
                 visibility: Visibility::Public,
-                package: package.clone(),
+                package: symbol_package,
                 trailing_lambda: sym.trailing_lambda,
                 deprecated: sym.deprecated,
             });

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -105,42 +105,26 @@ pub(crate) fn scan_gradle_jars(gradle_home: Option<&Path>) -> Vec<PathBuf> {
     scan_gradle_jars_split(gradle_home).0
 }
 
-/// Gradle build files that mark a workspace as a Gradle project — the gate
-/// for the global `~/.gradle/caches` JAR pipeline. Deliberately Gradle-only
-/// (no `pom.xml`/`Cargo.toml`): the pipeline reads GRADLE's cache, which is
-/// only meaningful for a Gradle build; Maven/Bazel/manual JVM projects use
-/// the explicitly configured `jarPaths` instead.
-const GRADLE_MARKERS: [&str; 6] = [
-    "settings.gradle",
-    "settings.gradle.kts",
-    "build.gradle",
-    "build.gradle.kts",
-    "gradlew",
-    "gradle.properties",
-];
-
-/// True when the workspace root (or any directory one level below it, for
-/// monorepo layouts like `repo/{android,ios}` opened at `repo/`) contains a
-/// Gradle build file. Without one, the workspace cannot reference anything
-/// in the Gradle cache, and the compiled-JAR + sources-JAR pipelines are
-/// pure waste (observed live: a Swift/Xcode repo paid a 1.28M-name Tier-1
-/// manifest over 755 JARs plus 1.66M sources-JAR symbols).
-pub(crate) fn workspace_has_gradle_markers(root: &Path) -> bool {
-    let marker_in = |dir: &Path| {
-        GRADLE_MARKERS
-            .iter()
-            .any(|marker| dir.join(marker).exists())
-    };
-    if marker_in(root) {
-        return true;
-    }
-    let Ok(entries) = std::fs::read_dir(root) else {
-        return false;
-    };
-    entries
-        .flatten()
-        .filter(|entry| entry.path().is_dir())
-        .any(|entry| marker_in(&entry.path()))
+/// True when the index contains at least one WORKSPACE Kotlin/Java source
+/// file — the gate for the global `~/.gradle/caches` JAR pipeline. A
+/// Swift-only workspace cannot reference JVM libraries, and unconditionally
+/// running the pipeline there cost a 1.28M-name Tier-1 manifest over 755
+/// JARs plus a 1.66M-symbol sources-JAR pass (observed live on an iOS repo).
+///
+/// Deliberately asks the INDEX (fully populated before the jar scan starts)
+/// instead of probing build files: a build-marker heuristic wrongly excluded
+/// non-Gradle JVM builds (Maven/Bazel/manual) and Gradle repos opened at a
+/// deep subdirectory (markers only above the root), and duplicated the
+/// root-marker detection that already lives in `document_handler`. Library
+/// source-set files (sourcePaths, extracted jar sources) don't count — they
+/// are not the workspace's own code.
+pub(crate) fn workspace_has_jvm_sources(indexer: &crate::indexer::Indexer) -> bool {
+    indexer.files.iter().any(|entry| {
+        entry.value().source_set != SourceSet::Library
+            && (entry.key().ends_with(".kt")
+                || entry.key().ends_with(".kts")
+                || entry.key().ends_with(".java"))
+    })
 }
 
 /// Scan for sources JARs only.

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -175,6 +175,8 @@ pub(crate) fn load_jar_cache() -> HashMap<String, JarCacheEntry> {
 /// acceptable: saves happen only on cache-miss materializations (rare once
 /// warm) and at crawl end.
 pub(crate) fn save_jar_cache(entries: &HashMap<String, JarCacheEntry>) {
+    #[cfg(test)]
+    SAVE_JAR_CACHE_CALLS.with(|count| count.set(count.get() + 1));
     let path = cache_path();
     if let Some(parent) = path.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
@@ -225,6 +227,99 @@ pub(crate) fn save_jar_cache(entries: &HashMap<String, JarCacheEntry>) {
         record_cache_file_fingerprint(&path);
         log::debug!("jar_cache: saved {} entries", entries.len());
     }
+}
+
+// Test-only instrumentation: counts, per test thread, how many times
+// `save_jar_cache` has been invoked — used to prove the save throttle
+// coalesces per-promotion whole-map writes. Thread-local for the same
+// parallel-test-isolation reason as `LOAD_JAR_CACHE_CALLS` above.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static SAVE_JAR_CACHE_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// How many newly cached JAR entries may accumulate unsaved before a save is
+/// forced regardless of the debounce window.
+pub(crate) const JAR_CACHE_SAVE_PENDING_LIMIT: usize = 16;
+
+/// Minimum interval between successive whole-map cache saves (except when
+/// [`JAR_CACHE_SAVE_PENDING_LIMIT`] forces one sooner).
+pub(crate) const JAR_CACHE_SAVE_DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Per-`Indexer` state for the save throttle: how many newly cached entries
+/// are not yet persisted, and when the last save ran.
+#[derive(Default)]
+pub(crate) struct JarCacheSaveThrottle {
+    pub(crate) pending_entries: usize,
+    pub(crate) last_save: Option<std::time::Instant>,
+}
+
+/// Throttled wrapper around [`save_jar_cache`] for the on-demand promotion
+/// path. `index_jars` runs once per promoted JAR there, and each save
+/// serializes and writes the ENTIRE memoized map — on a real
+/// multi-hundred-MB cache, one whole-map write per cold JAR turned a
+/// cache-heal storm (40+ cold promotions in a minute) into 40+ full
+/// serialize+write cycles inside interactive requests, pushing completion
+/// past the editor's timeout (wave-7 incident). Policy: save immediately
+/// when nothing has been persisted yet this session, then coalesce until
+/// [`JAR_CACHE_SAVE_PENDING_LIMIT`] entries accumulate or
+/// [`JAR_CACHE_SAVE_DEBOUNCE`] elapses. Suppressed entries stay in the
+/// memoized map (which every save writes in full, so nothing is ever
+/// dropped — only deferred); the LSP `shutdown` handler flushes the tail via
+/// [`flush_pending_jar_cache_save`], and a crash loses at most the pending
+/// tail — re-fetched and re-saved on next use, since the memoized map is
+/// rebuilt from the same immutable JARs.
+///
+/// Callers hold the `jar_symbol_cache` mutex (`entries` borrows from it);
+/// the throttle mutex nests INSIDE it — [`flush_pending_jar_cache_save`]
+/// takes them in the same order.
+pub(crate) fn maybe_save_jar_cache_throttled(
+    indexer: &crate::indexer::Indexer,
+    entries: &HashMap<String, JarCacheEntry>,
+    newly_added: usize,
+) {
+    let mut throttle = indexer
+        .jar_cache_save_throttle
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    throttle.pending_entries += newly_added;
+    let save_is_due = match throttle.last_save {
+        None => true,
+        Some(last_save) => {
+            last_save.elapsed() >= JAR_CACHE_SAVE_DEBOUNCE
+                || throttle.pending_entries >= JAR_CACHE_SAVE_PENDING_LIMIT
+        }
+    };
+    if !save_is_due {
+        return;
+    }
+    save_jar_cache(entries);
+    throttle.pending_entries = 0;
+    throttle.last_save = Some(std::time::Instant::now());
+}
+
+/// Persist any entries the save throttle has suppressed. Called from the LSP
+/// `shutdown` handler so a session's last few cached JARs aren't stranded
+/// in memory. Takes `jar_symbol_cache` BEFORE the throttle mutex — the same
+/// order as the `index_jars` → [`maybe_save_jar_cache_throttled`] path.
+pub(crate) fn flush_pending_jar_cache_save(indexer: &crate::indexer::Indexer) {
+    let jar_symbol_cache_guard = indexer
+        .jar_symbol_cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(entries) = jar_symbol_cache_guard.as_ref() else {
+        return;
+    };
+    let mut throttle = indexer
+        .jar_cache_save_throttle
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if throttle.pending_entries == 0 {
+        return;
+    }
+    save_jar_cache(entries);
+    throttle.pending_entries = 0;
+    throttle.last_save = Some(std::time::Instant::now());
 }
 
 /// Test-only: forget this process's recorded fingerprint for the current

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -298,6 +298,22 @@ pub(crate) fn maybe_save_jar_cache_throttled(
     throttle.last_save = Some(std::time::Instant::now());
 }
 
+/// Start the save-throttle debounce clock when the memoized cache is first
+/// decoded. Without this, a fully-warm session (crawl saves nothing, so
+/// `last_save` stays `None`) pays an immediate whole-map serialize+write on
+/// its FIRST interactive cold promotion; with it, that save coalesces like
+/// every later one. Callers hold `jar_symbol_cache` — same lock order as
+/// [`maybe_save_jar_cache_throttled`].
+pub(crate) fn note_jar_cache_loaded(indexer: &crate::indexer::Indexer) {
+    let mut throttle = indexer
+        .jar_cache_save_throttle
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if throttle.last_save.is_none() {
+        throttle.last_save = Some(std::time::Instant::now());
+    }
+}
+
 /// Persist any entries the save throttle has suppressed. Called from the LSP
 /// `shutdown` handler so a session's last few cached JARs aren't stranded
 /// in memory. Takes `jar_symbol_cache` BEFORE the throttle mutex — the same

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -2002,3 +2002,150 @@ fn save_jar_cache_skips_the_reload_when_the_file_is_unchanged() {
         );
     });
 }
+
+/// Build a one-entry cache map backed by a real file under `dir`, for the
+/// save-throttle tests below.
+fn one_entry_cache_map(
+    dir: &std::path::Path,
+    jar_file_name: &str,
+) -> std::collections::HashMap<String, crate::indexer::jar_cache::JarCacheEntry> {
+    let jar_path = dir.join(jar_file_name);
+    std::fs::write(&jar_path, b"jar bytes").expect("write fake jar");
+    let entry = crate::indexer::jar_cache::make_cache_entry(
+        &jar_path,
+        vec![make_sidecar_symbol("TypeA", "class", "class TypeA", "")],
+    )
+    .expect("cache entry");
+    let mut map = std::collections::HashMap::new();
+    map.insert(jar_path.to_string_lossy().to_string(), entry);
+    map
+}
+
+fn save_calls() -> usize {
+    crate::indexer::jar_cache::SAVE_JAR_CACHE_CALLS.with(|count| count.get())
+}
+
+/// Wave-7 amplifier regression: on-demand materialization saved the ENTIRE
+/// multi-hundred-MB cache map once per cold JAR — during a cache-heal storm
+/// (40+ cold promotions in a minute) that meant 40+ whole-map serialize+write
+/// cycles, each inside an interactive request's promotion, pushing completion
+/// past the editor's timeout. Saves must be throttled: immediate on the first
+/// dirty entries, then coalesced until enough entries accumulate or the
+/// debounce window elapses.
+#[test]
+fn jar_cache_save_throttle_coalesces_saves_within_the_debounce_window() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    crate::indexer::test_helpers::with_xdg_cache(tmp.path(), || {
+        let idx = crate::indexer::Indexer::new();
+        let map = one_entry_cache_map(tmp.path(), "lib-a.jar");
+
+        let before = save_calls();
+        crate::indexer::jar_cache::maybe_save_jar_cache_throttled(&idx, &map, 1);
+        assert_eq!(
+            save_calls(),
+            before + 1,
+            "the first dirty entries of a session must save immediately \
+             (nothing persisted yet)"
+        );
+
+        for _ in 0..5 {
+            crate::indexer::jar_cache::maybe_save_jar_cache_throttled(&idx, &map, 1);
+        }
+        assert_eq!(
+            save_calls(),
+            before + 1,
+            "follow-up single-entry saves inside the debounce window must \
+             coalesce, not rewrite the whole map per promoted JAR"
+        );
+    });
+}
+
+#[test]
+fn jar_cache_save_throttle_saves_when_enough_entries_accumulate() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    crate::indexer::test_helpers::with_xdg_cache(tmp.path(), || {
+        let idx = crate::indexer::Indexer::new();
+        let map = one_entry_cache_map(tmp.path(), "lib-a.jar");
+
+        crate::indexer::jar_cache::maybe_save_jar_cache_throttled(&idx, &map, 1);
+        let after_first = save_calls();
+
+        // Accumulate to the pending limit inside the debounce window: the
+        // throttle must flush rather than let an unbounded backlog build up.
+        crate::indexer::jar_cache::maybe_save_jar_cache_throttled(
+            &idx,
+            &map,
+            crate::indexer::jar_cache::JAR_CACHE_SAVE_PENDING_LIMIT,
+        );
+        assert_eq!(
+            save_calls(),
+            after_first + 1,
+            "reaching the pending-entry limit must force a save even inside \
+             the debounce window"
+        );
+    });
+}
+
+#[test]
+fn jar_cache_save_throttle_saves_again_after_the_debounce_elapses() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    crate::indexer::test_helpers::with_xdg_cache(tmp.path(), || {
+        let idx = crate::indexer::Indexer::new();
+        let map = one_entry_cache_map(tmp.path(), "lib-a.jar");
+
+        crate::indexer::jar_cache::maybe_save_jar_cache_throttled(&idx, &map, 1);
+        let after_first = save_calls();
+
+        // Rewind the recorded last-save instant past the debounce window —
+        // equivalent to real time passing without sleeping in the test.
+        {
+            let mut throttle = idx
+                .jar_cache_save_throttle
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            throttle.last_save = std::time::Instant::now()
+                .checked_sub(crate::indexer::jar_cache::JAR_CACHE_SAVE_DEBOUNCE * 2);
+        }
+
+        crate::indexer::jar_cache::maybe_save_jar_cache_throttled(&idx, &map, 1);
+        assert_eq!(
+            save_calls(),
+            after_first + 1,
+            "once the debounce window has elapsed, the next dirty entries \
+             must persist"
+        );
+    });
+}
+
+/// Entries suppressed by the throttle must not be stranded in memory when the
+/// editor shuts down: the LSP `shutdown` handler flushes the tail.
+#[test]
+fn flush_pending_jar_cache_save_persists_the_suppressed_tail() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    crate::indexer::test_helpers::with_xdg_cache(tmp.path(), || {
+        let idx = crate::indexer::Indexer::new();
+        let map = one_entry_cache_map(tmp.path(), "lib-a.jar");
+
+        crate::indexer::jar_cache::maybe_save_jar_cache_throttled(&idx, &map, 1);
+        // Second single entry: suppressed by the debounce, left pending.
+        crate::indexer::jar_cache::maybe_save_jar_cache_throttled(&idx, &map, 1);
+        *idx.jar_symbol_cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(map.clone());
+
+        let before = save_calls();
+        crate::indexer::jar_cache::flush_pending_jar_cache_save(&idx);
+        assert_eq!(
+            save_calls(),
+            before + 1,
+            "a flush with pending suppressed entries must write the cache"
+        );
+
+        crate::indexer::jar_cache::flush_pending_jar_cache_save(&idx);
+        assert_eq!(
+            save_calls(),
+            before + 1,
+            "a flush with nothing pending must be a no-op"
+        );
+    });
+}

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -2187,3 +2187,4 @@ fn gradle_marker_probe_accepts_gradle_one_level_below_the_root() {
     std::fs::write(android.join("build.gradle"), b"").expect("write");
     assert!(crate::indexer::jar::workspace_has_gradle_markers(tmp.path()));
 }
+

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -2149,3 +2149,41 @@ fn flush_pending_jar_cache_save_persists_the_suppressed_tail() {
         );
     });
 }
+
+// ── workspace_has_gradle_markers (Gradle-cache scan gate) ───────────────────
+
+/// A Swift/Xcode workspace (no Gradle build files anywhere near the root)
+/// must NOT trigger the global Gradle-cache JAR pipeline: on a real machine
+/// that pipeline manifested 1.28M names from 755 compiled JARs and parsed
+/// 1.66M symbols out of 521 sources JARs — pure waste for a project that
+/// cannot reference any of them (observed live on an iOS repo). Explicitly
+/// configured `jarPaths` remain the escape hatch for non-Gradle JVM builds.
+#[test]
+fn gradle_marker_probe_rejects_a_swift_only_workspace() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(tmp.path().join("Package.swift"), b"// swift").expect("write");
+    std::fs::create_dir_all(tmp.path().join("App.xcodeproj")).expect("mkdir");
+    assert!(
+        !crate::indexer::jar::workspace_has_gradle_markers(tmp.path()),
+        "a Swift-only workspace must not opt into the Gradle-cache scan"
+    );
+}
+
+#[test]
+fn gradle_marker_probe_accepts_gradle_at_the_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(tmp.path().join("settings.gradle.kts"), b"").expect("write");
+    assert!(crate::indexer::jar::workspace_has_gradle_markers(tmp.path()));
+}
+
+/// Monorepo layout: the user opens the parent directory whose CHILD holds the
+/// Gradle project (e.g. `repo/{android,ios}` opened at `repo/`). Markers one
+/// level below the root must still enable the scan.
+#[test]
+fn gradle_marker_probe_accepts_gradle_one_level_below_the_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let android = tmp.path().join("android");
+    std::fs::create_dir_all(&android).expect("mkdir");
+    std::fs::write(android.join("build.gradle"), b"").expect("write");
+    assert!(crate::indexer::jar::workspace_has_gradle_markers(tmp.path()));
+}

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -2150,44 +2150,61 @@ fn flush_pending_jar_cache_save_persists_the_suppressed_tail() {
     });
 }
 
-// ── workspace_has_gradle_markers (Gradle-cache scan gate) ───────────────────
+// ── workspace_has_jvm_sources (Gradle-cache scan gate) ──────────────────────
 
-/// A Swift/Xcode workspace (no Gradle build files anywhere near the root)
-/// must NOT trigger the global Gradle-cache JAR pipeline: on a real machine
-/// that pipeline manifested 1.28M names from 755 compiled JARs and parsed
-/// 1.66M symbols out of 521 sources JARs — pure waste for a project that
-/// cannot reference any of them (observed live on an iOS repo). Explicitly
-/// configured `jarPaths` remain the escape hatch for non-Gradle JVM builds.
+/// A Swift-only workspace must NOT trigger the global Gradle-cache JAR
+/// pipeline: on a real machine that pipeline manifested 1.28M names from
+/// 755 compiled JARs and parsed 1.66M symbols out of 521 sources JARs —
+/// pure waste for a project that cannot reference any of them (observed
+/// live on an iOS repo). The gate asks the INDEX (already populated when
+/// the jar scan starts) rather than probing build files: build-marker
+/// heuristics wrongly excluded non-Gradle JVM projects (Maven/Bazel) and
+/// Gradle repos opened at a deep subdirectory, and duplicated the root
+/// detection that already lives in document_handler.
 #[test]
-fn gradle_marker_probe_rejects_a_swift_only_workspace() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    std::fs::write(tmp.path().join("Package.swift"), b"// swift").expect("write");
-    std::fs::create_dir_all(tmp.path().join("App.xcodeproj")).expect("mkdir");
+fn jvm_source_probe_rejects_a_swift_only_workspace() {
+    let idx = crate::indexer::Indexer::new();
+    idx.index_content(
+        &tower_lsp::lsp_types::Url::parse("file:///ios/App.swift").unwrap(),
+        "struct App {}",
+    );
     assert!(
-        !crate::indexer::jar::workspace_has_gradle_markers(tmp.path()),
+        !crate::indexer::jar::workspace_has_jvm_sources(&idx),
         "a Swift-only workspace must not opt into the Gradle-cache scan"
     );
 }
 
 #[test]
-fn gradle_marker_probe_accepts_gradle_at_the_root() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    std::fs::write(tmp.path().join("settings.gradle.kts"), b"").expect("write");
-    assert!(crate::indexer::jar::workspace_has_gradle_markers(
-        tmp.path()
-    ));
+fn jvm_source_probe_accepts_kotlin_sources_regardless_of_build_system() {
+    let idx = crate::indexer::Indexer::new();
+    idx.index_content(
+        &tower_lsp::lsp_types::Url::parse("file:///ios/App.swift").unwrap(),
+        "struct App {}",
+    );
+    idx.index_content(
+        &tower_lsp::lsp_types::Url::parse("file:///shared/Model.kt").unwrap(),
+        "package shared\nclass Model",
+    );
+    assert!(
+        crate::indexer::jar::workspace_has_jvm_sources(&idx),
+        "any indexed Kotlin/Java source opts in — Maven/Bazel projects and \
+         deep-subdirectory opens of Gradle repos have no root build markers \
+         but still reference libraries"
+    );
 }
 
-/// Monorepo layout: the user opens the parent directory whose CHILD holds the
-/// Gradle project (e.g. `repo/{android,ios}` opened at `repo/`). Markers one
-/// level below the root must still enable the scan.
 #[test]
-fn gradle_marker_probe_accepts_gradle_one_level_below_the_root() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let android = tmp.path().join("android");
-    std::fs::create_dir_all(&android).expect("mkdir");
-    std::fs::write(android.join("build.gradle"), b"").expect("write");
-    assert!(crate::indexer::jar::workspace_has_gradle_markers(
-        tmp.path()
-    ));
+fn jvm_source_probe_ignores_library_sources() {
+    // Library-source-set files (sourcePaths / extracted jar sources) are not
+    // the workspace's own code — they must not opt a Swift project into the
+    // JVM pipeline on their own.
+    let idx = crate::indexer::Indexer::new();
+    let uri = tower_lsp::lsp_types::Url::parse("file:///sdk/lib/Api.kt").unwrap();
+    idx.index_content(&uri, "package lib\nclass Api");
+    if let Some(mut file) = idx.files.get_mut(uri.as_str()) {
+        let mut data = (**file.value()).clone();
+        data.source_set = crate::types::SourceSet::Library;
+        *file.value_mut() = std::sync::Arc::new(data);
+    }
+    assert!(!crate::indexer::jar::workspace_has_jvm_sources(&idx));
 }

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -2173,7 +2173,9 @@ fn gradle_marker_probe_rejects_a_swift_only_workspace() {
 fn gradle_marker_probe_accepts_gradle_at_the_root() {
     let tmp = tempfile::tempdir().expect("tempdir");
     std::fs::write(tmp.path().join("settings.gradle.kts"), b"").expect("write");
-    assert!(crate::indexer::jar::workspace_has_gradle_markers(tmp.path()));
+    assert!(crate::indexer::jar::workspace_has_gradle_markers(
+        tmp.path()
+    ));
 }
 
 /// Monorepo layout: the user opens the parent directory whose CHILD holds the
@@ -2185,6 +2187,7 @@ fn gradle_marker_probe_accepts_gradle_one_level_below_the_root() {
     let android = tmp.path().join("android");
     std::fs::create_dir_all(&android).expect("mkdir");
     std::fs::write(android.join("build.gradle"), b"").expect("write");
-    assert!(crate::indexer::jar::workspace_has_gradle_markers(tmp.path()));
+    assert!(crate::indexer::jar::workspace_has_gradle_markers(
+        tmp.path()
+    ));
 }
-

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -1070,12 +1070,69 @@ fn symbols_from_nested_type(
     // membership signal for jar-backed files. Without this, every member of
     // a compiled-only library class (no sources JAR published) is invisible
     // to member enumeration, while name-keyed lookups (hover) keep working.
+    //
+    // `container` holds the declaring class's SIMPLE name, and one synthetic
+    // FileData spans the whole JAR — so two top-level classes sharing a
+    // simple name in different packages of one JAR would have their members
+    // merged. Disambiguate with the per-symbol package side table
+    // (`jar_symbol_packages`, index-aligned with `symbols`): members must
+    // match the package of the `inner_name` class the caller means — the
+    // caller's explicit import when present, the declaring class symbol's
+    // own package otherwise. Also drop deprecated members: JAR symbols are
+    // always `Public`, so the shared visibility filter below never fires
+    // for them, and project policy hides deprecated library symbols from
+    // completion entirely (same as the direct jar-definitions paths).
     if indexer.jar_files.contains_key(file_uri) {
-        return symbols
-            .iter()
-            .filter(|symbol| symbol.container.as_deref() == Some(inner_name))
-            .filter(|symbol| symbol.visibility != Visibility::Private)
-            .map(|symbol| completion_item_for_nested_symbol(indexer, symbol, file_uri, caller))
+        let member_indices: Vec<usize> = {
+            let symbol_packages = indexer.jar_symbol_packages.get(file_uri);
+            let package_at = |index: usize| -> Option<&str> {
+                symbol_packages
+                    .as_ref()
+                    .and_then(|packages| packages.value().get(index))
+                    .map(String::as_str)
+            };
+            let imported_package = caller.uri.and_then(|caller_uri| {
+                let caller_file = indexer.files.get(caller_uri)?;
+                caller_file.imports.iter().find_map(|import| {
+                    (!import.is_star && import.local_name == inner_name)
+                        .then(|| import.full_path.strip_suffix(&format!(".{inner_name}")))
+                        .flatten()
+                        .map(str::to_owned)
+                })
+            });
+            let declaring_class_package = imported_package.or_else(|| {
+                symbols
+                    .iter()
+                    .position(|symbol| std::ptr::eq(symbol, type_symbol))
+                    .and_then(package_at)
+                    .map(str::to_owned)
+            });
+            symbols
+                .iter()
+                .enumerate()
+                .filter(|(_, symbol)| symbol.container.as_deref() == Some(inner_name))
+                .filter(|(index, _)| {
+                    match (declaring_class_package.as_deref(), package_at(*index)) {
+                        (Some(class_package), Some(member_package)) => {
+                            class_package == member_package
+                        }
+                        // Older cache entries without per-symbol packages:
+                        // keep the container match rather than dropping all.
+                        _ => true,
+                    }
+                })
+                .filter(|(_, symbol)| !symbol.deprecated)
+                .filter(|(_, symbol)| symbol.visibility != Visibility::Private)
+                .map(|(index, _)| index)
+                .collect()
+            // `symbol_packages` dashmap guard drops here — before the item
+            // construction below touches the indexer again.
+        };
+        return member_indices
+            .into_iter()
+            .map(|index| {
+                completion_item_for_nested_symbol(indexer, &symbols[index], file_uri, caller)
+            })
             .collect();
     }
 

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -276,7 +276,6 @@ impl ReceiverExpr {
     pub(crate) fn as_str(&self) -> &str {
         &self.chain
     }
-
 }
 
 /// Provide completion candidates for `prefix` at the current position.
@@ -1130,40 +1129,73 @@ fn symbols_from_nested_type(
                     .and_then(|packages| packages.value().get(index))
                     .map(String::as_str)
             };
-            let imported_package = caller.uri.and_then(|caller_uri| {
-                let caller_file = indexer.files.get(caller_uri)?;
-                caller_file.imports.iter().find_map(|import| {
-                    (!import.is_star && import.local_name == inner_name)
-                        .then(|| import.full_path.strip_suffix(&format!(".{inner_name}")))
-                        .flatten()
-                        .map(str::to_owned)
-                })
-            });
-            let declaring_class_package = imported_package.or_else(|| {
-                symbols
-                    .iter()
-                    .position(|symbol| std::ptr::eq(symbol, type_symbol))
-                    .and_then(package_at)
-                    .map(str::to_owned)
-            });
-            symbols
+            // Candidate members: container match + the shared symbol filters.
+            let candidate_indices: Vec<usize> = symbols
                 .iter()
                 .enumerate()
                 .filter(|(_, symbol)| symbol.container.as_deref() == Some(inner_name))
-                .filter(|(index, _)| {
-                    match (declaring_class_package.as_deref(), package_at(*index)) {
-                        (Some(class_package), Some(member_package)) => {
-                            class_package == member_package
-                        }
-                        // Older cache entries without per-symbol packages:
-                        // keep the container match rather than dropping all.
-                        _ => true,
-                    }
-                })
                 .filter(|(_, symbol)| !symbol.deprecated)
                 .filter(|(_, symbol)| symbol.visibility != Visibility::Private)
                 .map(|(index, _)| index)
-                .collect()
+                .collect();
+
+            // Package disambiguation via IMPORT-COVERAGE semantics
+            // (`ImportEntry::covers`), which — unlike a naive
+            // `full_path.strip_suffix(".Name")` — understands nested-class
+            // imports (`import com.example.Outer.Config` covers `Config`
+            // declared in package `com.example`). Members the caller's
+            // import covers win; when the import covers NONE of them (or no
+            // import names this class), fall back to the declaring class
+            // symbol's own package so the enumeration never goes empty just
+            // because the import points at a different library's same-named
+            // class.
+            let caller_imports: Vec<crate::types::ImportEntry> = caller
+                .uri
+                .and_then(|caller_uri| {
+                    indexer.files.get(caller_uri).map(|caller_file| {
+                        caller_file
+                            .imports
+                            .iter()
+                            .filter(|import| !import.is_star && import.local_name == inner_name)
+                            .cloned()
+                            .collect()
+                    })
+                })
+                .unwrap_or_default();
+            let import_covered: Vec<usize> = candidate_indices
+                .iter()
+                .copied()
+                .filter(|index| {
+                    package_at(*index).is_some_and(|member_package| {
+                        caller_imports
+                            .iter()
+                            .any(|import| import.covers(member_package, inner_name))
+                    })
+                })
+                .collect();
+            if !import_covered.is_empty() {
+                import_covered
+            } else {
+                let declaring_class_package = symbols
+                    .iter()
+                    .position(|symbol| std::ptr::eq(symbol, type_symbol))
+                    .and_then(package_at)
+                    .map(str::to_owned);
+                candidate_indices
+                    .into_iter()
+                    .filter(|index| {
+                        match (declaring_class_package.as_deref(), package_at(*index)) {
+                            (Some(class_package), Some(member_package)) => {
+                                class_package == member_package
+                            }
+                            // Older cache entries without per-symbol
+                            // packages: keep the container match rather
+                            // than dropping all.
+                            _ => true,
+                        }
+                    })
+                    .collect()
+            }
             // `symbol_packages` dashmap guard drops here — before the item
             // construction below touches the indexer again.
         };

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -176,30 +176,92 @@ impl ReceiverExpr {
             Cow::Borrowed(before_prefix)
         };
         let before_dot = normalized.strip_suffix('.')?;
-        let (before_call, is_call) = if before_dot.trim_end().ends_with(')') {
-            (Self::strip_call_args(before_dot.trim_end()), true)
-        } else {
-            (before_dot, false)
+        // Scan backwards for a chain of `ident` / `ident(...)` segments,
+        // skipping every BALANCED argument list — the real Compose idiom is
+        // several calls in a row (`Modifier.fillMaxSize().padding(x).`), and
+        // stripping only the trailing call left the scanner stranded on the
+        // previous `)`. Each skipped argument list is normalized to `()` so
+        // the dotted-chain resolver (which trims `()` per segment) can walk
+        // segment return types. Identifier bytes >= 0x80 keep non-ASCII
+        // identifiers working.
+        let scan_text = before_dot.trim_end();
+        let bytes = scan_text.as_bytes();
+        let mut i = scan_text.len();
+        // Chain pieces in reverse order: "()", identifiers, ".".
+        let mut reversed_parts: Vec<&str> = Vec::new();
+        let scan_identifier_back = |bytes: &[u8], mut from: usize| -> usize {
+            while from > 0 {
+                let c = bytes[from - 1];
+                if c.is_ascii_alphanumeric() || c == b'_' || c >= 0x80 {
+                    from -= 1;
+                } else {
+                    break;
+                }
+            }
+            from
         };
-        // Scan backwards for a dotted identifier chain.
-        // Includes bytes >= 0x80 to support non-ASCII identifiers.
-        let bytes = before_call.as_bytes();
-        let mut start = before_call.len();
-        for i in (0..before_call.len()).rev() {
-            let c = bytes[i];
-            if c.is_ascii_alphanumeric() || c == b'_' || c == b'.' || c >= 0x80 {
-                start = i;
+        loop {
+            if i > 0 && bytes[i - 1] == b')' {
+                let mut depth = 0usize;
+                let mut j = i;
+                let mut balanced = false;
+                while j > 0 {
+                    j -= 1;
+                    match bytes[j] {
+                        b')' => depth += 1,
+                        b'(' => {
+                            depth -= 1;
+                            if depth == 0 {
+                                balanced = true;
+                                break;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                if !balanced {
+                    break;
+                }
+                let ident_start = scan_identifier_back(bytes, j);
+                if ident_start == j {
+                    // An argument list with no callee name before it (e.g.
+                    // a closing `)` of surrounding syntax) — not a chain.
+                    break;
+                }
+                reversed_parts.push("()");
+                reversed_parts.push(&scan_text[ident_start..j]);
+                i = ident_start;
+            } else {
+                let ident_start = scan_identifier_back(bytes, i);
+                if ident_start == i {
+                    break;
+                }
+                reversed_parts.push(&scan_text[ident_start..i]);
+                i = ident_start;
+            }
+            if i > 0 && bytes[i - 1] == b'.' {
+                reversed_parts.push(".");
+                i -= 1;
             } else {
                 break;
             }
         }
-        let chain = before_call[start..].trim();
-        if chain.is_empty() || chain.starts_with('.') || chain.ends_with('.') {
+        // A chain whose scan ended ON a dot continues on an earlier line —
+        // the caller may retry with the joined multiline text.
+        if reversed_parts.is_empty() || reversed_parts.last() == Some(&".") {
             return None;
         }
+        let ends_with_call = reversed_parts.first() == Some(&"()");
+        let mut chain: String = reversed_parts.into_iter().rev().collect();
+        if ends_with_call {
+            // The FINAL segment's `()` is dropped (`is_call` carries that
+            // fact), matching the single-call behavior consumers rely on;
+            // intermediate segments keep their `()` markers.
+            chain.truncate(chain.len() - 2);
+        }
         Some(Self {
-            chain: chain.to_owned(),
-            is_call,
+            chain,
+            is_call: ends_with_call,
         })
     }
 
@@ -215,29 +277,6 @@ impl ReceiverExpr {
         &self.chain
     }
 
-    /// Strip a balanced trailing `(...)`, e.g. `"foo(arg, bar())"` → `"foo"`.
-    fn strip_call_args(s: &str) -> &str {
-        let bytes = s.as_bytes();
-        let mut depth = 0usize;
-        let mut i = bytes.len();
-        loop {
-            if i == 0 {
-                break;
-            }
-            i -= 1;
-            match bytes[i] {
-                b')' => depth += 1,
-                b'(' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        return s[..i].trim_end();
-                    }
-                }
-                _ => {}
-            }
-        }
-        s
-    }
 }
 
 /// Provide completion candidates for `prefix` at the current position.

--- a/src/resolver/hierarchy.rs
+++ b/src/resolver/hierarchy.rs
@@ -5,6 +5,22 @@ use std::collections::HashSet;
 use crate::indexer::Indexer;
 use crate::types::{CallerContext, FileData};
 
+/// Per-WALK cap on blocking sidecar-IPC promotion attempts for ancestor
+/// classes living in not-yet-materialized JARs. The walk runs on paths that
+/// carry no promotion budget of their own — per-name inference (inlay hints
+/// fan `resolve_from_class_hierarchy` out across every visible name) and
+/// bare completion's inherited-members collector — so an unbudgeted
+/// promotion here bypassed every existing request cap: with a cold cache,
+/// each distinct un-cached ancestor JAR paid a ~200ms blocking round trip,
+/// unbounded across a walk. Cache-backed promotions bypass this (free, pure
+/// in-memory); genuinely cold ancestors beyond the cap stay Tier-1 for this
+/// walk and are covered by file-open import promotion or a later walk —
+/// `materialized`/`materialization_failed` memoize outcomes, so per session
+/// each JAR pays at most one attempt. Per-REQUEST budget threading (one
+/// budget shared across all the walks a request triggers) is deferred to
+/// the accessor-function refactor.
+pub(crate) const MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK: usize = 3;
+
 /// Walk the class hierarchy starting from `start_class`, collecting items at each level.
 /// `T` is what the visitor produces per symbol. `max_depth` prevents infinite loops.
 pub(crate) fn walk_hierarchy<'a, T, F>(
@@ -25,6 +41,7 @@ where
         collect,
         visited: HashSet::from([(start_uri.to_owned(), start_class.to_owned())]),
         items: Vec::new(),
+        sidecar_budget: MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
     };
     walker.recurse(start_class, start_uri, 0);
     walker.items
@@ -40,6 +57,9 @@ where
     collect: F,
     visited: HashSet<(String, String)>,
     items: Vec<T>,
+    /// Remaining blocking-IPC promotion attempts for THIS walk (see
+    /// [`MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK`]).
+    sidecar_budget: usize,
 }
 
 impl<'a, T, F> HierarchyWalker<'a, T, F>
@@ -51,7 +71,9 @@ where
             return;
         }
 
-        for (super_name, super_uri) in supertype_targets(self.idx, class_name, class_uri) {
+        for (super_name, super_uri) in
+            supertype_targets(self.idx, class_name, class_uri, &mut self.sidecar_budget)
+        {
             if !self.visited.insert((super_uri.clone(), super_name.clone())) {
                 continue;
             }
@@ -66,7 +88,12 @@ where
     }
 }
 
-fn supertype_targets(idx: &Indexer, class_name: &str, class_uri: &str) -> Vec<(String, String)> {
+fn supertype_targets(
+    idx: &Indexer,
+    class_name: &str,
+    class_uri: &str,
+    sidecar_budget: &mut usize,
+) -> Vec<(String, String)> {
     use tower_lsp::lsp_types::Url;
     let Ok(uri) = Url::parse(class_uri) else {
         return vec![];
@@ -83,9 +110,15 @@ fn supertype_targets(idx: &Indexer, class_name: &str, class_uri: &str) -> Vec<(S
             // — promote it first, or the hierarchy walk silently dead-ends
             // here and every inherited member (e.g. `setState` on a library
             // `MviViewModel` base class) disappears from completion/hover.
-            // Same gate-then-promote pattern as the Task 8 consumer sites.
+            // Same gate-then-promote pattern as the Task 8 consumer sites,
+            // BUDGETED per walk (see the constant above): unbudgeted, this
+            // was the one promotion site reachable around every request cap.
             if idx.jar_qualified_or_bare_has_candidate(&super_name) {
-                crate::indexer::jar::ensure_jar_materialized(idx, &super_name);
+                crate::indexer::jar::ensure_jar_materialized_with_budget(
+                    idx,
+                    &super_name,
+                    sidecar_budget,
+                );
             }
             super::resolve_symbol_no_rg(idx, &super_name, &uri)
                 .into_iter()

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -29,17 +29,13 @@ pub(crate) use infer::{
 pub(crate) use infer_lines::extract_collection_element_type;
 pub(crate) use resolve::{ensure_file_data, fqns_for_name, resolve_symbol_no_rg};
 
-// The per-request sidecar-IPC promotion budget — shared by completion's own
-// promotion sites and non-resolver callers on the same class of interactive
-// path (file-open import promotion in `workspace::document_handler`).
-pub(crate) use complete::MAX_SYNC_JAR_PROMOTIONS_PER_COMPLETION;
-
 // Re-exports used only in tests.
 #[cfg(test)]
 pub(crate) use crate::rg::build_rg_pattern;
 #[cfg(test)]
 pub(crate) use complete::{
     complete_bare, complete_dot, is_screaming_snake, match_score, COMPLETION_CAP,
+    MAX_SYNC_JAR_PROMOTIONS_PER_COMPLETION,
 };
 #[cfg(test)]
 use fd::import_file_stems;

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -4598,6 +4598,76 @@ fn chained_extension_call_completion_from_compiled_jar() {
     );
 }
 
+/// Wave-7 root cause, reproduced from the REAL foundation-layout cache
+/// entry: `ExtensionEntry.package` used the per-JAR inferred package, and
+/// that inference takes the first class-like symbol with a dotted detail —
+/// which in foundation-layout is a package-less NESTED class detail
+/// (`class ContextualFlowColumnOverflow.Visible`), so every extension in
+/// the jar got package `"ContextualFlowColumnOverflow"`. The scope filter
+/// then rejected the explicitly imported `padding` (real package
+/// `androidx.compose.foundation.layout`), chain inference returned None,
+/// and `Modifier.padding().padd…` completion came back empty. Extension
+/// entries must carry the sidecar's real per-symbol `pkg`.
+#[test]
+fn extension_entries_carry_the_real_per_symbol_package() {
+    let idx = Indexer::new();
+    let mut padding = jar_sidecar_symbol(
+        "padding",
+        "fun",
+        "PaddingKt",
+        "fun Modifier.padding(all: Dp): Modifier",
+        "androidx.compose.foundation.layout",
+        false,
+    );
+    padding.top_level = true;
+    padding.extension_receiver_type = "Modifier".to_owned();
+    let compiled = vec![
+        // A nested class whose detail has NO package prefix — the real jar's
+        // first dotted class-like detail, which poisons the per-jar package
+        // inference ("ContextualFlowColumnOverflow" parses as `pkg.Type`).
+        jar_sidecar_symbol(
+            "Visible",
+            "class",
+            "ContextualFlowColumnOverflow",
+            "class ContextualFlowColumnOverflow.Visible",
+            "androidx.compose.foundation.layout",
+            false,
+        ),
+        padding,
+    ];
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        "/home/test/.gradle/caches/foundation-layout-1.0.aar".as_ref(),
+        &compiled,
+    );
+
+    let app_uri = Url::parse("file:///app/Screen.kt").unwrap();
+    idx.index_content(
+        &app_uri,
+        concat!(
+            "package app\n",
+            "import androidx.compose.ui.Modifier\n",
+            "import androidx.compose.foundation.layout.padding\n",
+            "fun screen() {\n",
+            "    Modifier.padding().padd\n",
+            "}\n",
+        ),
+    );
+
+    let return_type = crate::resolver::infer::find_extension_fn_return_type(
+        &idx,
+        "Modifier",
+        "padding",
+        Some(&app_uri),
+    );
+    assert_eq!(
+        return_type.as_deref(),
+        Some("Modifier"),
+        "an explicitly imported extension must be in scope regardless of \
+         what the per-jar package inference produced"
+    );
+}
+
 /// Review finding on the container-based jar member enumeration: the sidecar
 /// records each member's declaring class by SIMPLE name, and one synthetic
 /// `FileData` spans the whole JAR — so two top-level classes with the same
@@ -4687,3 +4757,4 @@ fn jar_member_enumeration_hides_deprecated_members() {
         "deprecated jar members must be hidden from completion — got: {dot_labels:?}"
     );
 }
+

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -4522,6 +4522,82 @@ fn jar_sidecar_symbol(
     }
 }
 
+/// The exact wave-7 user scenario, warm variant: chained-call completion
+/// `Modifier.padding().padd…` where `Modifier` and its extensions live in a
+/// fully materialized compiled JAR. The chain needs `padding`'s return type
+/// (extension fn on Modifier returning Modifier) to resolve the receiver of
+/// the second dot. Pins the whole path: ReceiverExpr::parse → is_call chain
+/// → resolve_dotted_receiver_type → extension return type → dot completion
+/// on the resulting Modifier, offering its extensions.
+#[test]
+fn chained_extension_call_completion_from_compiled_jar() {
+    let idx = Indexer::new();
+    let mut padding = jar_sidecar_symbol(
+        "padding",
+        "fun",
+        "",
+        "fun Modifier.padding(all: Dp): Modifier",
+        "lib",
+        false,
+    );
+    padding.extension_receiver_type = "Modifier".to_owned();
+    let mut vertical_scroll = jar_sidecar_symbol(
+        "verticalScroll",
+        "fun",
+        "",
+        "fun Modifier.verticalScroll(state: ScrollState): Modifier",
+        "lib",
+        false,
+    );
+    vertical_scroll.extension_receiver_type = "Modifier".to_owned();
+    let compiled = vec![
+        jar_sidecar_symbol(
+            "Modifier",
+            "interface",
+            "",
+            "interface lib.Modifier",
+            "lib",
+            false,
+        ),
+        padding,
+        vertical_scroll,
+    ];
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        "/home/test/.gradle/caches/compose-foundation-1.0.jar".as_ref(),
+        &compiled,
+    );
+
+    let app_uri = Url::parse("file:///app/Screen.kt").unwrap();
+    idx.index_content(
+        &app_uri,
+        concat!(
+            "package app\n",
+            "import lib.Modifier\n",
+            "import lib.padding\n",
+            "import lib.verticalScroll\n",
+            "fun screen() {\n",
+            "    Modifier.padding().padd\n",
+            "}\n",
+        ),
+    );
+
+    let expr = super::complete::ReceiverExpr::parse("    Modifier.padding().")
+        .expect("chain with call args must parse as a receiver expression");
+    assert!(
+        expr.is_call,
+        "receiver should be recognized as a call chain"
+    );
+    let (items, _) =
+        complete_symbol_with_context(&idx, "padd", Some(expr), &app_uri, false, false, Some(5));
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"padding"),
+        "chained-call completion must resolve padding's return type \
+         (Modifier) and offer Modifier's extensions — got: {labels:?}"
+    );
+}
+
 /// Review finding on the container-based jar member enumeration: the sidecar
 /// records each member's declaring class by SIMPLE name, and one synthetic
 /// `FileData` spans the whole JAR — so two top-level classes with the same

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -4204,6 +4204,68 @@ fn extension_completion_bounds_synchronous_promotion_attempts_per_request() {
     );
 }
 
+/// Review finding on the post-ship fix wave: `supertype_targets` promoted
+/// each super-class name with the UNBUDGETED `ensure_jar_materialized`, and
+/// the hierarchy walk runs on paths with no budget of their own — inference
+/// (`resolve_from_class_hierarchy`, depth 12; `find_extension_property_type`,
+/// depth 8 — both fanned out per name by inlay hints) and bare completion's
+/// inherited-members collector. Every distinct un-cached ancestor JAR paid a
+/// blocking sidecar round trip with no per-walk ceiling — the same cold-start
+/// stall pathology the completion caps exist for, reachable around them.
+/// Seeds a source-resolvable inheritance chain where every super name ALSO
+/// collides with a Tier-1-only candidate backed by a nonexistent JAR (so
+/// every attempt fails observably into `materialization_failed`), and
+/// asserts one walk's attempts are bounded.
+#[test]
+fn hierarchy_walk_bounds_synchronous_promotion_attempts_per_walk() {
+    let idx = Indexer::new();
+
+    const CHAIN_LENGTH: usize =
+        crate::resolver::hierarchy::MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK + 3;
+    let mut jar_ids = Vec::with_capacity(CHAIN_LENGTH);
+    for i in 0..CHAIN_LENGTH {
+        let class_uri = Url::parse(&format!("file:///sdk/Base{i}.kt")).unwrap();
+        let parent = i + 1;
+        let content = if i + 1 < CHAIN_LENGTH {
+            format!("package sdk\nopen class Base{i} : Base{parent}()")
+        } else {
+            format!("package sdk\nopen class Base{i}")
+        };
+        idx.index_content(&class_uri, &content);
+        // Each super name in the chain also has a cold compiled-JAR
+        // candidate — the promotion gate passes, and an unbudgeted walk
+        // would attempt every single one.
+        let jar_id = idx
+            .jar_table
+            .intern(&format!("/nonexistent/hierarchy-fixture{i}.jar"));
+        idx.jar_bare_names
+            .entry(format!("Base{i}"))
+            .or_default()
+            .push(jar_id);
+        jar_ids.push(jar_id);
+    }
+
+    let _ = crate::resolver::walk_hierarchy(
+        &idx,
+        "Base0",
+        "file:///sdk/Base0.kt",
+        crate::types::CallerContext::default(),
+        CHAIN_LENGTH,
+        |_, _, _, _| Vec::<()>::new(),
+    );
+
+    let attempted = jar_ids
+        .iter()
+        .filter(|id| idx.materialization_failed.contains(id))
+        .count();
+    assert!(
+        attempted <= crate::resolver::hierarchy::MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
+        "one hierarchy walk must cap synchronous promotion attempts at {}; \
+         {attempted} of {CHAIN_LENGTH} cold ancestors were attempted",
+        crate::resolver::hierarchy::MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK
+    );
+}
+
 /// A Tier-1-only candidate whose promotion to Tier 2 has already succeeded
 /// (simulated here — the decoy test above already pins the *attempt* against
 /// a nonexistent JAR, which always fails in a unit test with no sidecar) must
@@ -4432,5 +4494,120 @@ fn control_bare_completion_inherited_member_eager_population() {
     assert!(
         labels.contains(&"setState"),
         "bare completion of inherited setState under eager population — got: {labels:?}"
+    );
+}
+
+/// Compact `SidecarSymbol` builder for the jar member-enumeration tests below.
+fn jar_sidecar_symbol(
+    name: &str,
+    kind: &str,
+    container: &str,
+    detail: &str,
+    pkg: &str,
+    deprecated: bool,
+) -> crate::sidecar::SidecarSymbol {
+    crate::sidecar::SidecarSymbol {
+        name: name.to_owned(),
+        kind: kind.to_owned(),
+        container: container.to_owned(),
+        detail: detail.to_owned(),
+        doc: String::new(),
+        type_params: Vec::new(),
+        extension_receiver_type: String::new(),
+        trailing_lambda: false,
+        deprecated,
+        pkg: pkg.to_owned(),
+        top_level: container.is_empty(),
+        supers: vec![],
+    }
+}
+
+/// Review finding on the container-based jar member enumeration: the sidecar
+/// records each member's declaring class by SIMPLE name, and one synthetic
+/// `FileData` spans the whole JAR — so two top-level classes with the same
+/// simple name in different packages of one JAR had their members MERGED.
+/// The per-symbol package side table (`jar_symbol_packages`) is index-aligned
+/// with the symbols and must disambiguate: with the caller importing
+/// `com.a.Foo`, only `com.a.Foo`'s members belong in the list.
+#[test]
+fn jar_member_enumeration_does_not_merge_same_simple_name_classes() {
+    let idx = Indexer::new();
+    let compiled = vec![
+        jar_sidecar_symbol("Foo", "class", "", "class com.a.Foo", "com.a", false),
+        jar_sidecar_symbol("alpha", "fun", "Foo", "fun alpha(): Int", "com.a", false),
+        jar_sidecar_symbol("Foo", "class", "", "class com.b.Foo", "com.b", false),
+        jar_sidecar_symbol("beta", "fun", "Foo", "fun beta(): Int", "com.b", false),
+    ];
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        "/home/test/.gradle/caches/two-foos-1.0.jar".as_ref(),
+        &compiled,
+    );
+
+    let app_uri = Url::parse("file:///app/MyFoo.kt").unwrap();
+    idx.index_content(
+        &app_uri,
+        concat!(
+            "package app\n",
+            "import com.a.Foo\n",
+            "class MyFoo : Foo() {\n",
+            "    fun load() {}\n",
+            "}\n",
+        ),
+    );
+
+    let dot_items = complete_dot(&idx, "MyFoo", &app_uri, true, None);
+    let dot_labels: Vec<&str> = dot_items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        dot_labels.contains(&"alpha"),
+        "the imported com.a.Foo's own member must be offered — got: {dot_labels:?}"
+    );
+    assert!(
+        !dot_labels.contains(&"beta"),
+        "com.b.Foo's member must NOT leak into com.a.Foo's completion just \
+         because the classes share a simple name in one JAR — got: {dot_labels:?}"
+    );
+}
+
+/// Review finding: the jar member-enumeration branch filtered only
+/// `Visibility::Private` — vacuous for JAR symbols (always `Public`) — and
+/// ignored `deprecated`, which the sidecar populates. Project policy hides
+/// deprecated library symbols from completion entirely (same as the direct
+/// jar-definitions path and bare completion's stub path).
+#[test]
+fn jar_member_enumeration_hides_deprecated_members() {
+    let idx = Indexer::new();
+    let compiled = vec![
+        jar_sidecar_symbol("Widget", "class", "", "class lib.Widget", "lib", false),
+        jar_sidecar_symbol("fresh", "fun", "Widget", "fun fresh(): Int", "lib", false),
+        jar_sidecar_symbol("legacy", "fun", "Widget", "fun legacy(): Int", "lib", true),
+    ];
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        "/home/test/.gradle/caches/widget-lib-1.0.jar".as_ref(),
+        &compiled,
+    );
+
+    let app_uri = Url::parse("file:///app/MyWidget.kt").unwrap();
+    idx.index_content(
+        &app_uri,
+        concat!(
+            "package app\n",
+            "import lib.Widget\n",
+            "class MyWidget : Widget() {\n",
+            "    fun load() {}\n",
+            "}\n",
+        ),
+    );
+
+    let dot_items = complete_dot(&idx, "MyWidget", &app_uri, true, None);
+    let dot_labels: Vec<&str> = dot_items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        dot_labels.contains(&"fresh"),
+        "non-deprecated inherited jar member must be offered — got: {dot_labels:?}"
+    );
+    assert!(
+        !dot_labels.contains(&"legacy"),
+        "deprecated jar members must be hidden from completion — got: {dot_labels:?}"
     );
 }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -4598,6 +4598,92 @@ fn chained_extension_call_completion_from_compiled_jar() {
     );
 }
 
+/// The user's ACTUAL editing scenario (wave 7d, proven by a live LSP probe
+/// against the real project): a MULTILINE fluent chain, completing on a
+/// continuation line. The continuation line has no receiver of its own —
+/// the pipeline must reconstruct the chain from the lines above and resolve
+/// it exactly like the single-line form the sibling test covers.
+#[test]
+fn multiline_chain_completion_from_compiled_jar() {
+    let idx = Indexer::new();
+    let mut padding = jar_sidecar_symbol(
+        "padding",
+        "fun",
+        "PaddingKt",
+        "fun Modifier.padding(all: Dp): Modifier",
+        "lib",
+        false,
+    );
+    padding.top_level = true;
+    padding.extension_receiver_type = "Modifier".to_owned();
+    let mut vertical_scroll = jar_sidecar_symbol(
+        "verticalScroll",
+        "fun",
+        "ScrollKt",
+        "fun Modifier.verticalScroll(state: ScrollState): Modifier",
+        "lib",
+        false,
+    );
+    vertical_scroll.top_level = true;
+    vertical_scroll.extension_receiver_type = "Modifier".to_owned();
+    let mut fill_max_size = jar_sidecar_symbol(
+        "fillMaxSize",
+        "fun",
+        "SizeKt",
+        "fun Modifier.fillMaxSize(): Modifier",
+        "lib",
+        false,
+    );
+    fill_max_size.top_level = true;
+    fill_max_size.extension_receiver_type = "Modifier".to_owned();
+    let compiled = vec![
+        jar_sidecar_symbol("Modifier", "interface", "", "interface lib.Modifier", "lib", false),
+        padding,
+        vertical_scroll,
+        fill_max_size,
+    ];
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        "/home/test/.gradle/caches/compose-foundation-2.0.jar".as_ref(),
+        &compiled,
+    );
+
+    let app_uri = Url::parse("file:///app/Screen.kt").unwrap();
+    idx.index_content(
+        &app_uri,
+        concat!(
+            "package app\n",
+            "import lib.Modifier\n",
+            "import lib.padding\n",
+            "import lib.verticalScroll\n",
+            "import lib.fillMaxSize\n",
+            "fun screen() {\n",
+            "    Column(\n",
+            "        modifier = Modifier\n",
+            "            .fillMaxSize()\n",
+            "            .verticalScroll(rememberScrollState())\n",
+            "            .padd\n",
+            "    )\n",
+            "}\n",
+        ),
+    );
+
+    // Cursor at the end of `.padd` on the continuation line (0-based 10).
+    let (items, _) = crate::features::completion::run_completions(
+        &idx,
+        &app_uri,
+        tower_lsp::lsp_types::Position::new(10, 17),
+        false,
+    );
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"padding"),
+        "completion on a multiline-chain continuation line must reconstruct \
+         the chain from the lines above and offer Modifier's extensions — \
+         got: {labels:?}"
+    );
+}
+
 /// Wave-7 root cause, reproduced from the REAL foundation-layout cache
 /// entry: `ExtensionEntry.package` used the per-JAR inferred package, and
 /// that inference takes the first class-like symbol with a dotted detail —

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -4218,52 +4218,57 @@ fn extension_completion_bounds_synchronous_promotion_attempts_per_request() {
 /// asserts one walk's attempts are bounded.
 #[test]
 fn hierarchy_walk_bounds_synchronous_promotion_attempts_per_walk() {
-    let idx = Indexer::new();
+    // XDG isolation: the promotion probe lazily decodes the on-disk jar
+    // cache — without this the test reads the developer's real one.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    crate::indexer::test_helpers::with_xdg_cache(tmp.path(), || {
+        let idx = Indexer::new();
 
-    const CHAIN_LENGTH: usize =
-        crate::resolver::hierarchy::MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK + 3;
-    let mut jar_ids = Vec::with_capacity(CHAIN_LENGTH);
-    for i in 0..CHAIN_LENGTH {
-        let class_uri = Url::parse(&format!("file:///sdk/Base{i}.kt")).unwrap();
-        let parent = i + 1;
-        let content = if i + 1 < CHAIN_LENGTH {
-            format!("package sdk\nopen class Base{i} : Base{parent}()")
-        } else {
-            format!("package sdk\nopen class Base{i}")
-        };
-        idx.index_content(&class_uri, &content);
-        // Each super name in the chain also has a cold compiled-JAR
-        // candidate — the promotion gate passes, and an unbudgeted walk
-        // would attempt every single one.
-        let jar_id = idx
-            .jar_table
-            .intern(&format!("/nonexistent/hierarchy-fixture{i}.jar"));
-        idx.jar_bare_names
-            .entry(format!("Base{i}"))
-            .or_default()
-            .push(jar_id);
-        jar_ids.push(jar_id);
-    }
+        const CHAIN_LENGTH: usize =
+            crate::resolver::hierarchy::MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK + 3;
+        let mut jar_ids = Vec::with_capacity(CHAIN_LENGTH);
+        for i in 0..CHAIN_LENGTH {
+            let class_uri = Url::parse(&format!("file:///sdk/Base{i}.kt")).unwrap();
+            let parent = i + 1;
+            let content = if i + 1 < CHAIN_LENGTH {
+                format!("package sdk\nopen class Base{i} : Base{parent}()")
+            } else {
+                format!("package sdk\nopen class Base{i}")
+            };
+            idx.index_content(&class_uri, &content);
+            // Each super name in the chain also has a cold compiled-JAR
+            // candidate — the promotion gate passes, and an unbudgeted walk
+            // would attempt every single one.
+            let jar_id = idx
+                .jar_table
+                .intern(&format!("/nonexistent/hierarchy-fixture{i}.jar"));
+            idx.jar_bare_names
+                .entry(format!("Base{i}"))
+                .or_default()
+                .push(jar_id);
+            jar_ids.push(jar_id);
+        }
 
-    let _ = crate::resolver::walk_hierarchy(
-        &idx,
-        "Base0",
-        "file:///sdk/Base0.kt",
-        crate::types::CallerContext::default(),
-        CHAIN_LENGTH,
-        |_, _, _, _| Vec::<()>::new(),
-    );
+        let _ = crate::resolver::walk_hierarchy(
+            &idx,
+            "Base0",
+            "file:///sdk/Base0.kt",
+            crate::types::CallerContext::default(),
+            CHAIN_LENGTH,
+            |_, _, _, _| Vec::<()>::new(),
+        );
 
-    let attempted = jar_ids
-        .iter()
-        .filter(|id| idx.materialization_failed.contains(id))
-        .count();
-    assert!(
-        attempted <= crate::resolver::hierarchy::MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
-        "one hierarchy walk must cap synchronous promotion attempts at {}; \
+        let attempted = jar_ids
+            .iter()
+            .filter(|id| idx.materialization_failed.contains(id))
+            .count();
+        assert!(
+            attempted <= crate::resolver::hierarchy::MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
+            "one hierarchy walk must cap synchronous promotion attempts at {}; \
          {attempted} of {CHAIN_LENGTH} cold ancestors were attempted",
-        crate::resolver::hierarchy::MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK
-    );
+            crate::resolver::hierarchy::MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK
+        );
+    });
 }
 
 /// A Tier-1-only candidate whose promotion to Tier 2 has already succeeded
@@ -4637,7 +4642,14 @@ fn multiline_chain_completion_from_compiled_jar() {
     fill_max_size.top_level = true;
     fill_max_size.extension_receiver_type = "Modifier".to_owned();
     let compiled = vec![
-        jar_sidecar_symbol("Modifier", "interface", "", "interface lib.Modifier", "lib", false),
+        jar_sidecar_symbol(
+            "Modifier",
+            "interface",
+            "",
+            "interface lib.Modifier",
+            "lib",
+            false,
+        ),
         padding,
         vertical_scroll,
         fill_max_size,
@@ -4844,3 +4856,103 @@ fn jar_member_enumeration_hides_deprecated_members() {
     );
 }
 
+/// Review M2 on the member-enumeration disambiguation: a NESTED class import
+/// (`import com.example.Outer.Config`) names container segments the naive
+/// `strip_suffix(".Config")` treats as the package — deriving
+/// `com.example.Outer` while the members' real package is `com.example`, so
+/// every member of the imported class was filtered out. The filter must use
+/// import-coverage semantics (`ImportEntry::covers`), which already
+/// understand intermediate container segments.
+#[test]
+fn jar_member_enumeration_supports_nested_class_imports() {
+    let idx = Indexer::new();
+    let compiled = vec![
+        jar_sidecar_symbol(
+            "Outer",
+            "class",
+            "",
+            "class com.example.Outer",
+            "com.example",
+            false,
+        ),
+        jar_sidecar_symbol(
+            "Config",
+            "class",
+            "Outer",
+            "class com.example.Outer.Config",
+            "com.example",
+            false,
+        ),
+        jar_sidecar_symbol(
+            "mode",
+            "fun",
+            "Config",
+            "fun mode(): Int",
+            "com.example",
+            false,
+        ),
+    ];
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        "/home/test/.gradle/caches/nested-lib-1.0.jar".as_ref(),
+        &compiled,
+    );
+
+    let app_uri = Url::parse("file:///app/UseConfig.kt").unwrap();
+    idx.index_content(
+        &app_uri,
+        concat!(
+            "package app\n",
+            "import com.example.Outer.Config\n",
+            "class MyConfig : Config() {\n",
+            "    fun load() {}\n",
+            "}\n",
+        ),
+    );
+
+    let dot_items = complete_dot(&idx, "MyConfig", &app_uri, true, None);
+    let dot_labels: Vec<&str> = dot_items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        dot_labels.contains(&"mode"),
+        "members of a nested class imported via its container path must \
+         survive the package disambiguation — got: {dot_labels:?}"
+    );
+}
+
+/// Review M2 second variant: an import of a DIFFERENT library's same-named
+/// class must not filter this jar's members to zero — when the import
+/// covers none of the candidate members, fall back to the declaring class
+/// symbol's own package.
+#[test]
+fn jar_member_enumeration_falls_back_when_the_import_points_elsewhere() {
+    let idx = Indexer::new();
+    let compiled = vec![
+        jar_sidecar_symbol("Widget", "class", "", "class lib.Widget", "lib", false),
+        jar_sidecar_symbol("render", "fun", "Widget", "fun render(): Int", "lib", false),
+    ];
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        "/home/test/.gradle/caches/widget-lib-2.0.jar".as_ref(),
+        &compiled,
+    );
+
+    let app_uri = Url::parse("file:///app/UseWidget.kt").unwrap();
+    idx.index_content(
+        &app_uri,
+        concat!(
+            "package app\n",
+            "import other.vendor.Widget\n",
+            "class MyWidget : Widget() {\n",
+            "    fun load() {}\n",
+            "}\n",
+        ),
+    );
+
+    let dot_items = complete_dot(&idx, "MyWidget", &app_uri, true, None);
+    let dot_labels: Vec<&str> = dot_items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        dot_labels.contains(&"render"),
+        "an import that covers none of the jar's members must not empty the \
+         enumeration — got: {dot_labels:?}"
+    );
+}

--- a/src/workspace/document_handler.rs
+++ b/src/workspace/document_handler.rs
@@ -156,19 +156,38 @@ impl DocumentHandler {
             };
             // Return `content` from the closure so the second spawn_blocking
             // can reuse it without an upfront full-file clone.
-            let result = tokio::task::spawn_blocking(move || {
-                let _permit = permit;
-                let data = indexer.index_content(&uri, &content);
-                // Eagerly promote the file's own imports before the diagnostics
-                // pass below runs, so call-arg/nullable diagnostics against a
-                // freshly-opened file's own imported library types see real
-                // signatures on first publish rather than degrading to Task 7's
-                // suppression path for the common case.
-                promote_file_imports(&indexer, &uri);
-                Arc::clone(&indexer).prewarm_completion_cache(&uri);
-                (data, content)
+            //
+            // The parse permit covers ONLY `index_content`: import promotion
+            // is sidecar IPC, not parsing, and since the promotion became
+            // uncapped a cold import list can take seconds — holding a
+            // `parse_sem` permit (a single permit on 2-core machines) across
+            // it stalled every other parse task in the process.
+            let parse_result = tokio::task::spawn_blocking({
+                let indexer = Arc::clone(&indexer);
+                let uri = uri.clone();
+                move || {
+                    let _permit = permit;
+                    let data = indexer.index_content(&uri, &content);
+                    (data, content)
+                }
             })
             .await;
+            // Eagerly promote the file's own imports before the diagnostics
+            // pass below runs, so call-arg/nullable diagnostics against a
+            // freshly-opened file's own imported library types see real
+            // signatures on first publish rather than degrading to Task 7's
+            // suppression path for the common case.
+            let result = match parse_result {
+                Ok(parsed) => {
+                    tokio::task::spawn_blocking(move || {
+                        promote_file_imports(&indexer, &uri);
+                        Arc::clone(&indexer).prewarm_completion_cache(&uri);
+                        parsed
+                    })
+                    .await
+                }
+                Err(join_error) => Err(join_error),
+            };
 
             let (index_result, diagnostics_text) = match result {
                 Ok((data, text)) => (Ok(data), text),
@@ -237,57 +256,77 @@ impl DocumentHandler {
     /// completes so that files opened during the scan get their semantic
     /// diagnostics (which were suppressed while the index was partial).
     pub(crate) fn republish_open_file_diagnostics(&self) {
-        for entry in self.indexer.live_trees.iter() {
-            let Ok(uri) = Url::parse(entry.key()) else {
-                continue;
-            };
-            let indexer = Arc::clone(&self.indexer);
-            let client = self.client.clone();
-            tokio::task::spawn(async move {
-                let syntax_diags = indexer
-                    .files
-                    .get(uri.as_str())
-                    .map(|f| syntax_diagnostics(&f.syntax_errors))
-                    .unwrap_or_default();
-                let semantic_diags = tokio::task::spawn_blocking({
-                    let indexer = Arc::clone(&indexer);
-                    let uri = uri.clone();
-                    move || {
-                        // Re-attempt import promotion: this republish fires
-                        // when the jar scan completes, and any file opened
-                        // BEFORE that ran its didOpen promotion against an
-                        // empty Tier-1 manifest (no candidates, silent no-op)
-                        // — on a cold start that is every initially open
-                        // file, and nothing else ever retries. Idempotent
-                        // and cheap when already promoted (`materialized` /
-                        // `materialization_failed` memoize per JAR).
-                        promote_file_imports(&indexer, &uri);
-                        let mut d = Vec::new();
-                        d.extend(when_diagnostics(&indexer, &uri));
-                        if let Some(doc) = indexer.live_doc(&uri) {
-                            d.extend(call_arg_diagnostics(&indexer, &uri, &doc));
-                            d.extend(nullable_dot_call_diagnostics(&indexer, &uri, &doc));
-                        }
-                        let lines = indexer.mem_lines_for(uri.as_str());
-                        let lines: Vec<String> = lines
-                            .as_ref()
-                            .map(|l| l.as_ref().clone())
-                            .unwrap_or_default();
-                        if let Some(pkg_diag) = missing_package_diagnostic(&lines, &uri) {
-                            d.push(pkg_diag);
-                        }
-                        d
-                    }
-                })
-                .await
-                .unwrap_or_default();
-                let mut diagnostics = syntax_diags;
-                diagnostics.extend(semantic_diags);
-                if let Some(client) = client {
-                    client.publish_diagnostics(uri, diagnostics, None).await;
+        let open_uris: Vec<Url> = self
+            .indexer
+            .live_trees
+            .iter()
+            .filter_map(|entry| Url::parse(entry.key()).ok())
+            .collect();
+
+        // Re-attempt import promotion for EVERY open file, SEQUENTIALLY in
+        // one blocking task, before any per-file diagnostics run. This
+        // republish fires when the jar scan completes, and any file opened
+        // BEFORE that ran its didOpen promotion against an empty Tier-1
+        // manifest (no candidates, silent no-op) — on a cold start that is
+        // every initially open file, and nothing else ever retries.
+        // Sequential on purpose: per-file CONCURRENT promotions raced on the
+        // immediate-or-nothing sidecar `try_lock`, and a contended candidate
+        // is skipped with no memo and no retry — an arbitrary subset of a
+        // file's imports silently never materialized (review finding H1).
+        // Idempotent and cheap when already promoted (`materialized` /
+        // `materialization_failed` memoize per JAR).
+        let handler_indexer = Arc::clone(&self.indexer);
+        let handler_client = self.client.clone();
+        tokio::task::spawn(async move {
+            let promotion_indexer = Arc::clone(&handler_indexer);
+            let promotion_uris = open_uris.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                for uri in &promotion_uris {
+                    promote_file_imports(&promotion_indexer, uri);
                 }
-            });
-        }
+            })
+            .await;
+
+            for uri in open_uris {
+                let indexer = Arc::clone(&handler_indexer);
+                let client = handler_client.clone();
+                tokio::task::spawn(async move {
+                    let syntax_diags = indexer
+                        .files
+                        .get(uri.as_str())
+                        .map(|f| syntax_diagnostics(&f.syntax_errors))
+                        .unwrap_or_default();
+                    let semantic_diags = tokio::task::spawn_blocking({
+                        let indexer = Arc::clone(&indexer);
+                        let uri = uri.clone();
+                        move || {
+                            let mut d = Vec::new();
+                            d.extend(when_diagnostics(&indexer, &uri));
+                            if let Some(doc) = indexer.live_doc(&uri) {
+                                d.extend(call_arg_diagnostics(&indexer, &uri, &doc));
+                                d.extend(nullable_dot_call_diagnostics(&indexer, &uri, &doc));
+                            }
+                            let lines = indexer.mem_lines_for(uri.as_str());
+                            let lines: Vec<String> = lines
+                                .as_ref()
+                                .map(|l| l.as_ref().clone())
+                                .unwrap_or_default();
+                            if let Some(pkg_diag) = missing_package_diagnostic(&lines, &uri) {
+                                d.push(pkg_diag);
+                            }
+                            d
+                        }
+                    })
+                    .await
+                    .unwrap_or_default();
+                    let mut diagnostics = syntax_diags;
+                    diagnostics.extend(semantic_diags);
+                    if let Some(client) = client {
+                        client.publish_diagnostics(uri, diagnostics, None).await;
+                    }
+                });
+            }
+        });
     }
 
     fn spawn_outside_root_document_indexing(&self, uri: Url, content: String) {

--- a/src/workspace/document_handler.rs
+++ b/src/workspace/document_handler.rs
@@ -398,20 +398,25 @@ fn has_any_marker(directory: &Path, markers: &[&str]) -> bool {
 /// "always degraded by default").
 ///
 /// Reads `FileData::imports` (already populated by `index_content`, which
-/// must have been called for `uri` before this runs) and calls the budgeted
-/// promotion (Task 8's helper) once per non-star import's local name.
+/// must have been called for `uri` before this runs) and attempts promotion
+/// once per non-star import's local name.
 /// Star imports are skipped: the design defers package-keyed Tier-1 lookups
 /// to v2 (`ImportEntry::local_name` is `"*"` for a star import, which is not
 /// a usable `jar_bare_names` key).
 ///
-/// One shared sidecar-IPC budget across the WHOLE import list: a big file
-/// routinely has dozens of imports, and unbudgeted per-import blocking IPC
-/// on open contributed to a live promotion avalanche (sequential one-JAR
-/// sidecar round trips stacking up behind the sidecar lock, starving
-/// interactive requests). Fresh-cache-backed promotions are free and
-/// unlimited — with a healthy cache the whole import list still promotes
-/// fully; only genuinely uncached JARs are capped, and completion/hover can
-/// still promote those later on demand.
+/// NOT budget-capped, deliberately. This function is the designated safety
+/// net the zero-IPC inference sites lean on ("uncached JARs are covered by
+/// file-open import promotion") — a cap of 5 across a whole import list
+/// silently broke that contract for every cold import past the fifth, and a
+/// real Compose file imports dozens of names: with a partially wiped disk
+/// cache, an explicitly imported `padding` never materialized and
+/// chained-call completion (`Modifier.padding().padd…`) returned nothing,
+/// with no later request able to repair it (chain inference is zero-IPC and
+/// completion's own promotion is keyed on other names). It runs inside
+/// `spawn_blocking` on didOpen — a notification, not a user-facing request —
+/// so per-import blocking IPC costs background time, not request latency,
+/// and the per-JAR sidecar lock scoping lets interactive promotions
+/// interleave between imports.
 pub(crate) fn promote_file_imports(indexer: &Indexer, uri: &Url) {
     let imports: Vec<crate::types::ImportEntry> = match indexer.files.get(uri.as_str()) {
         Some(file_data) => file_data
@@ -422,13 +427,8 @@ pub(crate) fn promote_file_imports(indexer: &Indexer, uri: &Url) {
             .collect(),
         None => return,
     };
-    let mut sidecar_budget = crate::resolver::MAX_SYNC_JAR_PROMOTIONS_PER_COMPLETION;
     for import in &imports {
-        crate::indexer::jar::ensure_jar_materialized_with_budget(
-            indexer,
-            &import.local_name,
-            &mut sidecar_budget,
-        );
+        crate::indexer::jar::ensure_jar_materialized(indexer, &import.local_name);
     }
 }
 

--- a/src/workspace/document_handler.rs
+++ b/src/workspace/document_handler.rs
@@ -253,6 +253,15 @@ impl DocumentHandler {
                     let indexer = Arc::clone(&indexer);
                     let uri = uri.clone();
                     move || {
+                        // Re-attempt import promotion: this republish fires
+                        // when the jar scan completes, and any file opened
+                        // BEFORE that ran its didOpen promotion against an
+                        // empty Tier-1 manifest (no candidates, silent no-op)
+                        // — on a cold start that is every initially open
+                        // file, and nothing else ever retries. Idempotent
+                        // and cheap when already promoted (`materialized` /
+                        // `materialization_failed` memoize per JAR).
+                        promote_file_imports(&indexer, &uri);
                         let mut d = Vec::new();
                         d.extend(when_diagnostics(&indexer, &uri));
                         if let Some(doc) = indexer.live_doc(&uri) {

--- a/src/workspace/document_handler_tests.rs
+++ b/src/workspace/document_handler_tests.rs
@@ -88,6 +88,49 @@ fn promote_file_imports_skips_star_imports() {
 }
 
 #[test]
+fn promote_file_imports_attempts_every_import_not_just_the_first_five() {
+    // Regression: a hard cap of MAX_SYNC_JAR_PROMOTIONS_PER_COMPLETION (5)
+    // shared across the whole import list permanently starved every cold
+    // import beyond the first five — and file-open import promotion is the
+    // designated safety net the zero-IPC inference sites rely on ("uncached
+    // JARs are covered by file-open import promotion"). A real Compose file
+    // imports 20-50 names; with a partially wiped disk cache, `padding` et
+    // al. never materialized and chained-call completion
+    // (`Modifier.padding().padd…`) returned nothing. didOpen promotion runs
+    // inside spawn_blocking, not on a user-facing request, so it is NOT
+    // budget-capped: every explicitly imported name must get a real attempt.
+    let idx = Indexer::new();
+    let import_names = [
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
+    ];
+    let mut jar_ids = Vec::new();
+    for name in import_names {
+        let jar_id = idx.jar_table.intern(&format!("/fake/{name}.jar"));
+        idx.jar_bare_names
+            .entry(name.to_owned())
+            .or_default()
+            .push(jar_id);
+        jar_ids.push(jar_id);
+    }
+    let imports: String = import_names
+        .iter()
+        .map(|name| format!("import lib.{name}\n"))
+        .collect();
+    let file_uri = uri("/ManyImports.kt");
+    idx.index_content(&file_uri, &format!("{imports}\nfun Screen() {{}}"));
+
+    super::promote_file_imports(&idx, &file_uri);
+
+    for (name, jar_id) in import_names.iter().zip(&jar_ids) {
+        assert!(
+            idx.materialization_failed.contains(jar_id) || idx.materialized.contains(jar_id),
+            "import `{name}` never got a materialization attempt — the import \
+             list must not be budget-starved"
+        );
+    }
+}
+
+#[test]
 fn promote_file_imports_no_op_for_unindexed_uri() {
     let idx = Indexer::new();
     let file_uri = uri("/NeverOpened.kt");

--- a/src/workspace/document_handler_tests.rs
+++ b/src/workspace/document_handler_tests.rs
@@ -130,6 +130,50 @@ fn promote_file_imports_attempts_every_import_not_just_the_first_five() {
     }
 }
 
+#[tokio::test]
+async fn jar_ready_republish_promotes_imports_of_already_open_files() {
+    // Cold-start ordering gap: helix opens the file IMMEDIATELY, so didOpen's
+    // import promotion runs against an EMPTY Tier-1 manifest (the jar scan
+    // hasn't produced jar_bare_names yet), finds no candidates, and never
+    // runs again — the file's imports stay unmaterialized for the whole
+    // session and chained-call completion silently returns nothing. The
+    // republish pass that fires when the jar scan completes must re-attempt
+    // import promotion for every open file, now that Tier-1 exists.
+    let indexer = Arc::new(Indexer::new());
+    let handler = DocumentHandler::new(Arc::clone(&indexer), None);
+    let file_uri = Url::parse("file:///app/Screen.kt").unwrap();
+    let content = "import lib.padding\n\nfun screen() {}";
+    indexer.index_content(&file_uri, content);
+    indexer.store_live_tree(&file_uri, content);
+
+    // Tier-1 manifest arrives only AFTER the file was opened.
+    let jar_id = indexer.jar_table.intern("/fake/foundation.jar");
+    indexer
+        .jar_bare_names
+        .entry("padding".to_owned())
+        .or_default()
+        .push(jar_id);
+
+    handler.republish_open_file_diagnostics();
+
+    // The republish work runs on spawned tasks — poll for the attempt.
+    let mut attempted = false;
+    for _ in 0..200 {
+        if indexer.materialization_failed.contains(&jar_id)
+            || indexer.materialized.contains(&jar_id)
+        {
+            attempted = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert!(
+        attempted,
+        "when the jar scan completes, open files' imports must get a \
+         (re-)promotion attempt — didOpen ran before Tier-1 existed"
+    );
+}
+
 #[test]
 fn promote_file_imports_no_op_for_unindexed_uri() {
     let idx = Indexer::new();

--- a/src/workspace/document_handler_tests.rs
+++ b/src/workspace/document_handler_tests.rs
@@ -99,35 +99,40 @@ fn promote_file_imports_attempts_every_import_not_just_the_first_five() {
     // (`Modifier.padding().padd…`) returned nothing. didOpen promotion runs
     // inside spawn_blocking, not on a user-facing request, so it is NOT
     // budget-capped: every explicitly imported name must get a real attempt.
-    let idx = Indexer::new();
-    let import_names = [
-        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
-    ];
-    let mut jar_ids = Vec::new();
-    for name in import_names {
-        let jar_id = idx.jar_table.intern(&format!("/fake/{name}.jar"));
-        idx.jar_bare_names
-            .entry(name.to_owned())
-            .or_default()
-            .push(jar_id);
-        jar_ids.push(jar_id);
-    }
-    let imports: String = import_names
-        .iter()
-        .map(|name| format!("import lib.{name}\n"))
-        .collect();
-    let file_uri = uri("/ManyImports.kt");
-    idx.index_content(&file_uri, &format!("{imports}\nfun Screen() {{}}"));
+    // XDG isolation: the promotion probe lazily decodes the on-disk jar
+    // cache — without this the test reads the developer's real one.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    crate::indexer::test_helpers::with_xdg_cache(tmp.path(), || {
+        let idx = Indexer::new();
+        let import_names = [
+            "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
+        ];
+        let mut jar_ids = Vec::new();
+        for name in import_names {
+            let jar_id = idx.jar_table.intern(&format!("/fake/{name}.jar"));
+            idx.jar_bare_names
+                .entry(name.to_owned())
+                .or_default()
+                .push(jar_id);
+            jar_ids.push(jar_id);
+        }
+        let imports: String = import_names
+            .iter()
+            .map(|name| format!("import lib.{name}\n"))
+            .collect();
+        let file_uri = uri("/ManyImports.kt");
+        idx.index_content(&file_uri, &format!("{imports}\nfun Screen() {{}}"));
 
-    super::promote_file_imports(&idx, &file_uri);
+        super::promote_file_imports(&idx, &file_uri);
 
-    for (name, jar_id) in import_names.iter().zip(&jar_ids) {
-        assert!(
-            idx.materialization_failed.contains(jar_id) || idx.materialized.contains(jar_id),
-            "import `{name}` never got a materialization attempt — the import \
+        for (name, jar_id) in import_names.iter().zip(&jar_ids) {
+            assert!(
+                idx.materialization_failed.contains(jar_id) || idx.materialized.contains(jar_id),
+                "import `{name}` never got a materialization attempt — the import \
              list must not be budget-starved"
-        );
-    }
+            );
+        }
+    });
 }
 
 #[test]
@@ -153,36 +158,49 @@ fn jar_ready_republish_promotes_imports_of_already_open_files() {
         runtime.block_on(async {
             let indexer = Arc::new(Indexer::new());
             let handler = DocumentHandler::new(Arc::clone(&indexer), None);
-            let file_uri = Url::parse("file:///app/Screen.kt").unwrap();
-            let content = "import lib.padding\n\nfun screen() {}";
-            indexer.index_content(&file_uri, content);
-            indexer.store_live_tree(&file_uri, content);
-
-            // Tier-1 manifest arrives only AFTER the file was opened.
-            let jar_id = indexer.jar_table.intern("/fake/foundation.jar");
-            indexer
-                .jar_bare_names
-                .entry("padding".to_owned())
-                .or_default()
-                .push(jar_id);
+            // TWO open files: the promotion pass must cover every open file
+            // (it runs sequentially in one blocking task — concurrent
+            // per-file promotions raced on the immediate-or-nothing sidecar
+            // try_lock and silently dropped contended JARs).
+            let mut jar_ids = Vec::new();
+            for (file_name, import_name, jar_path) in [
+                ("Screen", "padding", "/fake/foundation.jar"),
+                ("Detail", "verticalScroll", "/fake/scroll.jar"),
+            ] {
+                let file_uri = Url::parse(&format!("file:///app/{file_name}.kt")).unwrap();
+                let content = format!("import lib.{import_name}\n\nfun body() {{}}");
+                indexer.index_content(&file_uri, &content);
+                indexer.store_live_tree(&file_uri, &content);
+                // Tier-1 manifest arrives only AFTER the files were opened.
+                let jar_id = indexer.jar_table.intern(jar_path);
+                indexer
+                    .jar_bare_names
+                    .entry(import_name.to_owned())
+                    .or_default()
+                    .push(jar_id);
+                jar_ids.push(jar_id);
+            }
 
             handler.republish_open_file_diagnostics();
 
-            // The republish work runs on spawned tasks — poll for the attempt.
-            let mut attempted = false;
+            // The republish work runs on spawned tasks — poll for the attempts.
+            let attempted = |jar_id: &crate::types::JarId| {
+                indexer.materialization_failed.contains(jar_id)
+                    || indexer.materialized.contains(jar_id)
+            };
+            let mut all_attempted = false;
             for _ in 0..400 {
-                if indexer.materialization_failed.contains(&jar_id)
-                    || indexer.materialized.contains(&jar_id)
-                {
-                    attempted = true;
+                if jar_ids.iter().all(&attempted) {
+                    all_attempted = true;
                     break;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             }
             assert!(
-                attempted,
-                "when the jar scan completes, open files' imports must get a \
-                 (re-)promotion attempt — didOpen ran before Tier-1 existed"
+                all_attempted,
+                "when the jar scan completes, EVERY open file's imports must \
+                 get a (re-)promotion attempt — didOpen ran before Tier-1 \
+                 existed, and no open file may be skipped"
             );
         });
     });

--- a/src/workspace/document_handler_tests.rs
+++ b/src/workspace/document_handler_tests.rs
@@ -130,8 +130,8 @@ fn promote_file_imports_attempts_every_import_not_just_the_first_five() {
     }
 }
 
-#[tokio::test]
-async fn jar_ready_republish_promotes_imports_of_already_open_files() {
+#[test]
+fn jar_ready_republish_promotes_imports_of_already_open_files() {
     // Cold-start ordering gap: helix opens the file IMMEDIATELY, so didOpen's
     // import promotion runs against an EMPTY Tier-1 manifest (the jar scan
     // hasn't produced jar_bare_names yet), finds no candidates, and never
@@ -139,39 +139,53 @@ async fn jar_ready_republish_promotes_imports_of_already_open_files() {
     // session and chained-call completion silently returns nothing. The
     // republish pass that fires when the jar scan completes must re-attempt
     // import promotion for every open file, now that Tier-1 exists.
-    let indexer = Arc::new(Indexer::new());
-    let handler = DocumentHandler::new(Arc::clone(&indexer), None);
-    let file_uri = Url::parse("file:///app/Screen.kt").unwrap();
-    let content = "import lib.padding\n\nfun screen() {}";
-    indexer.index_content(&file_uri, content);
-    indexer.store_live_tree(&file_uri, content);
+    //
+    // `with_xdg_cache` isolation matters here: the promotion probe lazily
+    // decodes the on-disk jar cache, and without isolation this test reads
+    // the developer's REAL multi-hundred-MB cache — slow and
+    // environment-dependent (it flaked exactly that way).
+    let tmp = tempfile::tempdir().expect("tempdir");
+    crate::indexer::test_helpers::with_xdg_cache(tmp.path(), || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("runtime");
+        runtime.block_on(async {
+            let indexer = Arc::new(Indexer::new());
+            let handler = DocumentHandler::new(Arc::clone(&indexer), None);
+            let file_uri = Url::parse("file:///app/Screen.kt").unwrap();
+            let content = "import lib.padding\n\nfun screen() {}";
+            indexer.index_content(&file_uri, content);
+            indexer.store_live_tree(&file_uri, content);
 
-    // Tier-1 manifest arrives only AFTER the file was opened.
-    let jar_id = indexer.jar_table.intern("/fake/foundation.jar");
-    indexer
-        .jar_bare_names
-        .entry("padding".to_owned())
-        .or_default()
-        .push(jar_id);
+            // Tier-1 manifest arrives only AFTER the file was opened.
+            let jar_id = indexer.jar_table.intern("/fake/foundation.jar");
+            indexer
+                .jar_bare_names
+                .entry("padding".to_owned())
+                .or_default()
+                .push(jar_id);
 
-    handler.republish_open_file_diagnostics();
+            handler.republish_open_file_diagnostics();
 
-    // The republish work runs on spawned tasks — poll for the attempt.
-    let mut attempted = false;
-    for _ in 0..200 {
-        if indexer.materialization_failed.contains(&jar_id)
-            || indexer.materialized.contains(&jar_id)
-        {
-            attempted = true;
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-    }
-    assert!(
-        attempted,
-        "when the jar scan completes, open files' imports must get a \
-         (re-)promotion attempt — didOpen ran before Tier-1 existed"
-    );
+            // The republish work runs on spawned tasks — poll for the attempt.
+            let mut attempted = false;
+            for _ in 0..400 {
+                if indexer.materialization_failed.contains(&jar_id)
+                    || indexer.materialized.contains(&jar_id)
+                {
+                    attempted = true;
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+            assert!(
+                attempted,
+                "when the jar scan completes, open files' imports must get a \
+                 (re-)promotion attempt — didOpen ran before Tier-1 existed"
+            );
+        });
+    });
 }
 
 #[test]

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -409,21 +409,21 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 return;
             }
             // ── Compiled-JAR first (sidecar path, populates jar_files / jar_definitions) ──
-            // The global Gradle cache is only meaningful for a Gradle
-            // workspace — a Swift/Xcode (or any non-Gradle) project cannot
-            // reference anything in it, and unconditionally running the
-            // pipeline there cost a 1.28M-name Tier-1 manifest over 755 JARs
-            // plus a 1.66M-symbol sources-JAR pass (observed live on an iOS
-            // repo). Explicitly configured `jarPaths` below stay unaffected.
-            let workspace_uses_gradle_cache = indexer
-                .workspace_root
-                .get()
-                .is_some_and(|root| crate::indexer::jar::workspace_has_gradle_markers(&root));
+            // The Gradle-cache pipeline only matters for a workspace with
+            // JVM sources — a Swift-only project cannot reference anything
+            // in it, and unconditionally running the pipeline there cost a
+            // 1.28M-name Tier-1 manifest over 755 JARs plus a 1.66M-symbol
+            // sources-JAR pass (observed live on an iOS repo). Gated on the
+            // INDEX (populated before this task runs), not on build-file
+            // markers — see `workspace_has_jvm_sources` for why. Explicitly
+            // configured `jarPaths` below stay unaffected.
+            let workspace_uses_gradle_cache =
+                crate::indexer::jar::workspace_has_jvm_sources(&indexer);
             let gradle_paths = if workspace_uses_gradle_cache {
                 crate::indexer::jar::scan_gradle_jars(None)
             } else {
                 log::info!(
-                    "jar: no Gradle build markers in the workspace — skipping the \
+                    "jar: no Kotlin/Java sources in the workspace — skipping the \
                      Gradle-cache JAR pipeline (configured jarPaths still honored)"
                 );
                 Vec::new()

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -409,7 +409,25 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 return;
             }
             // ── Compiled-JAR first (sidecar path, populates jar_files / jar_definitions) ──
-            let gradle_paths = crate::indexer::jar::scan_gradle_jars(None);
+            // The global Gradle cache is only meaningful for a Gradle
+            // workspace — a Swift/Xcode (or any non-Gradle) project cannot
+            // reference anything in it, and unconditionally running the
+            // pipeline there cost a 1.28M-name Tier-1 manifest over 755 JARs
+            // plus a 1.66M-symbol sources-JAR pass (observed live on an iOS
+            // repo). Explicitly configured `jarPaths` below stay unaffected.
+            let workspace_uses_gradle_cache = indexer
+                .workspace_root
+                .get()
+                .is_some_and(|root| crate::indexer::jar::workspace_has_gradle_markers(&root));
+            let gradle_paths = if workspace_uses_gradle_cache {
+                crate::indexer::jar::scan_gradle_jars(None)
+            } else {
+                log::info!(
+                    "jar: no Gradle build markers in the workspace — skipping the \
+                     Gradle-cache JAR pipeline (configured jarPaths still honored)"
+                );
+                Vec::new()
+            };
             let gradle_count = gradle_paths.len();
             let mut paths = gradle_paths;
 
@@ -474,8 +492,13 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             // Runs LAST so that when both pipelines contribute the same FQN to
             // `qualified` / `extension_by_receiver`, the sources-JAR entry (real
             // line numbers from tree-sitter) wins over the compiled-JAR entry
-            // (synthetic line indices from the sidecar).
-            let sources_total = crate::indexer::jar::index_sources_jars(&indexer, None, None);
+            // (synthetic line indices from the sidecar). Same Gradle gate as
+            // the compiled pipeline — sources JARs come from the same cache.
+            let sources_total = if workspace_uses_gradle_cache {
+                crate::indexer::jar::index_sources_jars(&indexer, None, None)
+            } else {
+                0
+            };
 
             if paths.is_empty() && sources_total == 0 {
                 if let Ok(mut phase) = indexer.jar_phase.lock() {


### PR DESCRIPTION
## Summary

The post-ship fix-wave series for the lazy-JAR-loading flip (#215), split out so each PR stays reviewable. Base is `feat/lazy-jar-loading` at the boundary of the first batched review; every commit here was covered by the second batched independent review (verdict applied in the final commit).

Seven commits, four user-reported live-testing waves:

- **`9ed46a8`** — uncap file-open import promotion (the designed safety net for zero-IPC inference; a cap of 5 permanently starved cold imports past the fifth) + throttle whole-map cache saves (one per cold JAR was pushing completion past editor timeouts during cache-heal storms).
- **`138f30a`** — first batched review's findings: dashmap lock-order fix (plausible deadlock), per-walk hierarchy promotion budget, jar member-enumeration package disambiguation + deprecated filter.
- **`c6ee13b`** — cold-start ordering gap: files open before the Tier-1 manifest exists, so didOpen promotion silently no-oped and never retried; the jar-scan-completion republish now re-promotes every open file's imports.
- **`7141898`** — Swift/Xcode workspaces ran the entire Gradle-cache pipeline (1.28M-name manifest + 1.66M sources-JAR symbols) they can't reference. New gate: Gradle build markers at the root or one level below; configured `jarPaths` unaffected.
- **`c880384`** — **warm-path root cause of the chain-completion failure**: `ExtensionEntry.package` came from a per-JAR inference poisoned by a package-less nested-class detail, so the scope filter rejected explicitly imported extensions. Entries now carry the sidecar's real per-symbol `pkg`. Found by dumping and replaying the real user cache entry.
- **`f8222f8`** — **the user's actual editing form**: multiline fluent chains (`.padd…` on a continuation line) and multi-call chains were never supported. New balanced-paren backward chain scanner + continuation-line reconstruction. Live-verified against the real project via a scripted LSP probe (both forms return the full Modifier extension set).
- **`1119cfa`** — second batched review's findings: sequential (race-free) republish promotion, comment-stripping in the chain join, import-coverage semantics for nested-class imports, parse-permit scope, save-throttle clock init, test isolation.

## Review status

Batched independent review of this exact series: verdict Request-changes with an explicit **redundancy audit confirming no commit is redundant** (the root-cause fixes operate on Tier-2 data that import promotion materializes — chicken-and-egg makes file-open promotion the designed vehicle). All actionable findings fixed in `1119cfa`; deferred lows tracked in `.superpowers/sdd/progress.md`.

## Test plan

- [x] `cargo test --bin kmp-lsp` — 1507 passed
- [x] `cargo clippy` (lib + tests) — clean
- [x] `cargo test --test lsp_smoke smoke_completion_from_compiled_jar` — passing
- [x] Scripted live LSP probe against the real Compose project: multiline continuation + single-line chain completion both return the full extension set; user-confirmed fixed in-editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)