### PR TITLE
refactor(jar): atomic gate+promote+read accessors (structural PR1)

### DIFF
--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -1042,6 +1042,58 @@ pub(crate) fn materialize_jar_on_demand(
     }
 }
 
+/// THE named gate+promote for every name-keyed Tier-2 consumer: checks
+/// Tier 1 for candidates and promotes them within `sidecar_budget`, in one
+/// call. Callers MUST run this before reading `jar_definitions`/`jar_files`
+/// (directly or via `resolve_symbol_no_rg`-style helpers) — the check-then-
+/// promote-then-read ordering was hand-rolled per site during the lazy-JAR
+/// work and produced two shipped promote-AFTER-read bugs plus one silent
+/// gate/promotion key mismatch; this function is the single place that
+/// ordering and key discipline live now.
+///
+/// Handles the dotted-spelling mismatch the hand-rolled gates had (PR #215
+/// follow-up #13): `jar_qualified_or_bare_has_candidate` passes for a
+/// QUALIFIED-only spelling (`class X : com.lib.Base()`), but promotion is
+/// keyed by BARE name — so the raw string found no candidates and the
+/// promotion silently no-oped, dead-ending hierarchy walks over qualified
+/// super types. A dotted `name` now falls back to its leaf segment.
+pub(crate) fn ensure_jar_definitions_for(
+    indexer: &crate::indexer::Indexer,
+    name: &str,
+    sidecar_budget: &mut usize,
+) -> bool {
+    if !indexer.jar_qualified_or_bare_has_candidate(name) {
+        return false;
+    }
+    if ensure_jar_materialized_with_budget(indexer, name, sidecar_budget) {
+        return true;
+    }
+    match name.rsplit('.').next() {
+        Some(leaf) if leaf != name && !leaf.is_empty() => {
+            ensure_jar_materialized_with_budget(indexer, leaf, sidecar_budget)
+        }
+        _ => false,
+    }
+}
+
+/// Atomic gate + promote + READ for extension entries keyed by receiver
+/// type: the one call completion/inference sites use instead of pairing a
+/// promotion with a separate `extension_by_receiver.get` — pairing the two
+/// by hand is exactly the ordering-bug shape that shipped twice during the
+/// lazy-JAR work. Source-derived entries are returned even when no JAR
+/// declares extensions on `receiver` (the promotion gate only guards the
+/// Tier-2 promotion, never the read).
+pub(crate) fn extension_entries_for<'indexer>(
+    indexer: &'indexer crate::indexer::Indexer,
+    receiver: &str,
+    sidecar_budget: &mut usize,
+) -> Option<dashmap::mapref::one::Ref<'indexer, String, Vec<crate::types::ExtensionEntry>>> {
+    if indexer.jar_extension_receivers.contains_key(receiver) {
+        ensure_jar_materialized_for_extension_receiver(indexer, receiver, sidecar_budget);
+    }
+    indexer.extension_by_receiver.get(receiver)
+}
+
 /// Shared promotion helper for every direct-read consumer of
 /// `jar_definitions`/`jar_files`: if `name` has a Tier-1 candidate that
 /// isn't materialized yet, attempt Tier-2 materialization via a bounded,

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -2208,3 +2208,97 @@ fn jvm_source_probe_ignores_library_sources() {
     }
     assert!(!crate::indexer::jar::workspace_has_jvm_sources(&idx));
 }
+
+// ── atomic promotion accessors (refactor PR1) ───────────────────────────────
+
+/// The dotted-name gate mismatch (PR #215 follow-up #13), now fixed inside
+/// the named accessor: `jar_qualified_or_bare_has_candidate` passes for a
+/// QUALIFIED-only spelling (`com.lib.Base` in `class X : com.lib.Base()`),
+/// but promotion keyed the raw string into `jar_bare_names` — which only
+/// holds bare names — so the gate passed and the promotion silently
+/// no-oped. The accessor must fall back to the bare leaf segment.
+#[test]
+fn promotion_accessor_promotes_dotted_qualified_names_via_their_leaf() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    crate::indexer::test_helpers::with_xdg_cache(tmp.path(), || {
+        let jar_path = tmp.path().join("base-lib.jar");
+        std::fs::write(&jar_path, b"jar bytes").expect("write fake jar");
+        let jar_path_key = jar_path.to_string_lossy().to_string();
+        let entry = crate::indexer::jar_cache::make_cache_entry(
+            &jar_path,
+            vec![make_sidecar_symbol(
+                "Base",
+                "class",
+                "class com.lib.Base",
+                "",
+            )],
+        )
+        .expect("cache entry");
+        let mut entries = std::collections::HashMap::new();
+        entries.insert(jar_path_key.clone(), entry);
+        crate::indexer::jar_cache::save_jar_cache(&entries);
+
+        let idx = crate::indexer::Indexer::new();
+        let jar_id = idx.jar_table.intern(&jar_path_key);
+        idx.jar_bare_names
+            .entry("Base".to_owned())
+            .or_default()
+            .push(jar_id);
+        idx.jar_qualified.insert("com.lib.Base".to_owned(), jar_id);
+
+        // The caller-side spelling is the QUALIFIED name.
+        let mut budget = 0usize; // cache-backed, so zero IPC budget suffices
+        crate::indexer::jar::ensure_jar_definitions_for(&idx, "com.lib.Base", &mut budget);
+        assert!(
+            idx.materialized.contains(&jar_id),
+            "a dotted qualified spelling must promote via its bare leaf — \
+             the gate already passes for it, so a silent no-op is a latent \
+             dead-end for hierarchy walks over qualified super types"
+        );
+    });
+}
+
+/// The atomic read accessor: gate + promote + read in ONE call, so no caller
+/// can reintroduce the promote-AFTER-read ordering bug class (two instances
+/// of which shipped and were caught by review during the lazy-loading work).
+#[test]
+fn extension_entries_accessor_promotes_before_reading() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    crate::indexer::test_helpers::with_xdg_cache(tmp.path(), || {
+        let jar_path = tmp.path().join("ext-lib.jar");
+        std::fs::write(&jar_path, b"jar bytes").expect("write fake jar");
+        let jar_path_key = jar_path.to_string_lossy().to_string();
+        let entry = crate::indexer::jar_cache::make_cache_entry(
+            &jar_path,
+            vec![make_sidecar_extension(
+                "pad",
+                "Widget",
+                "fun Widget.pad(): Widget",
+            )],
+        )
+        .expect("cache entry");
+        let mut entries = std::collections::HashMap::new();
+        entries.insert(jar_path_key.clone(), entry);
+        crate::indexer::jar_cache::save_jar_cache(&entries);
+
+        let idx = crate::indexer::Indexer::new();
+        let jar_id = idx.jar_table.intern(&jar_path_key);
+        idx.jar_extension_receivers
+            .entry("Widget".to_owned())
+            .or_default()
+            .push(jar_id);
+
+        let mut budget = 0usize;
+        let entries = crate::indexer::jar::extension_entries_for(&idx, "Widget", &mut budget);
+        let found = entries.is_some_and(|extension_entries| {
+            extension_entries
+                .iter()
+                .any(|extension_entry| extension_entry.name == "pad")
+        });
+        assert!(
+            found,
+            "one atomic call must materialize the Tier-1-only jar AND return \
+             its extension entries"
+        );
+    });
+}

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -66,9 +66,8 @@ impl Indexer {
     /// (index-aligned with the symbol's synthetic line number), falling back to the
     /// per-jar inferred package. The container is read from the JAR symbol entry.
     pub(crate) fn jar_declaration_scope(&self, name: &str) -> Option<(String, Option<String>)> {
-        if self.jar_qualified_or_bare_has_candidate(name) {
-            crate::indexer::jar::ensure_jar_materialized(self, name);
-        }
+        let mut unbudgeted = usize::MAX;
+        crate::indexer::jar::ensure_jar_definitions_for(self, name, &mut unbudgeted);
         let locs = self.jar_definitions.get(name)?;
         for loc in locs.iter() {
             let uri_str = loc.uri.as_str();

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -660,9 +660,8 @@ impl IndexRead for super::Indexer {
                     .collect()
             })
             .unwrap_or_default();
-        if self.jar_qualified_or_bare_has_candidate(name) {
-            crate::indexer::jar::ensure_jar_materialized(self, name);
-        }
+        let mut unbudgeted = usize::MAX;
+        crate::indexer::jar::ensure_jar_definitions_for(self, name, &mut unbudgeted);
         if let Some(jar_locs) = self.jar_definitions.get(name) {
             locs.extend(jar_locs.iter().cloned());
         }

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -389,17 +389,13 @@ fn extension_fn_completions(
     // completion (`MAX_SYNC_JAR_PROMOTIONS_PER_COMPLETION`).
     let mut jar_promotion_budget = MAX_SYNC_JAR_PROMOTIONS_PER_COMPLETION;
     for ancestor in &ancestor_set {
-        // `extension_by_receiver` is Tier 2 (populated only by full JAR
-        // materialization) — promote any not-yet-materialized JAR that
-        // Tier 1 knows declares an extension on this ancestor BEFORE
-        // reading it, so a not-yet-touched JAR's extensions (e.g.
-        // `viewModelScope`) aren't silently invisible.
-        crate::indexer::jar::ensure_jar_materialized_for_extension_receiver(
-            indexer,
-            ancestor,
-            &mut jar_promotion_budget,
-        );
-        if let Some(entries) = indexer.extension_by_receiver.get(ancestor) {
+        // Atomic promote+read: `extension_by_receiver` is Tier 2 (populated
+        // only by full JAR materialization), so a not-yet-touched JAR's
+        // extensions (e.g. `viewModelScope`) would be silently invisible
+        // without the accessor's promotion.
+        if let Some(entries) =
+            crate::indexer::jar::extension_entries_for(indexer, ancestor, &mut jar_promotion_budget)
+        {
             for entry in entries.iter() {
                 if crate::Language::from_path(&entry.file_uri) == crate::Language::Kotlin {
                     let is_library = is_library_extension(indexer, &entry.file_uri);
@@ -880,10 +876,8 @@ fn resolve_dot_receiver_file(
     // invisible to `resolve_symbol_no_rg` (Tier-2 `jar_definitions` reads) —
     // promote it first, or this returns `None` and BOTH direct-member and
     // inherited-member completion are skipped wholesale for that receiver.
-    // Same gate-then-promote pattern as the Task 8 consumer sites.
-    if indexer.jar_qualified_or_bare_has_candidate(outer_type) {
-        crate::indexer::jar::ensure_jar_materialized(indexer, outer_type);
-    }
+    let mut unbudgeted = usize::MAX;
+    crate::indexer::jar::ensure_jar_definitions_for(indexer, outer_type, &mut unbudgeted);
     Some(
         resolve_symbol_no_rg(indexer, outer_type, from_uri)
             .first()?
@@ -1930,26 +1924,17 @@ impl<'a> BareCompletionWalk<'a> {
         // Use the reverse index: O(ancestors × entries_per_receiver) instead of O(all_files).
         let prefix = self.prefix;
         for ancestor in ancestor_names.iter() {
-            // Same promotion-before-read discipline as `extension_fn_completions`
-            // (dot-completion) — `extension_by_receiver` is Tier 2 only. Gated
-            // on a real Tier-1 candidate existing (not just "budget left") so
-            // an ancestor with no JAR-declared extension never burns budget
-            // on a no-op — a deep hierarchy would otherwise exhaust the whole
-            // per-request cap before the cross-package promotion below ever
-            // runs. Shares the same cap/counter as that promotion: both spend
-            // from one per-request blocking-IPC budget.
-            if self.indexer.jar_extension_receivers.contains_key(ancestor) {
-                let cap_remaining = MAX_SYNC_JAR_PROMOTIONS_PER_COMPLETION
-                    .saturating_sub(self.jar_promotion_attempts);
-                let mut remaining = cap_remaining;
-                crate::indexer::jar::ensure_jar_materialized_for_extension_receiver(
-                    self.indexer,
-                    ancestor,
-                    &mut remaining,
-                );
-                self.jar_promotion_attempts += cap_remaining - remaining;
-            }
-            let Some(entries) = self.indexer.extension_by_receiver.get(ancestor) else {
+            // Atomic promote+read via the accessor. Shares the per-request
+            // blocking-IPC cap with the cross-package promotion below: the
+            // accessor spends from `remaining`, and the delta is charged
+            // back onto the request-wide counter.
+            let cap_remaining =
+                MAX_SYNC_JAR_PROMOTIONS_PER_COMPLETION.saturating_sub(self.jar_promotion_attempts);
+            let mut remaining = cap_remaining;
+            let entries =
+                crate::indexer::jar::extension_entries_for(self.indexer, ancestor, &mut remaining);
+            self.jar_promotion_attempts += cap_remaining - remaining;
+            let Some(entries) = entries else {
                 continue;
             };
             for entry in entries.iter() {

--- a/src/resolver/hierarchy.rs
+++ b/src/resolver/hierarchy.rs
@@ -110,16 +110,12 @@ fn supertype_targets(
             // — promote it first, or the hierarchy walk silently dead-ends
             // here and every inherited member (e.g. `setState` on a library
             // `MviViewModel` base class) disappears from completion/hover.
-            // Same gate-then-promote pattern as the Task 8 consumer sites,
             // BUDGETED per walk (see the constant above): unbudgeted, this
             // was the one promotion site reachable around every request cap.
-            if idx.jar_qualified_or_bare_has_candidate(&super_name) {
-                crate::indexer::jar::ensure_jar_materialized_with_budget(
-                    idx,
-                    &super_name,
-                    sidecar_budget,
-                );
-            }
+            // `super_name` can be a dotted qualified spelling
+            // (`class X : com.lib.Base()`) — the accessor handles the
+            // bare-leaf fallback.
+            crate::indexer::jar::ensure_jar_definitions_for(idx, &super_name, sidecar_budget);
             super::resolve_symbol_no_rg(idx, &super_name, &uri)
                 .into_iter()
                 .map(move |loc| (super_name.clone(), loc.uri.to_string()))

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -637,12 +637,11 @@ fn find_extension_property_type(indexer: &Indexer, prop_name: &str, uri: &Url) -
     // or by the completion sites' own budget instead.
     let mut jar_promotion_budget = 0usize;
     for ancestor in &ancestor_set {
-        crate::indexer::jar::ensure_jar_materialized_for_extension_receiver(
+        let Some(entries) = crate::indexer::jar::extension_entries_for(
             indexer,
             ancestor,
             &mut jar_promotion_budget,
-        );
-        let Some(entries) = indexer.extension_by_receiver.get(ancestor) else {
+        ) else {
             continue;
         };
         for entry in entries.iter() {
@@ -808,14 +807,8 @@ pub(crate) fn find_fun_return_type_reachable(
     // free and still happen; a genuinely uncached JAR is promoted by the
     // explicit user actions instead (completion's budget, file-open imports,
     // hover/goto-def resolution).
-    if indexer.jar_qualified_or_bare_has_candidate(fn_name) {
-        let mut cache_backed_only = 0usize;
-        crate::indexer::jar::ensure_jar_materialized_with_budget(
-            indexer,
-            fn_name,
-            &mut cache_backed_only,
-        );
-    }
+    let mut cache_backed_only = 0usize;
+    crate::indexer::jar::ensure_jar_definitions_for(indexer, fn_name, &mut cache_backed_only);
     let locations = crate::resolver::resolve_symbol_no_rg(indexer, fn_name, uri);
     let mut fallback: Option<String> = None;
     for loc in &locations {
@@ -969,15 +962,10 @@ fn find_extension_fn_return_type_scoped(
     // above: inference runs per-name on latency-critical paths (inlay hints)
     // — cache-backed promotions stay free, blocking IPC belongs to explicit
     // user actions.
-    if indexer.jar_qualified_or_bare_has_candidate(method_name) {
-        let mut cache_backed_only = 0usize;
-        crate::indexer::jar::ensure_jar_materialized_with_budget(
-            indexer,
-            method_name,
-            &mut cache_backed_only,
-        );
-    }
-    let entries = indexer.extension_by_receiver.get(receiver_base)?;
+    let mut cache_backed_only = 0usize;
+    crate::indexer::jar::ensure_jar_definitions_for(indexer, method_name, &mut cache_backed_only);
+    let entries =
+        crate::indexer::jar::extension_entries_for(indexer, receiver_base, &mut cache_backed_only)?;
     let caller_file_data = indexer.files.get(from_uri.as_str());
     let caller_file_data_ref: Option<&FileData> = caller_file_data.as_deref().map(|v| v.as_ref());
     let caller_package = caller_file_data.as_ref().and_then(|fd| fd.package.as_ref());


### PR DESCRIPTION
## Summary

First of the 3-PR structural refactor the lazy-JAR fix waves argued for: **seven** live regression waves traced to hand-rolled check-then-promote-then-read sequences around the Tier-1/Tier-2 maps — two shipped promote-after-read orderings, one silent gate/key mismatch, and per-site comments carrying an invariant no type enforced.

- `ensure_jar_definitions_for(name, budget)` — the named gate+promote every name-keyed Tier-2 consumer calls before resolving. Also fixes the dotted-spelling gate mismatch (#215 follow-up 13, test-pinned): qualified spellings now promote via their bare leaf instead of silently no-oping.
- `extension_entries_for(receiver, budget)` — atomic promote+read of `extension_by_receiver`; the read-first bug shape is now unrepresentable at call sites.
- All nine hand-rolled sites migrated; per-site budget semantics preserved (request cap / walk cap / zero-IPC / unbudgeted). `add_cross_package_name` deliberately deferred to PR3 (distinct attempt-counter semantics), together with the ~18 unwired `jar_definitions`/`jar_files` reads.

Follow-ups: PR2 = `note_bare_names_populated()` invalidation dedup (9 duplicate sites); PR3 = unwired-read migration onto these accessors.

## Test plan

- [x] `cargo test --bin kmp-lsp` — 1509 passed (2 new accessor tests, incl. the dotted-leaf regression pin)
- [x] `cargo clippy` (lib + tests) — clean
- [x] `cargo test --test lsp_smoke smoke_completion_from_compiled_jar` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)