### PR TITLE
refactor(jar): note_jar_symbols_populated — invalidation dedup (structural PR2)

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1075,6 +1075,18 @@ impl Indexer {
         self.files.remove(uri.as_str());
     }
 
+    /// One-stop invalidation for "JAR symbols were just populated" (Tier-1
+    /// manifest merge or Tier-2 on-demand materialization): the bare-name
+    /// cache must rebuild lazily AND every completion-adjacent cache must
+    /// drop. Previously hand-rolled as a three-line cluster at each populate
+    /// site — and every copy missed `this_ext_ancestor_cache`, so a freshly
+    /// materialized base class could keep serving a stale ancestor set to
+    /// bare completion's extension collector.
+    pub(crate) fn note_jar_symbols_populated(&self) {
+        self.bare_names_dirty.store(true, Ordering::Release);
+        self.invalidate_completion_cache();
+    }
+
     /// Bust the completion cache so the next request recomputes with the latest
     /// index state. Called when JAR indexing finishes to surface new symbols
     /// (e.g. `launch {}`) without requiring the user to retype.

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -480,15 +480,7 @@ pub(crate) fn apply_sources_contributions(
         total += contrib.file_data.1.symbols.len();
         apply_contribution_to_index(indexer, contrib);
     }
-    indexer
-        .bare_names_dirty
-        .store(true, std::sync::atomic::Ordering::Release);
-    if let Ok(mut last) = indexer.last_completion.lock() {
-        *last = None;
-    }
-    indexer
-        .completion_epoch
-        .fetch_add(1, std::sync::atomic::Ordering::Release);
+    indexer.note_jar_symbols_populated();
     total
 }
 
@@ -643,16 +635,7 @@ pub(crate) fn index_jars(
             "jar: indexed {total} symbols from {} compiled JARs/AARs ({cache_hits} from cache)",
             paths.len()
         );
-        indexer
-            .bare_names_dirty
-            .store(true, std::sync::atomic::Ordering::Release);
-        // Invalidate cached completion results.
-        if let Ok(mut last) = indexer.last_completion.lock() {
-            *last = None;
-        }
-        indexer
-            .completion_epoch
-            .fetch_add(1, std::sync::atomic::Ordering::Release);
+        indexer.note_jar_symbols_populated();
     } else {
         log::info!(
             "jar: zero symbols from {} compiled JARs (sidecar={}, cache_hits={cache_hits})",
@@ -1368,16 +1351,7 @@ pub(crate) fn build_jar_manifest(
         // afterward — every Tier-1-only candidate this call just manifested
         // would stay permanently invisible to bare-word/auto-import
         // completion for the rest of the process's life.
-        indexer
-            .bare_names_dirty
-            .store(true, std::sync::atomic::Ordering::Release);
-        // Invalidate cached completion results.
-        if let Ok(mut last) = indexer.last_completion.lock() {
-            *last = None;
-        }
-        indexer
-            .completion_epoch
-            .fetch_add(1, std::sync::atomic::Ordering::Release);
+        indexer.note_jar_symbols_populated();
     }
     total_names
 }


### PR DESCRIPTION
## Summary

Second of the 3-PR structural refactor (stacked on #217). The "JAR symbols were just populated" invalidation cluster (`bare_names_dirty` + `last_completion` + `completion_epoch`) was hand-rolled at three populate sites — and **every copy missed `this_ext_ancestor_cache`**, so a freshly materialized base class could keep serving a stale ancestor set to bare completion's extension collector.

One named method (`Indexer::note_jar_symbols_populated`) now owns the cluster, delegating to the canonical `invalidate_completion_cache` — the three sites collapse to one call each and the ancestor-cache gap closes as a side effect of reusing the whole invalidation instead of copying two-thirds of it.

Remaining: PR3 migrates the ~18 unwired `jar_definitions`/`jar_files` reads (plus `add_cross_package_name`) onto #217's accessors.

## Test plan

- [x] `cargo test --bin kmp-lsp` — 1509 passed
- [x] `cargo clippy` (lib + tests) — clean
- [x] `cargo test --test lsp_smoke smoke_completion_from_compiled_jar` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)