### PR TITLE
fix(jar): wait out the workspace-scan race in the Gradle-pipeline gate

### DIFF
--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -111,13 +111,18 @@ pub(crate) fn scan_gradle_jars(gradle_home: Option<&Path>) -> Vec<PathBuf> {
 /// running the pipeline there cost a 1.28M-name Tier-1 manifest over 755
 /// JARs plus a 1.66M-symbol sources-JAR pass (observed live on an iOS repo).
 ///
-/// Deliberately asks the INDEX (fully populated before the jar scan starts)
-/// instead of probing build files: a build-marker heuristic wrongly excluded
-/// non-Gradle JVM builds (Maven/Bazel/manual) and Gradle repos opened at a
-/// deep subdirectory (markers only above the root), and duplicated the
-/// root-marker detection that already lives in `document_handler`. Library
-/// source-set files (sourcePaths, extracted jar sources) don't count — they
-/// are not the workspace's own code.
+/// Deliberately asks the INDEX instead of probing build files: a
+/// build-marker heuristic wrongly excluded non-Gradle JVM builds
+/// (Maven/Bazel/manual) and Gradle repos opened at a deep subdirectory
+/// (markers only above the root), and duplicated the root-marker detection
+/// that already lives in `document_handler`. Library source-set files
+/// (sourcePaths, extracted jar sources) don't count — they are not the
+/// workspace's own code.
+///
+/// The index answers reliably only once the workspace scan has had a chance
+/// to populate it — consult this through [`wait_for_jvm_sources_gate`] on
+/// the jar-scan path, which is spawned concurrently with (and typically
+/// ahead of) the workspace scan.
 pub(crate) fn workspace_has_jvm_sources(indexer: &crate::indexer::Indexer) -> bool {
     indexer.files.iter().any(|entry| {
         entry.value().source_set != SourceSet::Library
@@ -125,6 +130,45 @@ pub(crate) fn workspace_has_jvm_sources(indexer: &crate::indexer::Indexer) -> bo
                 || entry.key().ends_with(".kts")
                 || entry.key().ends_with(".java"))
     })
+}
+
+/// Scan-race-safe wrapper around [`workspace_has_jvm_sources`], for the jar
+/// pipeline task. That task is spawned right after the workspace scan is
+/// ENQUEUED — evaluating the gate immediately read an EMPTY index and
+/// skipped the whole Gradle pipeline on a Kotlin repo (observed live:
+/// "jar: no Kotlin/Java sources in the workspace" on a Compose project →
+/// Tier-1 manifests never populated → jar auto-import/doc/extension data
+/// silently missing for the rest of the session).
+///
+/// Blocks (poll + sleep; callers run on a `spawn_blocking` thread) until one
+/// of:
+/// - a workspace JVM source shows up in the index → `Some(true)`. On a JVM
+///   repo the scan indexes one within its first files, so the pipeline
+///   still starts near-immediately and keeps its old concurrency with the
+///   workspace scan;
+/// - `is_scanning` reports the scan queue drained → final verdict from the
+///   now-authoritative index (re-checked AFTER observing the drain, so a
+///   source indexed between the two probes isn't missed);
+/// - `generation_ok` fails (root changed mid-wait; this task is superseded)
+///   → `None`, caller abandons like the other stale-generation checkpoints.
+pub(crate) fn wait_for_jvm_sources_gate(
+    indexer: &crate::indexer::Indexer,
+    is_scanning: impl Fn() -> bool,
+    generation_ok: impl Fn() -> bool,
+    poll: std::time::Duration,
+) -> Option<bool> {
+    loop {
+        if !generation_ok() {
+            return None;
+        }
+        if workspace_has_jvm_sources(indexer) {
+            return Some(true);
+        }
+        if !is_scanning() {
+            return Some(workspace_has_jvm_sources(indexer));
+        }
+        std::thread::sleep(poll);
+    }
 }
 
 /// Scan for sources JARs only.

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -2156,8 +2156,9 @@ fn flush_pending_jar_cache_save_persists_the_suppressed_tail() {
 /// pipeline: on a real machine that pipeline manifested 1.28M names from
 /// 755 compiled JARs and parsed 1.66M symbols out of 521 sources JARs —
 /// pure waste for a project that cannot reference any of them (observed
-/// live on an iOS repo). The gate asks the INDEX (already populated when
-/// the jar scan starts) rather than probing build files: build-marker
+/// live on an iOS repo). The gate asks the INDEX (via
+/// `wait_for_jvm_sources_gate`, which waits out the workspace-scan race)
+/// rather than probing build files: build-marker
 /// heuristics wrongly excluded non-Gradle JVM projects (Maven/Bazel) and
 /// Gradle repos opened at a deep subdirectory, and duplicated the root
 /// detection that already lives in document_handler.
@@ -2207,6 +2208,101 @@ fn jvm_source_probe_ignores_library_sources() {
         *file.value_mut() = std::sync::Arc::new(data);
     }
     assert!(!crate::indexer::jar::workspace_has_jvm_sources(&idx));
+}
+
+// ── wait_for_jvm_sources_gate (scan-race fix) ───────────────────────────────
+
+/// THE regression this function exists for: `spawn_jar_indexing` fires right
+/// after the workspace scan is ENQUEUED, so evaluating the gate immediately
+/// reads an EMPTY index and skips the whole Gradle pipeline on a Kotlin
+/// repo (observed live: "jar: no Kotlin/Java sources in the workspace" on
+/// Moneta → Tier-1 never populated → auto-import/docs dead for jar classes).
+/// The gate must keep waiting while the scan runs and flip to `true` as soon
+/// as the scan indexes the first JVM source.
+#[test]
+fn gate_waits_for_the_scan_to_index_the_first_jvm_source() {
+    let idx = crate::indexer::Indexer::new();
+    let polls = std::sync::atomic::AtomicUsize::new(0);
+    let verdict = crate::indexer::jar::wait_for_jvm_sources_gate(
+        &idx,
+        || {
+            // Scan "runs" for two polls; the second poll indexes a Kotlin file
+            // (mid-scan), exactly like the real prioritized scan does.
+            let n = polls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n == 1 {
+                idx.index_content(
+                    &tower_lsp::lsp_types::Url::parse("file:///app/Main.kt").unwrap(),
+                    "package app\nclass Main",
+                );
+            }
+            n < 3
+        },
+        || true,
+        std::time::Duration::from_millis(1),
+    );
+    assert_eq!(
+        verdict,
+        Some(true),
+        "a JVM source indexed while the scan is still running must open the gate"
+    );
+}
+
+/// A genuinely JVM-free workspace: the gate must return `false` only AFTER
+/// the scan queue drains (the scan has proven there is nothing to find),
+/// not before.
+#[test]
+fn gate_rejects_a_swift_only_workspace_only_after_the_scan_drains() {
+    let idx = crate::indexer::Indexer::new();
+    idx.index_content(
+        &tower_lsp::lsp_types::Url::parse("file:///ios/App.swift").unwrap(),
+        "struct App {}",
+    );
+    let polls = std::sync::atomic::AtomicUsize::new(0);
+    let verdict = crate::indexer::jar::wait_for_jvm_sources_gate(
+        &idx,
+        || polls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) < 3,
+        || true,
+        std::time::Duration::from_millis(1),
+    );
+    assert_eq!(verdict, Some(false));
+    assert!(
+        polls.load(std::sync::atomic::Ordering::SeqCst) >= 3,
+        "the negative verdict must wait for the scan queue to drain"
+    );
+}
+
+/// A JVM source that is already indexed when the gate is consulted (warm
+/// path, or a didOpen that beat the jar task) must open the gate immediately
+/// — even if a scan is still in flight — preserving the old scan/jar
+/// concurrency for JVM repos.
+#[test]
+fn gate_opens_immediately_when_a_jvm_source_is_already_indexed() {
+    let idx = crate::indexer::Indexer::new();
+    idx.index_content(
+        &tower_lsp::lsp_types::Url::parse("file:///shared/Model.kt").unwrap(),
+        "package shared\nclass Model",
+    );
+    let verdict = crate::indexer::jar::wait_for_jvm_sources_gate(
+        &idx,
+        || panic!("gate must not poll the scan state when the index already answers"),
+        || true,
+        std::time::Duration::from_millis(1),
+    );
+    assert_eq!(verdict, Some(true));
+}
+
+/// A workspace-root change mid-wait supersedes this jar task; the gate must
+/// report that instead of answering for the wrong root.
+#[test]
+fn gate_bails_out_when_the_generation_changes_mid_wait() {
+    let idx = crate::indexer::Indexer::new();
+    let verdict = crate::indexer::jar::wait_for_jvm_sources_gate(
+        &idx,
+        || true,
+        || false,
+        std::time::Duration::from_millis(1),
+    );
+    assert_eq!(verdict, None, "stale generation must abort, not answer");
 }
 
 // ── atomic promotion accessors (refactor PR1) ───────────────────────────────

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -432,9 +432,18 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                     .load(Ordering::Acquire)
                     == expected_gen
             };
+            // Recover from a poisoned queue lock rather than panicking: a
+            // panic here would strand `jar_indexing_in_progress` as true and
+            // wedge the jar pipeline for the rest of the process. Reading
+            // `is_in_progress` off a poisoned queue is harmless.
             let workspace_uses_gradle_cache = match crate::indexer::jar::wait_for_jvm_sources_gate(
                 &indexer,
-                || scan_queue.lock().unwrap().is_in_progress(),
+                || {
+                    scan_queue
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .is_in_progress()
+                },
                 generation_ok,
                 std::time::Duration::from_millis(100),
             ) {

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -42,7 +42,9 @@ pub(crate) struct ScanHandler<R: ProgressReporter + 'static> {
     indexer: Arc<Indexer>,
     reporter: Arc<R>,
     state: Arc<RwLock<State>>,
-    scan_queue: Mutex<ScanQueue>,
+    /// `Arc` so the jar-pipeline task can poll "is a workspace scan still
+    /// running" from its blocking thread — see `wait_for_jvm_sources_gate`.
+    scan_queue: Arc<Mutex<ScanQueue>>,
     scan_done_tx: mpsc::UnboundedSender<()>,
     /// Signals the actor when background JAR indexing reaches a terminal phase so
     /// it can recompute diagnostics for files diagnosed against a partial index.
@@ -67,7 +69,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             indexer,
             reporter,
             state,
-            scan_queue: Mutex::new(ScanQueue::new()),
+            scan_queue: Arc::new(Mutex::new(ScanQueue::new())),
             scan_done_tx,
             jar_done_tx,
             jar_indexing_in_progress: Arc::new(AtomicBool::new(false)),
@@ -381,6 +383,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
         let indexer = Arc::clone(&self.indexer);
         let in_progress = Arc::clone(&self.jar_indexing_in_progress);
         let jar_done_tx = self.jar_done_tx.clone();
+        let scan_queue = Arc::clone(&self.scan_queue);
 
         // Init-options `jarPaths` specs (cheap string clone). The actual filesystem
         // expansion (reading workspace.json, walking dirs) happens inside the
@@ -414,11 +417,33 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             // in it, and unconditionally running the pipeline there cost a
             // 1.28M-name Tier-1 manifest over 755 JARs plus a 1.66M-symbol
             // sources-JAR pass (observed live on an iOS repo). Gated on the
-            // INDEX (populated before this task runs), not on build-file
-            // markers — see `workspace_has_jvm_sources` for why. Explicitly
-            // configured `jarPaths` below stay unaffected.
-            let workspace_uses_gradle_cache =
-                crate::indexer::jar::workspace_has_jvm_sources(&indexer);
+            // INDEX, not on build-file markers — see
+            // `workspace_has_jvm_sources` for why. This task races the
+            // workspace scan that populates that index (every caller
+            // enqueues the scan first, so the queue is already non-idle
+            // here), so the gate WAITS: it opens the moment the scan
+            // indexes the first JVM source, and returns a negative verdict
+            // only once the queue drains. Explicitly configured `jarPaths`
+            // below stay unaffected.
+            let generation_ok = || {
+                indexer
+                    .workspace_root
+                    .generation_atomic()
+                    .load(Ordering::Acquire)
+                    == expected_gen
+            };
+            let workspace_uses_gradle_cache = match crate::indexer::jar::wait_for_jvm_sources_gate(
+                &indexer,
+                || scan_queue.lock().unwrap().is_in_progress(),
+                generation_ok,
+                std::time::Duration::from_millis(100),
+            ) {
+                Some(verdict) => verdict,
+                None => {
+                    abandon_stale_jar_scan(&indexer, &in_progress, &jar_done_tx);
+                    return;
+                }
+            };
             let gradle_paths = if workspace_uses_gradle_cache {
                 crate::indexer::jar::scan_gradle_jars(None)
             } else {

--- a/tests/lsp_smoke.rs
+++ b/tests/lsp_smoke.rs
@@ -381,36 +381,46 @@ fn smoke_completion_cross_package() {
     let uri = file_uri(root, "src/Screen.kt");
     client.open_file(&uri, "kotlin", edit_text);
 
-    // Line 2 (0-based), col 7 = after "    Pay" (4 spaces + 3 chars)
-    let resp = client.request(
-        "textDocument/completion",
-        json!({
-            "textDocument": {"uri": uri},
-            "position": pos(edit_text, 2, 7),
-        }),
-    );
-    let result = &resp["result"];
-    let items = if result.is_array() {
-        result.as_array().unwrap().clone()
-    } else {
-        result["items"].as_array().cloned().unwrap_or_default()
-    };
-
-    let labels: Vec<&str> = items.iter().filter_map(|v| v["label"].as_str()).collect();
-
-    assert!(
-        labels.contains(&"PaymentService"),
-        "PaymentService from library must appear for prefix 'Pay'; got: {labels:?}"
-    );
-
-    // Completion response must not be incomplete (isIncomplete==false means the
-    // index is done; true means the server returned a partial fallback).
-    if result.is_object() {
-        let incomplete = result["isIncomplete"].as_bool().unwrap_or(false);
-        assert!(
-            !incomplete,
-            "completion must not be isIncomplete after indexing; got: {result}"
+    // `isIncomplete` stays true while the JAR phase is still resolving —
+    // that phase finishes shortly AFTER the workspace-scan `end` progress
+    // that wait_for_indexing observes (the JVM-sources gate waits for the
+    // scan before answering). A real client re-requests on isIncomplete, so
+    // do the same here: poll until the response settles to complete.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        // Line 2 (0-based), col 7 = after "    Pay" (4 spaces + 3 chars)
+        let resp = client.request(
+            "textDocument/completion",
+            json!({
+                "textDocument": {"uri": uri},
+                "position": pos(edit_text, 2, 7),
+            }),
         );
+        let result = &resp["result"];
+        let items = if result.is_array() {
+            result.as_array().unwrap().clone()
+        } else {
+            result["items"].as_array().cloned().unwrap_or_default()
+        };
+
+        let labels: Vec<&str> = items.iter().filter_map(|v| v["label"].as_str()).collect();
+
+        assert!(
+            labels.contains(&"PaymentService"),
+            "PaymentService from library must appear for prefix 'Pay'; got: {labels:?}"
+        );
+
+        // isIncomplete==false means the index (workspace scan AND jar phase)
+        // is done; true means the server wants the client to re-request.
+        let incomplete = result.is_object() && result["isIncomplete"].as_bool().unwrap_or(false);
+        if !incomplete {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "completion never settled to isIncomplete=false; got: {result}"
+        );
+        std::thread::sleep(Duration::from_millis(200));
     }
 }
 


### PR DESCRIPTION
## Problem

`spawn_jar_indexing` fires right after the workspace scan is **enqueued**, but the pipeline gate `workspace_has_jvm_sources` reads the **index**. Evaluating it immediately saw an empty index and skipped the entire Gradle-cache pipeline on a Kotlin repo — observed live (`jar: no Kotlin/Java sources in the workspace — skipping the Gradle-cache JAR pipeline` in the server log of a session against a Compose project).

With Tier-1 manifests never populated, `importable_fqns` never learns any jar FQNs, so jar classes silently lose auto-import, signature detail, and documentation for the whole session: typing `Modifier` offered the bare name with no import edit and no javadoc (user report). Whether a session was healthy or degraded depended purely on whether the first workspace file happened to be indexed before the jar task's gate check — a per-startup coin flip.

## Fix

New `wait_for_jvm_sources_gate` polls instead of answering once:

- opens the moment the scan indexes the **first** JVM source — on JVM repos that's within the scan's first files, preserving the old scan/jar concurrency;
- returns a negative verdict only after the scan queue **drains**, re-checking the index after observing the drain so a source indexed between the two probes isn't missed;
- aborts on a mid-wait generation change (root switch), matching the task's other stale-generation checkpoints.

Every `spawn_jar_indexing` caller enqueues its scan before spawning (`enqueue_scan` marks the queue in-progress synchronously), so the queue is already non-idle when the wait starts — no start-side race. `scan_queue` becomes `Arc`-shared so the blocking jar task can poll it.

## Verification

- 4 new gate tests (RED-first), incl. the exact regression shape: empty index at task start, scan indexes a `.kt` mid-wait → gate must open.
- 1515 unit tests, both clippy profiles green.
- Live-verified with a scripted LSP session against the real project: `val x = Modif` now offers `Modifier` with `import androidx.compose.ui.Modifier` + package detail; completing the word materializes it (detail `interface Modifier`) and `completionItem/resolve` returns the real KDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)