### PR TITLE
refactor(infer): chain-walk collapse + repair-seam hoist (CST slice 4)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-cst-chain-collapse.md
+++ b/docs/superpowers/plans/2026-07-17-cst-chain-collapse.md
@@ -1,0 +1,503 @@
+# CST Chain Collapse + Repair-Seam Hoist Implementation Plan (Slice 4)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the last text-splitting chain resolver in `chain.rs` (with a strictness gate so the node walk doesn't get *looser*), and hoist the brace-repair seam into `speculative.rs`, wiring the three unprotected lambda-family consumers.
+
+**Architecture:** The `KIND_NAV_EXPR` arm of `resolve_root_node_type` redirects to the existing node-native segment walk, gated by a new typed `SuffixStrictness` (nav position = `Fail` on unresolved suffixes, receiver positions keep today's `LeakReceiver`). `LambdaResolutionDoc` moves to `speculative.rs` as the transform-agnostic `ResolutionDoc` with seam `lambda_doc_at`; the scope walk, `lambda_params_at_col`, and the named-param resolver get mid-typing resilience. Spec: `docs/superpowers/specs/2026-07-17-cst-chain-collapse-design.md`.
+
+**Tech Stack:** Rust, tree-sitter, existing `InferDeps`/`TestDeps` seam.
+
+## Global Constraints
+
+- Branch `refactor/cst-chain-collapse` → PR to `refactor/unified-resolution`. Suite + pre-commit clippy per commit; final: both clippy profiles, e2e smoke, live probe.
+- Decoy discipline: concrete-type assertions with `assert_ne!` against bare generic params; `None`-asserting decoys for the two strictness cases (they bite on index gaps the suite doesn't otherwise model).
+- Never resurrect text scanning; if the node walk lacks a capability a test needs, extend the walk.
+- Repair stays bounded (`MAX_BRACE_REPAIRS`) and self-verifying; the hoist is behavior-neutral for the two existing consumers.
+- The resolver-side `*_in_lines` family (`resolver/infer_lines.rs`) is EXCLUDED from renames — its lines are load-bearing.
+- Cheap-agent dispatch for mechanical batches (user directive); controller reviews diffs and runs gates.
+
+---
+
+### Task 1: `SuffixStrictness` gate in the forward walk
+
+**Files:**
+- Modify: `src/indexer/infer/chain.rs` (`forward_resolve_segments` ~97-207, `resolve_segments_type` ~524-542, caller sites :229 and :424)
+- Test: `src/indexer/infer/mod_tests.rs` (has `super::`-level access to `chain`)
+
+**Interfaces:**
+- Produces:
+```rust
+/// How an unresolvable navigation suffix is handled during a forward walk.
+#[derive(Clone, Copy, PartialEq)]
+pub(super) enum SuffixStrictness {
+    /// Receiver-position semantics: an unresolved suffix leaves the receiver
+    /// type in place (best-effort; the caller probes members next).
+    LeakReceiver,
+    /// Expression-position semantics: an unresolved suffix fails the walk —
+    /// the expression's own type is unknown (matches the deleted text
+    /// walker's per-segment `?`).
+    Fail,
+}
+pub(super) fn forward_resolve_segments(segments, bytes, deps, uri, strictness: SuffixStrictness) -> Option<(String, String)>
+pub(super) fn resolve_segments_type(segments, bytes, deps, uri, strictness: SuffixStrictness) -> Option<String>
+```
+- Consumes: existing `NavSegment`, `resolve_member_type_on`, `SCOPE_FUNCTIONS`.
+
+- [ ] **Step 1: Write the failing decoy** (in `mod_tests.rs`; check its existing helpers for `TestDeps` + `parse_live` usage and mirror them)
+
+```rust
+/// Strictness decoy: an unresolved FINAL member must fail the walk under
+/// `Fail` (the old text walker's per-segment `?`), while `LeakReceiver`
+/// keeps today's receiver-position best-effort.
+#[test]
+fn unresolved_final_suffix_fails_the_strict_walk() {
+    use super::chain::{collect_nav_segments, resolve_segments_type, SuffixStrictness};
+    use crate::indexer::live_tree::parse_live;
+
+    let deps = super::deps::TestDeps::new().with_var("wrapper", "Wrapper");
+    // NOTE: no field `unknownField` on Wrapper.
+    let doc = parse_live("fun f() { wrapper.unknownField }", tree_sitter_kotlin::language()).unwrap();
+    let uri = tower_lsp::lsp_types::Url::parse("file:///t/T.kt").unwrap();
+    let nav = find_first_node_of_kind(doc.tree.root_node(), "navigation_expression");
+    let segments = collect_nav_segments(nav, &doc.bytes);
+
+    assert_eq!(
+        resolve_segments_type(&segments, &doc.bytes, &deps, &uri, SuffixStrictness::Fail),
+        None,
+        "unknown member must not leak the receiver's type"
+    );
+    assert_eq!(
+        resolve_segments_type(&segments, &doc.bytes, &deps, &uri, SuffixStrictness::LeakReceiver)
+            .as_deref(),
+        Some("Wrapper"),
+        "receiver-position semantics unchanged"
+    );
+}
+```
+
+Add a local `find_first_node_of_kind(root, kind) -> Node` helper (recursive walk) if `mod_tests.rs` doesn't have one; check `TestDeps` for the exact `with_var` builder name (grep `fn with_var` in `deps.rs` — if the builder is named differently, use the real one).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --bin kmp-lsp unresolved_final_suffix 2>&1 | tail -5`
+Expected: compile error — `SuffixStrictness` not defined / wrong arity.
+
+- [ ] **Step 3: Implement**
+
+In `forward_resolve_segments`: add the `strictness` parameter; in the `NavSegment::Suffix` branch replace
+
+```rust
+                last_suffix_resolved = false;
+                if let Some(ref cur) = current_type {
+                    if let Some(resolved) = resolve_member_type_on(cur, name, deps, uri) {
+                        current_type = Some(resolved);
+                        last_suffix_resolved = true;
+                    } else if SCOPE_FUNCTIONS.contains(&name.as_str()) {
+                        // Scope function: receiver type flows through.
+                    }
+                }
+```
+
+with
+
+```rust
+                last_suffix_resolved = false;
+                if let Some(ref cur) = current_type {
+                    if let Some(resolved) = resolve_member_type_on(cur, name, deps, uri) {
+                        current_type = Some(resolved);
+                        last_suffix_resolved = true;
+                    } else if SCOPE_FUNCTIONS.contains(&name.as_str()) {
+                        // Scope function: receiver type flows through.
+                    } else if strictness == SuffixStrictness::Fail {
+                        return None;
+                    }
+                } else if strictness == SuffixStrictness::Fail {
+                    return None;
+                }
+```
+
+(The second arm also fails the walk when there is no receiver type at all — an unresolved root followed by a suffix that then failed to resolve is covered by the first arm; a root that resolved to nothing ends the strict walk immediately.)
+
+`resolve_segments_type` gains and forwards the parameter. Update the two existing callers with `SuffixStrictness::LeakReceiver`:
+- chain.rs:229 (`cst_forward_resolve_receiver_type` — receiver position),
+- chain.rs:424 (`resolve_call_expr_type`'s `segments[..len-1]` receiver typing).
+
+- [ ] **Step 4: Run** `cargo test --bin kmp-lsp 2>&1 | grep -E "^test result"` — full suite green (existing behavior pinned by LeakReceiver at both call sites).
+
+- [ ] **Step 5: Commit** `git add -A src/ && git commit -m "feat(infer): typed SuffixStrictness gate on the forward chain walk"`
+
+---
+
+### Task 2: Nav-arm redirect; delete the text walker
+
+**Files:**
+- Modify: `src/indexer/infer/chain.rs` (`resolve_root_node_type` nav arm ~393-396; delete `resolve_dotted_text_type` ~558-580 and `uppercase_dotted_type_prefix` ~547-556; fix the stale comment at ~278 "matching the text path's `extract_collection_element_type`" — drop the text-path reference, keep the type-keyed rationale)
+- Test: `src/indexer/infer/mod_tests.rs`, `src/indexer/infer/it_this_tests.rs`
+
+**Interfaces:**
+- Consumes: Task 1's `resolve_segments_type(..., SuffixStrictness)`.
+- Produces: nothing new — deletions plus the redirect.
+
+- [ ] **Step 1: Write the failing decoys**
+
+In `mod_tests.rs` (strict nav-position semantics through the real arm):
+
+```rust
+/// Unknown ROOT decoy: `resolve_root_node_type` falls back to `Some(name)`
+/// for an unresolvable root ident; combined with a leaking walk this used to
+/// be able to resolve a nav to the literal root string. The strict nav arm
+/// must yield None instead.
+#[test]
+fn unknown_root_nav_expression_resolves_to_none() {
+    use super::chain::resolve_root_node_type;
+    use crate::indexer::live_tree::parse_live;
+
+    let deps = super::deps::TestDeps::new(); // nothing indexed at all
+    let doc = parse_live("fun f() { foo.bar }", tree_sitter_kotlin::language()).unwrap();
+    let uri = tower_lsp::lsp_types::Url::parse("file:///t/T.kt").unwrap();
+    let nav = find_first_node_of_kind(doc.tree.root_node(), "navigation_expression");
+
+    assert_eq!(resolve_root_node_type(nav, &doc.bytes, &deps, &uri), None);
+}
+```
+
+In `it_this_tests.rs` (generic-survival decoy, end-to-end through `it` typing — mirror the file's existing fixture style with a real `Indexer`):
+
+```rust
+/// Generics-survival decoy for the nav-arm redirect: a chain ROOTED at a
+/// navigation expression whose type is generic must keep its type args —
+/// the deleted text walker stripped them at exit, collapsing List<Product>
+/// to List and killing element extraction.
+#[test]
+fn nav_rooted_generic_chain_keeps_element_type_for_it() {
+    let (uri, idx) = indexed(
+        "/W.kt",
+        "package p\n\
+         class Product { val price: Int = 0 }\n\
+         class Wrapper { val items: List<Product> = listOf() }\n\
+         fun f(wrapper: Wrapper) {\n\
+             wrapper.items.map { it }\n\
+         }\n",
+    );
+    let pos = crate::types::CursorPos { line: 4, utf16_col: 25 }; // inside the lambda
+    let resolved = find_it_element_type_in_lines(&lines_of(&idx, &uri), pos, &idx, &uri);
+    assert_eq!(resolved.as_deref(), Some("Product"));
+    assert_ne!(resolved.as_deref(), Some("T"), "bare type param must never leak");
+}
+```
+
+(Adapt helper names — `indexed`, `lines_of` — to what `it_this_tests.rs` actually provides; the existing tests at the top of the file show the pattern. If this scenario already passes before the redirect via a different path, KEEP the test as a pin and note it in the commit message.)
+
+- [ ] **Step 2: Run to verify** — `cargo test --bin kmp-lsp unknown_root_nav 2>&1 | tail -3` — expected FAIL (arm still routes to the text walker, which for an unindexed `foo` root returns None already — if it passes pre-change, verify it STILL passes post-change; the generic decoy is the one expected to flip).
+
+- [ ] **Step 3: Implement the redirect**
+
+```rust
+        k if k == KIND_NAV_EXPR => {
+            let segments = collect_nav_segments(node, bytes);
+            resolve_segments_type(&segments, bytes, deps, uri, SuffixStrictness::Fail)
+        }
+```
+
+Delete `resolve_dotted_text_type` and `uppercase_dotted_type_prefix`; remove their imports/uses (`cargo build` finds stragglers). Fix the chain.rs:278 comment.
+
+- [ ] **Step 4: Run the full suite** — `cargo test --bin kmp-lsp 2>&1 | grep -E "^test result|FAILED"`. Any failure here is a real capability the walk lacks — extend the walk (e.g. root resolution), never resurrect text. Timebox: if a gap needs design, stop and flag.
+
+- [ ] **Step 5: Commit** `git add -A src/ && git commit -m "refactor(infer): nav arm resolves via the segment walk — text chain walker deleted"`
+
+---
+
+### Task 3: Hoist the repair seam into `speculative.rs`
+
+**Files:**
+- Modify: `src/indexer/infer/speculative.rs` (receives `ResolutionDoc`, `LambdaTreeGate`, `lambda_tree_gate`, `repaired_doc_at`, `lambda_doc_at`; extend the module doc to cover both transforms)
+- Modify: `src/indexer/infer/it_this.rs` (delete the moved items; `find_it_element_type_in_lines` + `find_this_context_in_lines` call `speculative::lambda_doc_at`; `MAX_BRACE_REPAIRS` moves with `repaired_doc_at`)
+- Test: existing repair tests in `it_this_tests.rs` are the neutrality net — no new tests in this task.
+
+**Interfaces:**
+- Produces (later tasks consume these exact names):
+```rust
+// speculative.rs
+pub(crate) enum ResolutionDoc {
+    /// The tree from `Indexer::live_doc_or_parse` — authoritative.
+    Parsed(std::sync::Arc<LiveDoc>),
+    /// An append-only brace-repaired transient reparse (never cached).
+    Repaired(LiveDoc),
+}
+impl ResolutionDoc { pub(crate) fn doc(&self) -> &LiveDoc }
+pub(crate) fn lambda_doc_at(idx: &Indexer, uri: &Url, pos: CursorPos) -> Option<ResolutionDoc>
+```
+
+- [ ] **Step 1: Move the code.** Cut `LambdaResolutionDoc` (renaming to `ResolutionDoc`), `LambdaTreeGate`, `lambda_tree_gate`, `repaired_doc_at`, `lambda_resolution_doc_at` (renaming to `lambda_doc_at`), and `MAX_BRACE_REPAIRS` from `it_this.rs` into `speculative.rs`. Visibility: `pub(crate)` for `ResolutionDoc`/`doc()`/`lambda_doc_at`; the gate + repair stay private to the module. `lambda_doc_at` needs `&Indexer` — `speculative.rs` may not import `Indexer` yet; add `use crate::indexer::Indexer;` (it's within the same crate module tree — `cursor_node_at` and `lang_for_path`/`parse_live` imports come along with the moved code). Update `it_this.rs` call sites (`:181`, `:201`) to `use super::speculative::{lambda_doc_at, ResolutionDoc};` — the match arms rename mechanically. Update speculative.rs's module doc: it now hosts BOTH healed-doc constructors (marker insertion for receiver derivation; brace repair for lambda resolution) — co-located, not merged.
+
+- [ ] **Step 2: Run the full suite** — `cargo test --bin kmp-lsp 2>&1 | grep -E "^test result"`. Every existing repair test must pass unchanged (the move is behavior-neutral).
+
+- [ ] **Step 3: Commit** `git add -A src/ && git commit -m "refactor(infer): hoist brace-repair seam into speculative.rs as ResolutionDoc"`
+
+---
+
+### Task 4: Wire the scope walk
+
+**Files:**
+- Modify: `src/features/completion_context.rs` (`collect_lambda_scopes` ~270-282)
+- Test: `src/features/completion_context_tests.rs`
+
+**Interfaces:**
+- Consumes: `speculative::lambda_doc_at` (re-export through `src/indexer.rs`'s existing `pub(crate) use self::infer::speculative::{...}` line — add `lambda_doc_at` and `ResolutionDoc` to it).
+
+- [ ] **Step 1: Write the failing test** (multi-line, unclosed `{` — the broken tree forms no `lambda_literal`, so today the scope stack comes back empty)
+
+```rust
+#[test]
+fn scope_walk_survives_an_unclosed_lambda() {
+    let src = "package com.example\n\
+               class Item { val price: Int = 0 }\n\
+               fun main(items: List<Item>) {\n\
+               \x20   items.forEach {\n\
+               \x20       \n"; // lambda AND function braces both unclosed
+    let (uri, index) = indexed_with_live("/Unclosed.kt", src);
+    let scope = ScopeContext::build(Position::new(4, 8), &index, &uri);
+    assert_eq!(
+        scope.resolve_receiver("it"),
+        Some("Item"),
+        "brace repair must recover the lambda scope stack mid-typing"
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — `cargo test --bin kmp-lsp scope_walk_survives 2>&1 | tail -5`. Expected: assertion failure (`None`). If it PASSES, the `it_type` merge in `ScopeContext::build` (via the already-repaired `infer_lambda_param_type_at` path) is masking the walk — strengthen the assertion to check `scope.lambda_scopes` is non-empty instead, and note which signal proved the gap.
+
+- [ ] **Step 3: Implement**
+
+```rust
+fn collect_lambda_scopes(index: &Indexer, uri: &Url, position: Position) -> Vec<LambdaScope> {
+    let cursor = CursorPos {
+        line: position.line as usize,
+        utf16_col: position.character as usize,
+    };
+    let Some(resolution) = lambda_doc_at(index, uri, cursor) else {
+        return Vec::new();
+    };
+    let doc = resolution.doc();
+    let Some(node) = cursor_node_at(doc, cursor) else {
+        return Vec::new();
+    };
+    CstQuery::new(node, doc, index, uri, ResolveIo::NoRg)
+        .lambda_scope()
+        .into_iter()
+        .map(LambdaScope::from)
+        .collect()
+}
+```
+
+- [ ] **Step 4: Run** — target test passes; full suite green.
+
+- [ ] **Step 5: Commit** `git add -A src/ && git commit -m "feat(complete): scope walk resolves against the repaired tree mid-typing"`
+
+---
+
+### Task 5: `lambda_params_at_col` broken-tree gate
+
+**Files:**
+- Modify: `src/indexer/scope.rs` (`cst_lambda_params_at_col` ~299-317)
+- Test: `src/indexer/scope_tests.rs`
+
+**Interfaces:** self-contained (restores the existing text-scan fallback in broken states).
+
+- [ ] **Step 1: Write the failing test** (multi-line — the single-line case is masked by `is_lambda_param`'s same-line text check)
+
+```rust
+#[test]
+fn lambda_params_fall_back_to_the_text_scan_on_a_broken_tree() {
+    // Unclosed lambda: the CST forms no lambda_literal, so the CST path
+    // used to answer Some(vec![]) and short-circuit the text fallback.
+    let src = "fun f(items: List<Item>) {\n    items.map { item ->\n        \n";
+    let (uri, indexer) = indexed_with_live(src); // adapt to the file's fixture helper
+    let params = indexer.lambda_params_at_col(&uri, 2, 8);
+    assert!(
+        params.iter().any(|p| p == "item"),
+        "broken tree must fall through to the text scan; got {params:?}"
+    );
+}
+```
+
+(Check `scope_tests.rs`'s fixture helpers for how live docs are stored — the test needs `store_live_tree` so `live_doc` finds a tree.)
+
+- [ ] **Step 2: Run to verify failure** — expected: empty `params`.
+
+- [ ] **Step 3: Implement** — in `cst_lambda_params_at_col`, after `let params = collect_cst_lambda_params(node, &doc.bytes);` (inline the current tail expression into a binding):
+
+```rust
+        let params = collect_cst_lambda_params(node, &doc.bytes);
+        if params.is_empty() && doc.tree.root_node().has_error() {
+            // A broken tree may simply have failed to FORM the enclosing
+            // lambda_literal (unclosed `{`); empty here does not mean "no
+            // params" — let the caller fall through to the text scan.
+            return None;
+        }
+        Some(params)
+```
+
+- [ ] **Step 4: Run** — target + full suite.
+
+- [ ] **Step 5: Commit** `git add -A src/ && git commit -m "fix(scope): broken-tree lambda-param CST miss falls through to the text scan"`
+
+---
+
+### Task 6: Wire the named-param resolver + end-to-end pipeline test
+
+**Files:**
+- Modify: `src/indexer/infer/it_this.rs` (`find_named_lambda_param_type` ~231-240)
+- Test: `src/indexer/infer/it_this_tests.rs` (unit) + `src/resolver/tests.rs` (pipeline)
+
+**Interfaces:**
+- Consumes: `speculative::lambda_doc_at` (Task 3).
+
+- [ ] **Step 1: Write the failing unit test** (multi-line, unclosed)
+
+```rust
+#[test]
+fn named_param_type_resolves_in_an_unclosed_lambda() {
+    let (u, idx) = indexed(
+        "/N.kt",
+        "class Item { val price: Int = 0 }\nfun f(items: List<Item>) {\n    items.map { item ->\n        \n",
+    );
+    // store the live tree so live_doc_or_parse sees the broken state
+    // (adapt to the fixture; index_content + store_live_tree)
+    let pos = crate::types::CursorPos { line: 3, utf16_col: 8 };
+    assert_eq!(
+        find_named_lambda_param_type("item", pos, &idx, &u).as_deref(),
+        Some("Item"),
+        "brace repair must recover the named param's type mid-typing"
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement**
+
+```rust
+pub(crate) fn find_named_lambda_param_type(
+    param_name: &str,
+    pos: CursorPos,
+    idx: &Indexer,
+    uri: &Url,
+) -> Option<String> {
+    let resolution = super::speculative::lambda_doc_at(idx, uri, pos)?;
+    cst_named_lambda_param_type(pos, param_name, resolution.doc(), idx, uri)
+}
+```
+
+(Update the doc comment: repair-protected like the `it`/`this` resolvers.)
+
+- [ ] **Step 4: Write the end-to-end pipeline test** (in `resolver/tests.rs`, exercising Tasks 4+5+6 together through `run_completions`)
+
+```rust
+/// Mid-typing named-param completion: multi-line lambda with BOTH braces
+/// unclosed. Exercises the whole repaired path: lambda_params_at_col
+/// fall-through (broken-tree gate) → is_lambda_param → complete_lambda_dot →
+/// find_named_lambda_param_type (repair-wired).
+#[test]
+fn named_param_completion_survives_unclosed_lambda() {
+    let idx = Indexer::new();
+    let app_uri = Url::parse("file:///app/U.kt").unwrap();
+    let src = "package app\n\
+               class Item { val price: Int = 0 }\n\
+               fun f(items: List<Item>) {\n\
+               \x20   items.map { item ->\n\
+               \x20       item.\n";
+    idx.index_content(&app_uri, src);
+    idx.store_live_tree(&app_uri, src);
+    let (items, _) = crate::features::completion::run_completions(
+        &idx,
+        &app_uri,
+        tower_lsp::lsp_types::Position::new(4, 13),
+        false,
+    );
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.iter().any(|l| l.starts_with("price")),
+        "named-param completion in the broken state — got: {labels:?}"
+    );
+}
+```
+
+- [ ] **Step 5: Run** — both tests + full suite green.
+
+- [ ] **Step 6: Commit** `git add -A src/ && git commit -m "feat(infer): named-param resolution repair-wired; end-to-end mid-typing completion test"`
+
+---
+
+### Task 7: Rename carry-in — drop the vestigial `_lines` params (cheap-agent dispatch)
+
+**Files:**
+- Modify: `src/indexer/infer/it_this.rs` (3 public fns + doc comments), ~26 production call sites, test files incl. the two shims
+- Test: full suite (mechanical change).
+
+**Interfaces:** renames only:
+- `find_it_element_type_in_lines(lines, pos, idx, uri)` → `find_it_element_type(pos, idx, uri)`
+- `find_this_context_in_lines(pos, idx, uri)` → `find_this_context(pos, idx, uri)` (check whether it still has a `_lines` param — drop only what exists)
+- `find_this_element_type_in_lines(...)` → `find_this_element_type(...)`
+
+Dispatch to a subagent with these EXACT pre-handling instructions:
+1. FIRST rename the two test shims `fn find_it_element_type` (`src/indexer/infer/it_this_tests.rs:27`, `src/indexer/scope_tests.rs:25`) to `fn it_type_at_line_end` (update their local callers) — otherwise the production rename shadows them.
+2. Then rename the three production fns, dropping their `_lines`/`lines` parameters (verify each param really is unused in the body — if any is read, STOP and report instead of renaming that fn).
+3. Update every call site (`grep -rn "_in_lines" src/ --include='*.rs'` — EXCLUDE `resolver/infer_lines.rs` and any `resolver/`-side function; those lines are load-bearing).
+4. Update the re-export list in `src/indexer.rs` (the `it_this::{...}` use block).
+5. Delete the now-false "`_lines` is vestigial" doc notes on the renamed fns.
+6. `cargo test --bin kmp-lsp` must be green; do not commit.
+
+- [ ] **Step 1: Dispatch the agent** with the instructions above.
+- [ ] **Step 2: Review the diff** (`git diff --stat` + spot-check the shims and one call site per file).
+- [ ] **Step 3: Run** the full suite + `cargo clippy --all-targets -- -D warnings`.
+- [ ] **Step 4: Commit** `git add -A src/ && git commit -m "refactor(infer): drop vestigial _lines params from the it/this resolver family"`
+
+---
+
+### Task 8: Nested-generic-`it` completion test (ledger minor)
+
+**Files:**
+- Test: `src/indexer/infer/it_this_tests.rs`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+/// Ledger minor (2026-07-04 wave): `it` over a nested-generic element.
+/// `List<Optional<Foo>>` → `it` is `Optional<Foo>`; `it.getOrNull()?.`
+/// member access must reach Foo's members, not leak `T`.
+#[test]
+fn nested_generic_it_resolves_to_the_concrete_inner_type() {
+    let (u, idx) = indexed(
+        "/G.kt",
+        "class Foo { val bar: Int = 0 }\n\
+         class Optional<T> { fun getOrNull(): T? = null }\n\
+         fun f(items: List<Optional<Foo>>) {\n\
+             items.map { it }\n\
+         }\n",
+    );
+    let pos = crate::types::CursorPos { line: 3, utf16_col: 17 };
+    let resolved = find_it_element_type(pos, &idx, &u); // post-Task-7 name
+    assert_eq!(resolved.as_deref(), Some("Optional<Foo>"));
+    assert_ne!(resolved.as_deref(), Some("T"));
+}
+```
+
+- [ ] **Step 2: Run it.** If it FAILS: do NOT fix inference in this slice — mark `#[ignore = "known gap: nested-generic it (ledger 2026-07-17)"]`, record in the ledger, and flag in the PR. If it passes, it's a free pin.
+- [ ] **Step 3: Commit** `git add -A src/ && git commit -m "test(infer): pin (or flag) nested-generic it element typing"`
+
+---
+
+### Task 9: Gates, live probe, PR
+
+- [ ] **Step 1:** `cargo test 2>&1 | tail -3 && cargo clippy --all-targets -- -D warnings 2>&1 | tail -2 && cargo clippy --release --all-targets -- -D warnings 2>&1 | tail -2 && cargo test --test lsp_smoke 2>&1 | tail -3`
+- [ ] **Step 2:** `cargo build`, then run the live probe (`scratchpad/lsp_probe_cst.py`, BIN at the worktree `target/debug/kmp-lsp`) — scenarios A/B/C must stay green (C exercises the broken-state pipeline this slice touches).
+- [ ] **Step 3:** Push (`--no-verify` only for the known false-positive hook patterns; fix any GENUINE new violations first), open PR → `refactor/unified-resolution`. PR body: deletions (2 fns), the strictness gate + its two decoys, the three repair wires with the multi-line RED tests, rename summary, nested-generic-it disposition, probe results.
+- [ ] **Step 4:** Ledger entry + memory update (`cst-resolution-unification`: slice 4 done; remaining = 5-remainder, 6).
+
+## Self-review notes
+
+- Spec coverage: §A = Tasks 1-2 (incl. deltas 4-5 as the gate + decoys); §B = Tasks 3-6 (three wires; move-neutrality in Task 3); §C = Tasks 7-8 + comment fixes folded into Tasks 2/3/7; EOF-remap carry-in dispositioned in the spec (no task, per spec). Testing section = decoys in 1-2, RED tests in 4-6, probe in 9.
+- Type consistency: `SuffixStrictness` (Tasks 1-2), `ResolutionDoc`/`lambda_doc_at` (Tasks 3-6), post-rename `find_it_element_type` used by Task 8 (runs after Task 7).
+- Known judgment points: Task 2 Step 4 gap-handling (extend walk vs stop-and-flag); Task 4 Step 2's masking check; fixture-helper names in test files must be adapted to what each file provides.

--- a/docs/superpowers/specs/2026-07-17-cst-chain-collapse-design.md
+++ b/docs/superpowers/specs/2026-07-17-cst-chain-collapse-design.md
@@ -1,0 +1,127 @@
+# CST Chain Collapse + Repair-Seam Hoist — Design (Slice 4)
+
+Status: **approved design** (brainstormed with the user 2026-07-17; decisions: repair hoist =
+lambda family only; nav arm redirects to the existing segment walk).
+Slice 4 of [CST resolution unification](2026-06-30-cst-resolution-unification-design.md);
+refines the sketch in `docs/superpowers/plans/2026-07-05-post-fable-roadmap-refinements.md` §4.
+Branch: `refactor/cst-chain-collapse` off `refactor/unified-resolution` (post-#222).
+
+## Context (why)
+
+Two collapse targets remain in `indexer/infer/chain.rs` and its surroundings after the
+receiver-derivation slice (#222):
+
+1. **A third chain resolver.** `resolve_root_node_type`'s `KIND_NAV_EXPR` arm holds a real CST
+   node but flattens it to text and calls `resolve_dotted_text_type` — a `split('.')` walker,
+   the same shaky-code class #222 deleted from `resolver/complete.rs`. chain.rs already owns the
+   node-native walk (`collect_nav_segments` + `forward_resolve_segments`, wrapped by
+   `resolve_segments_type`).
+2. **The brace-repair mechanism is private to `it`/`this` resolution.** `lambda_resolution_doc_at`
+   (append-only `}` repair, self-verifying, bounded) protects `find_it_element_type_in_lines` and
+   `find_this_context_in_lines` — but the scope walk (`collect_lambda_scopes`,
+   `features/completion_context.rs`) and the named-param path (`it_this.rs`) still resolve against
+   the broken tree in mid-typing states, exactly the states #222 made receiver derivation
+   resilient to.
+
+Plus small debts the wave follow-ups tracked: vestigial `_lines: &[String]` params on the
+`*_in_lines` family (~10 production sites, ~40 with tests), the stale "text path's" comment at
+chain.rs:278, and the nested-generic-`it` completion test.
+
+## Goals / non-goals
+
+**Goals**
+
+1. Delete `resolve_dotted_text_type` and (its now-dead helper) `uppercase_dotted_type_prefix`;
+   the nav arm resolves through the node-native segment walk.
+2. Hoist the brace-repair seam into `indexer/infer/speculative.rs` and wire the two unprotected
+   lambda-family consumers (scope walk, named-param path).
+3. Carry-ins: drop `_lines` vestigial params (renaming the `*_in_lines` fns), fix stale comments,
+   add the nested-generic-`it` completion test.
+4. Existing suites pass; intended behavior deltas are decoy-gated and listed in the PR.
+
+**Non-goals**
+
+- Unifying chain.rs's segment walk with expr_type.rs's recursive nav resolver — a possible later
+  consolidation, out of scope here (roadmap: slice 4 = chain.rs internals).
+- Paren repair / cst_cursor call-info resilience — a NEW transform, not the house mechanism;
+  separate slice if ever needed.
+- The string engine (`resolver/`) — heuristic by design, untouched. If a chain.rs function's only
+  callers turn out to be resolver-side, it MOVES there rather than being deleted.
+
+## Design
+
+### A. Node-native nav resolution
+
+```rust
+k if k == KIND_NAV_EXPR => {
+    let segments = collect_nav_segments(node, bytes);
+    resolve_segments_type(&segments, bytes, deps, uri)
+}
+```
+
+Deleted: `resolve_dotted_text_type` (~24 lines), `uppercase_dotted_type_prefix` (~10 lines; its
+only production caller is the deleted fn). No recursion hazard: `collect_nav_segments` flattens
+nested nav trees, so roots handed back to `resolve_root_node_type` are never nav nodes.
+
+**Deliberate behavior deltas (each decoy-gated):**
+
+1. **Generics survive.** The old exit normalization (`dotted_ident_prefix`) stripped `<...>`, so
+   a nav root like `wrapper.items` with `items: List<Product>` resolved to bare `List`, killing
+   downstream element-type extraction. The forward walk returns the raw type. Decoy: a chain
+   rooted at a nav expression with a generic type must produce the CONCRETE element type, with
+   `assert_ne!` against the bare parameter name (house pattern).
+2. **Methods resolve mid-chain.** The text walker resolved fields only; `resolve_member_type_on`
+   probes fields then methods. Strictly more capable.
+3. **The whole-dotted-text-as-variable first-try disappears** (`find_var_type("a.b")`). The suite
+   arbitrates; if anything relied on it, the fix is a real segment-walk capability, never a text
+   resurrect.
+
+### B. Repair-seam hoist (lambda family only)
+
+Move from `it_this.rs` into `indexer/infer/speculative.rs`: `LambdaResolutionDoc`
+(`Parsed(Arc<LiveDoc>)` / `Repaired(LiveDoc)`), `LambdaTreeGate` + `lambda_tree_gate`,
+`repaired_doc_at`, `lambda_resolution_doc_at` (public seam name:
+`speculative::lambda_doc_at(idx, uri, pos) -> Option<LambdaResolutionDoc>`).
+
+`speculative.rs` becomes the home of both transient-healed-doc constructors — marker insertion
+(receiver derivation) and brace repair (lambda resolution). **Co-located, not merged**: different
+transforms answering different questions, sharing the module and parse helpers. The move is
+behavior-neutral for the two existing consumers (their repair tests keep passing unchanged).
+
+Newly wired consumers, each RED-first (failing test with an unclosed `{` above the cursor first):
+
+- **Scope walk** — `collect_lambda_scopes` (`features/completion_context.rs`): bare-word
+  completion inside a just-opened, unclosed lambda must still see the lambda scope stack.
+- **Named-param path** — the `it_this.rs` consumer at the raw `live_doc_or_parse` site:
+  `items.map { item -> item. }` with the brace unclosed must still type `item`.
+
+Out of scope: `cst_cursor.rs` call-info sites (their broken state is an unclosed `(`).
+
+### C. Carry-ins (mechanical, separate commits)
+
+- Rename `find_it_element_type_in_lines` → `find_it_element_type`,
+  `find_this_context_in_lines` → `find_this_context`,
+  `find_this_element_type_in_lines` → `find_this_element_type` (and any sibling `*_in_lines`
+  whose `_lines` param is vestigial); drop the `_lines` params; update ~40 call sites.
+  Mechanical — dispatched to a subagent with exact instructions.
+- Fix stale comments: chain.rs:278 ("matching the text path's …"), the `_lines is vestigial`
+  doc note (made true by the rename), and any comment referencing the deleted fns.
+- Nested-generic-`it` completion test (ledger minor): e.g. `it` inside a lambda over
+  `List<Optional<Foo>>` must complete `Foo`-typed members after `.getOrNull()?.`-style access.
+  If it exposes a real inference gap, STOP AND FLAG (fix belongs to its own change, not this
+  slice).
+
+## Error handling
+
+- Repair remains bounded (`MAX_BRACE_REPAIRS`) and self-verifying; unverified candidates are
+  discarded and the caller returns the authoritative `None` — unchanged semantics, now shared.
+- The nav arm returns `None` exactly where `resolve_segments_type` does; no new panic paths.
+
+## Testing
+
+- Decoys per behavior delta in A (concrete-type assertions; `assert_ne!` bare generic params —
+  the type_subst wrong-answer-factory trap from the roadmap).
+- RED-first repair tests per new consumer in B; existing repair tests pin the move's neutrality.
+- Full suite + clippy per commit; live probe (`lsp_probe_cst.py` — its scenario C exercises the
+  broken-state pipeline end-to-end) before the PR.
+- One PR: `refactor/cst-chain-collapse` → `refactor/unified-resolution`, commits per component.

--- a/docs/superpowers/specs/2026-07-17-cst-chain-collapse-design.md
+++ b/docs/superpowers/specs/2026-07-17-cst-chain-collapse-design.md
@@ -72,30 +72,64 @@ nested nav trees, so roots handed back to `resolve_root_node_type` are never nav
    `assert_ne!` against the bare parameter name (house pattern).
 2. **Methods resolve mid-chain.** The text walker resolved fields only; `resolve_member_type_on`
    probes fields then methods. Strictly more capable.
-3. **The whole-dotted-text-as-variable first-try disappears** (`find_var_type("a.b")`). The suite
-   arbitrates; if anything relied on it, the fix is a real segment-walk capability, never a text
-   resurrect.
+3. **The whole-dotted-text-as-variable first-try disappears** (`find_var_type("a.b")`).
+   Verified effectively dead (a dotted string can't match a declaration-shaped lookup; no test
+   pins it) — free insurance: the suite arbitrates; never a text resurrect.
+
+**Strictness gates the redirect must add (independent critique findings — the bare walk is
+LOOSER than the text walker in two ways, and both are wrong-answer paths, not capabilities):**
+
+4. **Unresolved-final-member leak.** `forward_resolve_segments` returns the RECEIVER's type when
+   the final suffix doesn't resolve (`last_suffix_resolved` stays false but the pair is returned
+   anyway) — the old text walker returned `None` there. Ungated, `wrapper.unknownField.` would
+   resolve to `wrapper`'s own type. The nav arm must return `None` when the final segment did
+   not actually resolve. Decoy: unknown final member ⇒ `None`.
+5. **Unknown-root capitalization heuristic.** `resolve_root_node_type` falls through to
+   `Some(name)` for an unresolvable root ident, after which `resolve_member_type_on`
+   capitalizes it (`foo` → probing members on type `Foo`); combined with delta 4's leak this
+   could resolve a nav to the literal root string. The old walker required the root variable to
+   resolve. The gate from delta 4 contains the damage; add an unknown-root decoy asserting
+   `None` (these cases bite on index gaps, which the existing suite rarely models — the decoys
+   are the only net).
 
 ### B. Repair-seam hoist (lambda family only)
 
-Move from `it_this.rs` into `indexer/infer/speculative.rs`: `LambdaResolutionDoc`
-(`Parsed(Arc<LiveDoc>)` / `Repaired(LiveDoc)`), `LambdaTreeGate` + `lambda_tree_gate`,
-`repaired_doc_at`, `lambda_resolution_doc_at` (public seam name:
-`speculative::lambda_doc_at(idx, uri, pos) -> Option<LambdaResolutionDoc>`).
+Move from `it_this.rs` into `indexer/infer/speculative.rs`, renaming the enum to the
+transform-agnostic **`ResolutionDoc`** (`Parsed(Arc<LiveDoc>)` / `Repaired(LiveDoc)`) — the
+variants carry no lambda-specific meaning, and the roadmap's stated destination (CstQuery-level
+resilience, possible future paren transform) reuses exactly this shape; naming it neutrally at
+hoist time avoids a guaranteed rename later. The gate stays lambda-specific:
+`LambdaTreeGate` + `lambda_tree_gate`, `repaired_doc_at`, and the public seam
+`speculative::lambda_doc_at(idx, uri, pos) -> Option<ResolutionDoc>` (the lambda-family
+constructor). Extend `speculative.rs`'s module doc to cover both transforms.
 
 `speculative.rs` becomes the home of both transient-healed-doc constructors — marker insertion
-(receiver derivation) and brace repair (lambda resolution). **Co-located, not merged**: different
-transforms answering different questions, sharing the module and parse helpers. The move is
-behavior-neutral for the two existing consumers (their repair tests keep passing unchanged).
+(receiver derivation) and brace repair (lambda resolution). **Co-located, not merged**: a shared
+generic transform/verify loop was evaluated and rejected — the only genuinely shared code is the
+parse call, and a generic seam would cost more lines than it saves while complicating the
+marker path's incremental-reparse optimization. The move is behavior-neutral for the two
+existing consumers (their repair tests keep passing unchanged).
 
 Newly wired consumers, each RED-first (failing test with an unclosed `{` above the cursor first):
 
 - **Scope walk** — `collect_lambda_scopes` (`features/completion_context.rs`): bare-word
   completion inside a just-opened, unclosed lambda must still see the lambda scope stack.
+- **`lambda_params_at_col` CST short-circuit** (independent critique finding — without this the
+  named-param wire below is dead code): `cst_lambda_params_at_col` returns `Some(vec![])` on a
+  broken tree (no `lambda_literal` forms above the ERROR node), and that `Some` short-circuits
+  the text fallback — so `is_lambda_param`'s multi-line branch returns false and the completion
+  ladder never reaches the named-param resolver in exactly the mid-typing states this slice
+  targets. Fix: route the CST path through `lambda_doc_at` (or equivalently, treat
+  empty-params-on-a-broken-tree as "CST cannot answer" and fall through). RED test must be
+  MULTI-LINE (the single-line case is masked by the same-line text check).
 - **Named-param path** — the `it_this.rs` consumer at the raw `live_doc_or_parse` site:
-  `items.map { item -> item. }` with the brace unclosed must still type `item`.
+  multi-line `items.map { item ->\n item. }` with the brace unclosed must still type `item`.
 
 Out of scope: `cst_cursor.rs` call-info sites (their broken state is an unclosed `(`).
+Also verified during critique: `derive_dot_receiver` needs no repair of its own — no
+constructible unclosed-brace state defeats the marker ascent (pinned by the existing
+unclosed-delimiter characterization tests), and lambda-context TYPING behind it routes through
+the resolvers this slice protects.
 
 ### C. Carry-ins (mechanical, separate commits)
 
@@ -103,9 +137,16 @@ Out of scope: `cst_cursor.rs` call-info sites (their broken state is an unclosed
   `find_this_context_in_lines` → `find_this_context`,
   `find_this_element_type_in_lines` → `find_this_element_type` (and any sibling `*_in_lines`
   whose `_lines` param is vestigial); drop the `_lines` params; update ~40 call sites.
-  Mechanical — dispatched to a subagent with exact instructions.
+  Mechanical — dispatched to a subagent with exact instructions. TWO traps the instructions
+  must pre-handle (critique findings): (a) test shims named `find_it_element_type` already
+  exist in `it_this_tests.rs:27` and `scope_tests.rs:25` — rename or `super::`-qualify them
+  FIRST or the production rename shadows them; (b) the resolver-side `*_in_lines` family
+  (`resolver/infer_lines.rs`) is EXCLUDED — its lines are load-bearing.
 - Fix stale comments: chain.rs:278 ("matching the text path's …"), the `_lines is vestigial`
   doc note (made true by the rename), and any comment referencing the deleted fns.
+- Roadmap carry-in "EOF remap unbalanced-brace gate refinement": EOF-remap coverage exists
+  (`it_this_tests.rs` EOF tests); dispositioned as ALREADY COVERED — no work in this slice
+  unless the new multi-line repair tests contradict that.
 - Nested-generic-`it` completion test (ledger minor): e.g. `it` inside a lambda over
   `List<Optional<Foo>>` must complete `Foo`-typed members after `.getOrNull()?.`-style access.
   If it exposes a real inference gap, STOP AND FLAG (fix belongs to its own change, not this

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -15,7 +15,7 @@ use tower_lsp::lsp_types::{
 use crate::indexer::resolution::{enrich_at_line, IndexRead, ResolveOptions, SubstitutionContext};
 use crate::indexer::Indexer;
 use crate::indexer::{
-    find_it_element_type_in_lines, find_named_lambda_param_type, is_lambda_param, last_ident_in,
+    find_it_element_type, find_named_lambda_param_type, is_lambda_param, last_ident_in,
 };
 use crate::resolver::complete::{
     complete_symbol, complete_symbol_with_context, is_annotation_context, DotReceiver,
@@ -181,7 +181,6 @@ pub(crate) fn run_completions(
     }
 
     let annotation_only = is_annotation_context(before, prefix);
-    let lines = index.lines_for(uri).unwrap_or_default();
     // Only a `.` before the prefix can carry a dot-completion receiver — the
     // gate spares bare-word completions the speculative reparse inside
     // `derive_dot_receiver`.
@@ -198,11 +197,7 @@ pub(crate) fn run_completions(
                     index,
                     recv_str,
                     &ctx.scope,
-                    CompletionSite {
-                        position,
-                        uri,
-                        lines: lines.as_ref(),
-                    },
+                    CompletionSite { position, uri },
                     snippets,
                     prefix,
                 ),
@@ -280,7 +275,6 @@ fn store_in_cache(
 struct CompletionSite<'a> {
     position: Position,
     uri: &'a Url,
-    lines: &'a [String],
 }
 
 /// Run dot-completion for a lambda receiver (`it.`, `this.`, `this@label.`, or named param).
@@ -360,12 +354,11 @@ fn resolve_named_lambda_param_type(
 }
 
 /// Resolve the element type of `it` at the completion site via the CST-first
-/// lambda resolver (same path used for hover/inlay `it` typing). Reuses the
-/// lines already fetched for this completion request and the real cursor
-/// position, so multi-line lambdas resolve like they do on the hover path
-/// rather than via a same-line `rfind('{')` text scan.
+/// lambda resolver (same path used for hover/inlay `it` typing), using the
+/// real cursor position so multi-line lambdas resolve like they do on the
+/// hover path rather than via a same-line `rfind('{')` text scan.
 fn resolve_it_element_type(index: &Indexer, site: &CompletionSite<'_>) -> Option<String> {
-    find_it_element_type_in_lines(site.lines, CursorPos::from(site.position), index, site.uri)
+    find_it_element_type(CursorPos::from(site.position), index, site.uri)
 }
 
 /// Append members of the implicit receiver inside `with` / `apply` / `run` lambdas.

--- a/src/features/completion_context.rs
+++ b/src/features/completion_context.rs
@@ -3,9 +3,9 @@ use tower_lsp::lsp_types::{Position, Url};
 use crate::features::completion::param_names_from_sig;
 use crate::features::traits::{LiveTreeAccess, SignatureIndex};
 use crate::indexer::{
-    cursor_node_at, find_this_context_in_lines, receiver_node_for_marker, speculative_doc,
-    split_params_at_depth_zero, CstQuery, Indexer, LambdaScopeInfo, Resolution, ResolveIo,
-    ThisContext,
+    cursor_node_at, find_this_context_in_lines, lambda_doc_at, receiver_node_for_marker,
+    speculative_doc, split_params_at_depth_zero, CstQuery, Indexer, LambdaScopeInfo, Resolution,
+    ResolveIo, ThisContext,
 };
 use crate::queries::{KIND_CALL_EXPR, KIND_SIMPLE_IDENT, KIND_SUPER_EXPR, KIND_THIS_EXPR};
 use crate::resolver::complete::DotReceiver;
@@ -269,17 +269,20 @@ fn resolve_labeled_receiver<'a>(scope: &'a ScopeContext, expr: &str) -> Option<&
 /// The tree comes from `live_doc_or_parse`: the live tree for open files, a
 /// transient parse otherwise — completion works the same either way.
 fn collect_lambda_scopes(index: &Indexer, uri: &Url, position: Position) -> Vec<LambdaScope> {
-    let Some(doc) = index.live_doc_or_parse(uri) else {
-        return Vec::new();
-    };
     let cursor = CursorPos {
         line: position.line as usize,
         utf16_col: position.character as usize,
     };
-    let Some(node) = cursor_node_at(&doc, cursor) else {
+    // Repair-wired acquisition: a mid-typing unclosed `{` forms no
+    // lambda_literal on the raw tree — the walk would silently see no scopes.
+    let Some(resolution) = lambda_doc_at(index, uri, cursor) else {
         return Vec::new();
     };
-    CstQuery::new(node, &doc, index, uri, ResolveIo::NoRg)
+    let doc = resolution.doc();
+    let Some(node) = cursor_node_at(doc, cursor) else {
+        return Vec::new();
+    };
+    CstQuery::new(node, doc, index, uri, ResolveIo::NoRg)
         .lambda_scope()
         .into_iter()
         .map(LambdaScope::from)

--- a/src/features/completion_context.rs
+++ b/src/features/completion_context.rs
@@ -3,9 +3,9 @@ use tower_lsp::lsp_types::{Position, Url};
 use crate::features::completion::param_names_from_sig;
 use crate::features::traits::{LiveTreeAccess, SignatureIndex};
 use crate::indexer::{
-    cursor_node_at, find_this_context_in_lines, lambda_doc_at, receiver_node_for_marker,
-    speculative_doc, split_params_at_depth_zero, CstQuery, Indexer, LambdaScopeInfo, Resolution,
-    ResolveIo, ThisContext,
+    cursor_node_at, find_this_context, lambda_doc_at, receiver_node_for_marker, speculative_doc,
+    split_params_at_depth_zero, CstQuery, Indexer, LambdaScopeInfo, Resolution, ResolveIo,
+    ThisContext,
 };
 use crate::queries::{KIND_CALL_EXPR, KIND_SIMPLE_IDENT, KIND_SUPER_EXPR, KIND_THIS_EXPR};
 use crate::resolver::complete::DotReceiver;
@@ -241,7 +241,7 @@ impl ScopeContext {
 /// type is known. Does not fall back to the enclosing class — that would
 /// duplicate locals and wrongly offer class members in `forEach { }` blocks.
 fn resolve_lambda_this_type(position: Position, index: &Indexer, uri: &Url) -> Option<String> {
-    match find_this_context_in_lines(CursorPos::from(position), index, uri) {
+    match find_this_context(CursorPos::from(position), index, uri) {
         ThisContext::Resolved(resolved_type) => Some(resolved_type),
         ThisContext::InsideReceiver | ThisContext::NotFound => None,
     }

--- a/src/features/completion_context_tests.rs
+++ b/src/features/completion_context_tests.rs
@@ -240,3 +240,24 @@ fn no_receiver_for_bare_word_or_string_interior() {
     assert!(derive_at_caret("/Bare.kt", "fun f() { Modif| }\n").is_none());
     assert!(derive_at_caret("/Str.kt", "fun f() { val s = \"foo.|\" }\n").is_none());
 }
+
+// ─── repair-wired scope walk ─────────────────────────────────────────────────
+
+#[test]
+fn scope_walk_survives_an_unclosed_lambda() {
+    // Lambda AND function braces both unclosed: the broken tree forms no
+    // lambda_literal, so without brace repair the scope stack comes back
+    // empty in exactly the mid-typing states completion cares about.
+    let src = "package com.example\n\
+               class Item { val price: Int = 0 }\n\
+               fun main(items: List<Item>) {\n\
+               \x20   items.forEach {\n\
+               \x20       \n";
+    let (uri, index) = indexed_with_live("/Unclosed.kt", src);
+    let scope = ScopeContext::build(Position::new(4, 8), &index, &uri);
+    assert_eq!(
+        scope.resolve_receiver("it"),
+        Some("Item"),
+        "brace repair must recover the lambda scope stack mid-typing"
+    );
+}

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -28,7 +28,9 @@ pub(crate) use self::infer::args::has_named_params_not_it;
 #[cfg(test)]
 #[allow(unused_imports)]
 pub(crate) use self::infer::deps::TestDeps;
-pub(crate) use self::infer::speculative::{receiver_node_for_marker, speculative_doc};
+pub(crate) use self::infer::speculative::{
+    lambda_doc_at, receiver_node_for_marker, speculative_doc,
+};
 #[allow(unused_imports)]
 pub(crate) use self::infer::{
     args::{extract_first_arg, find_as_call_arg_type, find_named_param_type_in_sig},

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -39,8 +39,8 @@ pub(crate) use self::infer::{
     deps::{CallableInfo, InferDeps, OuterScopedParams},
     expr_type::infer_expr_type,
     it_this::{
-        find_it_element_type_in_lines, find_named_lambda_param_type, find_this_context_in_lines,
-        find_this_element_type_in_lines, is_lambda_param, lambda_brace_pos_for_param,
+        find_it_element_type, find_named_lambda_param_type, find_this_context,
+        find_this_element_type, is_lambda_param, lambda_brace_pos_for_param,
         lambda_param_position_on_line, line_has_lambda_param, ThisContext,
     },
     lambda::{lambda_type_nth_input, lambda_type_receiver, RECEIVER_THIS_FNS, SCOPE_FUNCTIONS},

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -292,9 +292,8 @@ pub(super) fn cst_forward_resolve_receiver_type(
     }
     // Otherwise, when the receiver itself is a known collection type, `it` is its
     // element type (`items: List<Product>` → `Product` for `forEach`/`map`/…).
-    // The decision is on the receiver *type*, not the method name — matching the
-    // text path's `extract_collection_element_type`, which likewise keys off the
-    // collection type. Non-collection receivers yield `None` (unchanged).
+    // The decision is on the receiver *type*, not the method name — keyed off
+    // the collection type. Non-collection receivers yield `None` (unchanged).
     extract_collection_element_type(&root_type)
 }
 
@@ -408,8 +407,8 @@ pub(super) fn resolve_root_node_type(
             Some(name)
         }
         k if k == KIND_NAV_EXPR => {
-            let text = node.utf8_text_owned(bytes)?;
-            resolve_dotted_text_type(&text, deps, uri)
+            let segments = collect_nav_segments(node, bytes);
+            resolve_segments_type(&segments, bytes, deps, uri, SuffixStrictness::Fail)
         }
         k if k == KIND_CALL_EXPR => resolve_call_expr_type(node, bytes, deps, uri),
         _ => None,
@@ -564,43 +563,4 @@ pub(super) fn resolve_segments_type(
     // The final type after all segments is what we want.
     forward_resolve_segments(segments, bytes, deps, uri, strictness)
         .map(|(resolved_type, _)| resolved_type)
-}
-
-/// Preserve a dot-qualified type name's prefix while dropping generics/nullable
-/// suffixes.  Use when `raw` is a **type string** (e.g. "Contract.Effect",
-/// "ImmutableList<T>"), not a variable or field name.
-pub(super) fn uppercase_dotted_type_prefix(raw: &str) -> Option<String> {
-    let base = raw.dotted_ident_prefix();
-    let base = base.trim_end_matches('.');
-    if base.is_empty() || is_generic_param(base) {
-        return None;
-    }
-    let first_seg = base.split('.').next().unwrap_or(base);
-    first_seg.starts_with_uppercase().then(|| base.to_owned())
-}
-
-/// Resolve the type of a dotted text expression like `settings.familyCreationDate`.
-pub(super) fn resolve_dotted_text_type(
-    text: &str,
-    deps: &impl InferDeps,
-    uri: &Url,
-) -> Option<String> {
-    // Try as single variable first
-    if let Some(raw) = deps.find_var_type(text, uri) {
-        return uppercase_dotted_type_prefix(&raw);
-    }
-    // Split on dots and resolve segment by segment
-    let parts: Vec<&str> = text.split('.').collect();
-    if parts.len() < 2 {
-        return None;
-    }
-    let mut current_type = deps.find_var_type(parts[0], uri)?;
-    for &field in &parts[1..] {
-        let type_name = current_type.dotted_ident_prefix();
-        if type_name.is_empty() {
-            return None;
-        }
-        current_type = deps.find_field_type(&type_name, field)?;
-    }
-    uppercase_dotted_type_prefix(&current_type)
 }

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -93,12 +93,25 @@ fn collect_nav_segments_recursive<'a>(
     }
 }
 
+/// How an unresolvable navigation suffix is handled during a forward walk.
+#[derive(Clone, Copy, PartialEq)]
+pub(super) enum SuffixStrictness {
+    /// Receiver-position semantics: an unresolved suffix leaves the receiver
+    /// type in place (best-effort; the caller probes members next).
+    LeakReceiver,
+    /// Expression-position semantics: an unresolved suffix fails the walk —
+    /// the expression's own type is unknown (matches the deleted text
+    /// walker's per-segment `?`).
+    Fail,
+}
+
 /// Forward-resolve a chain of segments to get (receiver_type_before_last, last_method_name).
 pub(super) fn forward_resolve_segments(
     segments: &[NavSegment<'_>],
     bytes: &[u8],
     deps: &impl InferDeps,
     uri: &Url,
+    strictness: SuffixStrictness,
 ) -> Option<(String, String)> {
     if segments.is_empty() {
         return None;
@@ -141,7 +154,11 @@ pub(super) fn forward_resolve_segments(
                         last_suffix_resolved = true;
                     } else if SCOPE_FUNCTIONS.contains(&name.as_str()) {
                         // Scope function: receiver type flows through.
+                    } else if strictness == SuffixStrictness::Fail {
+                        return None;
                     }
+                } else if strictness == SuffixStrictness::Fail {
+                    return None;
                 }
                 last_suffix = Some(name.clone());
             }
@@ -226,7 +243,7 @@ pub(super) fn resolve_callee_chain(
             if segments.is_empty() {
                 return None;
             }
-            forward_resolve_segments(&segments, bytes, deps, uri)
+            forward_resolve_segments(&segments, bytes, deps, uri, SuffixStrictness::LeakReceiver)
         }
         k if k == KIND_SIMPLE_IDENT || k == KIND_TYPE_IDENT => {
             let name = callee.utf8_text_owned(bytes)?;
@@ -421,7 +438,13 @@ pub(super) fn resolve_call_expr_type(
     let receiver_type = if callee.kind() == KIND_NAV_EXPR {
         let segments = collect_nav_segments(callee, bytes);
         if segments.len() >= 2 {
-            resolve_segments_type(&segments[..segments.len() - 1], bytes, deps, uri)
+            resolve_segments_type(
+                &segments[..segments.len() - 1],
+                bytes,
+                deps,
+                uri,
+                SuffixStrictness::LeakReceiver,
+            )
         } else {
             None
         }
@@ -526,6 +549,7 @@ pub(super) fn resolve_segments_type(
     bytes: &[u8],
     deps: &impl InferDeps,
     uri: &Url,
+    strictness: SuffixStrictness,
 ) -> Option<String> {
     if segments.is_empty() {
         return None;
@@ -538,7 +562,8 @@ pub(super) fn resolve_segments_type(
     }
     // Otherwise use forward_resolve_segments which returns (final_type, last_suffix).
     // The final type after all segments is what we want.
-    forward_resolve_segments(segments, bytes, deps, uri).map(|(resolved_type, _)| resolved_type)
+    forward_resolve_segments(segments, bytes, deps, uri, strictness)
+        .map(|(resolved_type, _)| resolved_type)
 }
 
 /// Preserve a dot-qualified type name's prefix while dropping generics/nullable

--- a/src/indexer/infer/cst_lambda.rs
+++ b/src/indexer/infer/cst_lambda.rs
@@ -231,10 +231,10 @@ const IT_SCAN_BACK_LINES: usize = 15;
 /// lambda receiver, NOT the enclosing class.
 ///
 /// Used in `infer_lambda_param_type_at` to suppress the `enclosing_class_at`
-/// fallback when `find_this_element_type_in_lines` returned `None` only
+/// fallback when `find_this_element_type` returned `None` only
 /// because the receiver variable's type couldn't be resolved.
 /// Used by tests only — production code uses [`cst_this_context`] via
-/// [`crate::indexer::find_this_context_in_lines`] which returns the richer
+/// [`crate::indexer::find_this_context`] which returns the richer
 /// [`ThisContext`] enum and avoids a redundant second scan.
 #[cfg(test)]
 pub(crate) fn is_inside_receiver_lambda(
@@ -544,7 +544,7 @@ fn cst_with_receiver_ctx(
 /// distinguishes resolved types, unresolvable receiver lambdas, and
 /// "not inside any receiver lambda" — without requiring a second scan.
 ///
-/// This is the CST fast-path for [`find_this_context_in_lines`] in `it_this`.
+/// This is the CST fast-path for [`find_this_context`] in `it_this`.
 pub(super) fn cst_this_context(
     start_node: tree_sitter::Node<'_>,
     doc: &crate::indexer::live_tree::LiveDoc,
@@ -569,7 +569,7 @@ pub(super) fn cst_this_context(
 /// Walk ancestors from `start_node` looking for the nearest `lambda_literal`
 /// without named params, then resolve the implicit `it` element type for it.
 ///
-/// The resolution engine behind `find_it_element_type_in_lines`, which runs it
+/// The resolution engine behind `find_it_element_type`, which runs it
 /// against the tree picked by `it_resolution_doc_at` (live, transient, or
 /// brace-repaired). `this` resolution is handled separately by [`cst_this_context`].
 pub(super) fn cst_it_element_type(

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -115,17 +115,18 @@ pub(crate) fn find_this_element_type_in_lines(
 /// (`items.forEach { item -> item.… }`, including multi-line and multi-param
 /// `{ index, item -> }` lambdas).
 ///
-/// CST-only: the tree comes from [`Indexer::live_doc_or_parse`], so open files
-/// use the live tree and indexed-but-not-open files get a transient parse — the
-/// same universal-CST path the `it`/`this` resolvers use.
+/// CST-only and repair-protected like the `it`/`this` resolvers: the tree
+/// comes from [`super::speculative::lambda_doc_at`] — the live/transient parse
+/// normally, an append-only brace-repaired reparse when the lambda brace is
+/// still unclosed mid-typing.
 pub(crate) fn find_named_lambda_param_type(
     param_name: &str,
     pos: CursorPos,
     idx: &Indexer,
     uri: &Url,
 ) -> Option<String> {
-    let doc = idx.live_doc_or_parse(uri)?;
-    cst_named_lambda_param_type(pos, param_name, &doc, idx, uri)
+    let resolution = lambda_doc_at(idx, uri, pos)?;
+    cst_named_lambda_param_type(pos, param_name, resolution.doc(), idx, uri)
 }
 
 /// Check whether `recv` looks like an explicitly-named lambda parameter

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -8,13 +8,11 @@
 //! - `find_named_lambda_param_type`    — named lambda param (hover + completion)
 //! - `is_lambda_param`                 — guard before named-param inference
 
-use std::sync::Arc;
-
 use tower_lsp::lsp_types::Url;
 
-use crate::indexer::live_tree::{lang_for_path, parse_live, LiveDoc};
-use crate::indexer::{Indexer, NodeExt};
-use crate::queries::KIND_LAMBDA_LIT;
+use crate::indexer::Indexer;
+#[cfg(test)]
+use crate::indexer::NodeExt;
 use crate::types::CursorPos;
 use crate::StrExt;
 
@@ -34,6 +32,7 @@ pub(super) use super::cst_lambda::{
 use super::cst_lambda::{
     cst_it_element_type, cst_named_lambda_param_type, cst_this_context, cursor_node_at,
 };
+use super::speculative::lambda_doc_at;
 use super::type_subst::is_generic_param;
 
 /// Guard: the inference resolved to a bare generic placeholder (T, R, E).
@@ -52,115 +51,6 @@ pub(super) use super::type_subst::build_ext_fn_type_subst;
 #[cfg(test)]
 pub(crate) use super::type_subst::find_last_dot_at_depth_zero;
 
-/// Upper bound on closing braces appended during broken-syntax brace repair
-/// in [`repaired_doc_at`].
-const MAX_BRACE_REPAIRS: usize = 8;
-
-/// The parse tree an `it` resolution ran against.
-///
-/// The two variants keep a repaired-tree answer from silently masquerading as
-/// a normal one: any consumer that cares which tree produced the answer must
-/// match. [`find_it_element_type_in_lines`] treats both the same because the
-/// resolution algorithm is identical either way.
-enum LambdaResolutionDoc {
-    /// The tree from [`Indexer::live_doc_or_parse`] — authoritative.
-    Parsed(Arc<LiveDoc>),
-    /// An append-only brace-repaired transient reparse (never cached into
-    /// `live_trees`): the original tree had an ERROR node at/above the cursor
-    /// and no enclosing `lambda_literal`.
-    Repaired(LiveDoc),
-}
-
-impl LambdaResolutionDoc {
-    fn doc(&self) -> &LiveDoc {
-        match self {
-            LambdaResolutionDoc::Parsed(doc) => doc,
-            LambdaResolutionDoc::Repaired(doc) => doc,
-        }
-    }
-}
-
-/// Typed observation of the cursor's tree, deciding whether broken-syntax
-/// brace repair is permitted.
-enum LambdaTreeGate {
-    /// The ancestor chain contains a `lambda_literal`, or the whole tree is
-    /// error-free — resolve on this tree; its answer (including `None`) is
-    /// authoritative.
-    Resolvable,
-    /// No enclosing `lambda_literal` and the tree contains a parse error —
-    /// the missing lambda may be unrepresentable (unclosed `{`); repair is
-    /// permitted. Tree-wide, not chain-only: comments are tree-sitter extras
-    /// that attach outside the ERROR node, so a cursor remapped onto a
-    /// trailing comment has no ERROR ancestor even though the lambda is
-    /// unclosed.
-    BrokenSyntax,
-}
-
-fn lambda_tree_gate(node: tree_sitter::Node<'_>, tree_has_error: bool) -> LambdaTreeGate {
-    let mut cursor = Some(node);
-    while let Some(current) = cursor {
-        if current.kind() == KIND_LAMBDA_LIT {
-            return LambdaTreeGate::Resolvable;
-        }
-        cursor = current.parent();
-    }
-    if tree_has_error {
-        LambdaTreeGate::BrokenSyntax
-    } else {
-        LambdaTreeGate::Resolvable
-    }
-}
-
-/// Pick the tree to resolve `it` against at `pos`.
-///
-/// Normally the tree from [`Indexer::live_doc_or_parse`]. When that tree has
-/// an ERROR node at/above the cursor and no enclosing `lambda_literal`, the
-/// syntax is broken in a way the CST cannot represent — tree-sitter forms no
-/// `lambda_literal` for an unclosed `{`; the brace opens an ERROR node instead
-/// (`it` in `items.forEach { it.name` parses as `simple_identifier` →
-/// `navigation_expression` → `statements` → ERROR → `source_file`). In that
-/// case resolve against an append-only brace repair (see [`repaired_doc_at`]).
-fn lambda_resolution_doc_at(
-    idx: &Indexer,
-    uri: &Url,
-    pos: CursorPos,
-) -> Option<LambdaResolutionDoc> {
-    let doc = idx.live_doc_or_parse(uri)?;
-    let node = cursor_node_at(&doc, pos)?;
-    let tree_has_error = doc.tree.root_node().has_error();
-    match lambda_tree_gate(node, tree_has_error) {
-        LambdaTreeGate::Resolvable => Some(LambdaResolutionDoc::Parsed(doc)),
-        LambdaTreeGate::BrokenSyntax => {
-            repaired_doc_at(&doc, uri, pos).map(LambdaResolutionDoc::Repaired)
-        }
-    }
-}
-
-/// Append-only brace repair for a tree whose cursor sits under an ERROR node.
-///
-/// Appending `\n}` at end-of-file shifts no existing byte offsets, so `pos`
-/// remains a valid position in every repaired candidate. Each attempt appends
-/// one more closing brace, reparses (a transient parse — never cached), and
-/// self-verifies by checking that the cursor now has an enclosing
-/// `lambda_literal`; unverified candidates are discarded. Bounded by
-/// [`MAX_BRACE_REPAIRS`]; when no candidate verifies, the caller returns the
-/// authoritative `None`.
-fn repaired_doc_at(doc: &LiveDoc, uri: &Url, pos: CursorPos) -> Option<LiveDoc> {
-    let lang = lang_for_path(uri.path())?;
-    let mut source = std::str::from_utf8(&doc.bytes).ok()?.to_owned();
-    for _ in 0..MAX_BRACE_REPAIRS {
-        source.push_str("\n}");
-        let candidate = parse_live(&source, lang.clone())?;
-        let cursor_in_lambda = cursor_node_at(&candidate, pos)
-            .and_then(|node| node.enclosing_lambda_literal())
-            .is_some();
-        if cursor_in_lambda {
-            return Some(candidate);
-        }
-    }
-    None
-}
-
 /// Resolve the element type of `it` when inside a lambda (multi-line aware).
 ///
 /// CST-only: the tree comes from [`Indexer::live_doc_or_parse`], so open files
@@ -168,7 +58,7 @@ fn repaired_doc_at(doc: &LiveDoc, uri: &Url, pos: CursorPos) -> Option<LiveDoc> 
 /// When the syntax at the cursor is too broken for tree-sitter to form the
 /// enclosing `lambda_literal` (unclosed `{` while typing), the resolution runs
 /// against an append-only brace-repaired reparse instead — same resolver,
-/// repaired tree (see [`lambda_resolution_doc_at`]).
+/// repaired tree (see [`super::speculative::lambda_doc_at`]).
 ///
 /// `_lines` is vestigial (the CST resolution reads the tree, not the raw lines);
 /// it is kept so the many `_in_lines` call sites keep a stable signature.
@@ -178,7 +68,7 @@ pub(crate) fn find_it_element_type_in_lines(
     idx: &Indexer,
     uri: &Url,
 ) -> Option<String> {
-    let resolution_doc = lambda_resolution_doc_at(idx, uri, pos)?;
+    let resolution_doc = lambda_doc_at(idx, uri, pos)?;
     let doc = resolution_doc.doc();
     let node = cursor_node_at(doc, pos)?;
     concrete_or_none(cst_it_element_type(node, doc, idx, uri))
@@ -198,7 +88,7 @@ pub(crate) fn find_this_context_in_lines(pos: CursorPos, idx: &Indexer, uri: &Ur
     // Same repair-gated tree acquisition as the `it` path: an unclosed `{`
     // (mid-typing) forms no lambda_literal, so `this` inside `with(x) { this.`
     // is only resolvable against the brace-repaired parse.
-    let Some(resolution) = lambda_resolution_doc_at(idx, uri, pos) else {
+    let Some(resolution) = lambda_doc_at(idx, uri, pos) else {
         return ThisContext::NotFound;
     };
     let doc = resolution.doc();

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -3,8 +3,8 @@
 //! All functions take explicit `(inputs) -> output` signatures — no hidden state.
 //!
 //! Public surface (re-exported through `infer::mod`):
-//! - `find_it_element_type_in_lines`   — multi-line `it.` (hover + completion)
-//! - `find_this_element_type_in_lines` — multi-line hover `this.`
+//! - `find_it_element_type`   — multi-line `it.` (hover + completion)
+//! - `find_this_element_type` — multi-line hover `this.`
 //! - `find_named_lambda_param_type`    — named lambda param (hover + completion)
 //! - `is_lambda_param`                 — guard before named-param inference
 
@@ -59,15 +59,7 @@ pub(crate) use super::type_subst::find_last_dot_at_depth_zero;
 /// enclosing `lambda_literal` (unclosed `{` while typing), the resolution runs
 /// against an append-only brace-repaired reparse instead — same resolver,
 /// repaired tree (see [`super::speculative::lambda_doc_at`]).
-///
-/// `_lines` is vestigial (the CST resolution reads the tree, not the raw lines);
-/// it is kept so the many `_in_lines` call sites keep a stable signature.
-pub(crate) fn find_it_element_type_in_lines(
-    _lines: &[String],
-    pos: CursorPos,
-    idx: &Indexer,
-    uri: &Url,
-) -> Option<String> {
+pub(crate) fn find_it_element_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String> {
     let resolution_doc = lambda_doc_at(idx, uri, pos)?;
     let doc = resolution_doc.doc();
     let node = cursor_node_at(doc, pos)?;
@@ -82,9 +74,8 @@ pub(crate) fn find_it_element_type_in_lines(
 ///
 /// Uses [`Indexer::live_doc_or_parse`] so the CST path is taken for both open
 /// files (live tree) and indexed-but-not-open files (transient parse from the
-/// indexed lines).  The `lines` parameter has been removed; callers that still
-/// need `lines` for `it`/named-param paths retain their own parameter.
-pub(crate) fn find_this_context_in_lines(pos: CursorPos, idx: &Indexer, uri: &Url) -> ThisContext {
+/// indexed lines).
+pub(crate) fn find_this_context(pos: CursorPos, idx: &Indexer, uri: &Url) -> ThisContext {
     // Same repair-gated tree acquisition as the `it` path: an unclosed `{`
     // (mid-typing) forms no lambda_literal, so `this` inside `with(x) { this.`
     // is only resolvable against the brace-repaired parse.
@@ -98,14 +89,10 @@ pub(crate) fn find_this_context_in_lines(pos: CursorPos, idx: &Indexer, uri: &Ur
     cst_this_context(node, doc, idx, uri)
 }
 
-/// Convenience wrapper: returns `Some(type)` when `find_this_context_in_lines`
+/// Convenience wrapper: returns `Some(type)` when `find_this_context`
 /// yields a resolved receiver type, `None` otherwise.
-pub(crate) fn find_this_element_type_in_lines(
-    pos: CursorPos,
-    idx: &Indexer,
-    uri: &Url,
-) -> Option<String> {
-    match find_this_context_in_lines(pos, idx, uri) {
+pub(crate) fn find_this_element_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String> {
+    match find_this_context(pos, idx, uri) {
         ThisContext::Resolved(resolved_type) => Some(resolved_type),
         ThisContext::InsideReceiver | ThisContext::NotFound => None,
     }

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -2671,3 +2671,31 @@ fn this_type_named_argument_builder_lambda_infers_receiver() {
         "named-argument builder lambda: this should resolve to LazyListScope"
     );
 }
+
+/// Generics-survival decoy for the nav-arm redirect: a chain ROOTED at a
+/// navigation expression whose type is generic must keep its type args —
+/// the deleted text walker stripped them at exit, collapsing List<Product>
+/// to List and killing element extraction.
+#[test]
+fn nav_rooted_generic_chain_keeps_element_type_for_it() {
+    let src = "class Product { val price: Int = 0 }\n\
+               class Wrapper { val items: List<Product> = listOf() }\n\
+               fun f(wrapper: Wrapper) {\n\
+                   wrapper.items.map { it }\n\
+               }";
+    let (u, idx) = indexed("/NavRootGeneric.kt", src);
+    let lines: Vec<String> = src.lines().map(String::from).collect();
+    // line 3: "wrapper.items.map { it }" (the `\`-continuation eats the
+    // indent) — cursor ON `it` at col 21.
+    let pos = crate::types::CursorPos {
+        line: 3,
+        utf16_col: 21,
+    };
+    let resolved = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    assert_eq!(resolved.as_deref(), Some("Product"));
+    assert_ne!(
+        resolved.as_deref(),
+        Some("T"),
+        "bare type param must never leak"
+    );
+}

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -2699,3 +2699,23 @@ fn nav_rooted_generic_chain_keeps_element_type_for_it() {
         "bare type param must never leak"
     );
 }
+
+#[test]
+fn named_param_type_resolves_in_an_unclosed_lambda() {
+    let src = "class Item { val price: Int = 0 }\n\
+               fun f(items: List<Item>) {\n\
+                   items.map { item ->\n\
+                       \n";
+    let (u, idx) = indexed("/UnclosedNamed.kt", src);
+    idx.store_live_tree(&u, src);
+    idx.set_live_lines(&u, src);
+    let pos = crate::types::CursorPos {
+        line: 3,
+        utf16_col: 0,
+    };
+    assert_eq!(
+        find_named_lambda_param_type("item", pos, &idx, &u).as_deref(),
+        Some("Item"),
+        "brace repair must recover the named param's type mid-typing"
+    );
+}

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -2702,3 +2702,24 @@ fn named_param_type_resolves_in_an_unclosed_lambda() {
         "brace repair must recover the named param's type mid-typing"
     );
 }
+
+/// Ledger minor (2026-07-04 wave): `it` over a nested-generic element.
+/// `List<Optional<Foo>>` → `it` must be the full `Optional<Foo>`, never a
+/// bare `T` and never a stripped `Optional`.
+#[test]
+fn nested_generic_it_resolves_to_the_concrete_inner_type() {
+    let src = "class Foo { val bar: Int = 0 }\n\
+               class Optional<T> { fun getOrNull(): T? = null }\n\
+               fun f(items: List<Optional<Foo>>) {\n\
+                   items.map { it }\n\
+               }";
+    let (u, idx) = indexed("/NestedGeneric.kt", src);
+    // line 3 = "items.map { it }" (continuation-eaten indent), `it` at col 12.
+    let pos = crate::types::CursorPos {
+        line: 3,
+        utf16_col: 13,
+    };
+    let resolved = find_it_element_type(pos, &idx, &u);
+    assert_eq!(resolved.as_deref(), Some("Optional<Foo>"));
+    assert_ne!(resolved.as_deref(), Some("T"));
+}

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -23,14 +23,13 @@ fn indexed(path: &str, src: &str) -> (Url, Indexer) {
 
 /// Test shim for the former single-line `find_it_element_type`: routes
 /// `before_cursor` (text up to the cursor) through the production CST-first
-/// `find_it_element_type_in_lines` with the cursor at end of a one-line file.
-fn find_it_element_type(before_cursor: &str, indexer: &Indexer, uri: &Url) -> Option<String> {
-    let lines = vec![before_cursor.to_owned()];
+/// `find_it_element_type` with the cursor at end of a one-line file.
+fn it_type_at_line_end(before_cursor: &str, indexer: &Indexer, uri: &Url) -> Option<String> {
     let pos = crate::types::CursorPos {
         line: 0,
         utf16_col: before_cursor.encode_utf16().count(),
     };
-    find_it_element_type_in_lines(&lines, pos, indexer, uri)
+    find_it_element_type(pos, indexer, uri)
 }
 
 /// Index `sig_src` for signature lookup, plus store a live tree for `code_src`
@@ -55,13 +54,12 @@ fn it_element_type_simple_foreach() {
     // `List<User>`.
     let src = "val users: List<User> = emptyList()\nusers.forEach { it }";
     let (u, idx) = indexed("/t.kt", src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // line 1: "users.forEach { it }" — `it` at col 16.
     let pos = crate::types::CursorPos {
         line: 1,
         utf16_col: 17,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("User"),
@@ -73,14 +71,13 @@ fn it_element_type_simple_foreach() {
 fn it_element_type_flow() {
     let src = "val events: Flow<Event> = emptyFlow()\nevents.collect { it }";
     let (u, idx) = indexed("/t.kt", src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // line 1: "events.collect { it }" — `it` at col 17.
     let pos = crate::types::CursorPos {
         line: 1,
         utf16_col: 18,
     };
     assert_eq!(
-        find_it_element_type_in_lines(&lines, pos, &idx, &u).as_deref(),
+        find_it_element_type(pos, &idx, &u).as_deref(),
         Some("Event")
     );
 }
@@ -88,10 +85,7 @@ fn it_element_type_flow() {
 #[test]
 fn it_element_type_unknown_var_returns_none() {
     let (u, idx) = indexed("/t.kt", "");
-    assert_eq!(
-        find_it_element_type("unknown.forEach { it.", &idx, &u),
-        None
-    );
+    assert_eq!(it_type_at_line_end("unknown.forEach { it.", &idx, &u), None);
 }
 
 #[test]
@@ -99,16 +93,12 @@ fn it_element_type_scope_fn_let() {
     // `user.let { it }` — `it` is the User itself (non-collection receiver)
     let src = "val user: User = User()\nuser.let { it }";
     let (u, idx) = indexed("/t.kt", src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // line 1: "user.let { it }" — `it` at col 11.
     let pos = crate::types::CursorPos {
         line: 1,
         utf16_col: 12,
     };
-    assert_eq!(
-        find_it_element_type_in_lines(&lines, pos, &idx, &u).as_deref(),
-        Some("User")
-    );
+    assert_eq!(find_it_element_type(pos, &idx, &u).as_deref(), Some("User"));
 }
 
 // ── cursor at end-of-file (trailing empty line) ──────────────────────────────
@@ -124,13 +114,12 @@ fn it_resolves_on_trailing_empty_line_at_eof() {
     // resolve identically: through repair to the enclosing forEach lambda.
     let code = "val items: List<Item> = listOf()\nitems.forEach {\n";
     let (u, idx, _lines) = indexed_with_live("/t.kt", "class Item { val price: Int = 0 }", code);
-    let lines: Vec<String> = code.lines().map(String::from).collect();
     let pos = crate::types::CursorPos {
         line: 2,
         utf16_col: 0,
     };
     assert_eq!(
-        find_it_element_type_in_lines(&lines, pos, &idx, &u).as_deref(),
+        find_it_element_type(pos, &idx, &u).as_deref(),
         Some("Item"),
         "cursor on the trailing empty line must resolve `it` inside the unclosed lambda"
     );
@@ -144,13 +133,12 @@ fn it_resolves_at_eof_when_last_line_ends_in_multibyte_char() {
     // mid-codepoint point.
     let code = "val items: List<Item> = listOf()\nitems.forEach { // žluť\n";
     let (u, idx, _lines) = indexed_with_live("/t.kt", "class Item { val price: Int = 0 }", code);
-    let lines: Vec<String> = code.lines().map(String::from).collect();
     let pos = crate::types::CursorPos {
         line: 2,
         utf16_col: 0,
     };
     assert_eq!(
-        find_it_element_type_in_lines(&lines, pos, &idx, &u).as_deref(),
+        find_it_element_type(pos, &idx, &u).as_deref(),
         Some("Item"),
         "EOF remap onto a multi-byte final character must not split the codepoint"
     );
@@ -167,7 +155,6 @@ fn it_type_second_of_two_lambdas_same_line() {
                fun setEffect(block: (Effect) -> Unit) {}\n\
                { setState { it } }, { setEffect { it } }";
     let (u, idx) = indexed("/t.kt", src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // line 2: first `it` at col 13, second `it` at col 35.
     let pos_first = crate::types::CursorPos {
         line: 2,
@@ -178,12 +165,12 @@ fn it_type_second_of_two_lambdas_same_line() {
         utf16_col: 36,
     };
     assert_eq!(
-        find_it_element_type_in_lines(&lines, pos_first, &idx, &u).as_deref(),
+        find_it_element_type(pos_first, &idx, &u).as_deref(),
         Some("State"),
         "first it (inside setState) should resolve to State"
     );
     assert_eq!(
-        find_it_element_type_in_lines(&lines, pos_second, &idx, &u).as_deref(),
+        find_it_element_type(pos_second, &idx, &u).as_deref(),
         Some("Effect"),
         "second it (inside setEffect) should resolve to Effect"
     );
@@ -203,12 +190,12 @@ fn it_type_second_lambda_multiline_unindexed_inner() {
     // Line 2: "    { setEffect { it } }"
     //          0123456789012345678901234
     // second `it` is at col 18 on line 2
-    let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
+    let (u, idx, _lines) = indexed_with_live("/t.kt", sig_src, code_src);
     let pos = crate::types::CursorPos {
         line: 2,
         utf16_col: 18,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("Effect"),
@@ -224,12 +211,12 @@ fn it_type_first_lambda_multiline_unindexed_inner() {
     // Line 1: "    { setState { it } },"
     //          012345678901234567890123
     // first `it` is at col 17 on line 1
-    let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
+    let (u, idx, _lines) = indexed_with_live("/t.kt", sig_src, code_src);
     let pos = crate::types::CursorPos {
         line: 1,
         utf16_col: 17,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("State"),
@@ -244,13 +231,13 @@ fn it_type_first_lambda_multiline_unindexed_inner() {
 #[test]
 fn it_type_unindexed_foreach_resolves_collection_element_via_cst() {
     let src = "val items: List<Product> = emptyList()\nitems.forEach { it }";
-    let (u, idx, lines) = indexed_with_live("/t.kt", src, src);
+    let (u, idx, _lines) = indexed_with_live("/t.kt", src, src);
     // Line 1: "items.forEach { it }" — `it` at col 17.
     let pos = crate::types::CursorPos {
         line: 1,
         utf16_col: 17,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("Product"),
@@ -258,7 +245,7 @@ fn it_type_unindexed_foreach_resolves_collection_element_via_cst() {
     );
 }
 
-// ── find_this_element_type_in_lines ─────────────────────────────────────────
+// ── find_this_element_type ─────────────────────────────────────────
 
 #[test]
 fn this_element_type_multiline_scope_fn() {
@@ -269,7 +256,7 @@ fn this_element_type_multiline_scope_fn() {
     let src = "val items: List<String> = emptyList()\nitems.run {\n    this.\n}";
     let (u, idx) = indexed("/t.kt", src);
     // `run` is a stdlib scope function (RECEIVER_THIS_FNS) → `this` refers to List<String> → "List"
-    let result = find_this_element_type_in_lines(
+    let result = find_this_element_type(
         CursorPos {
             line: 2,
             utf16_col: 9,
@@ -291,7 +278,7 @@ fn this_type_with_block() {
     // with(user) { this. } — this should resolve to User
     let src = "val user: User = User()\nwith(user) {\n    this.\n}";
     let (u, idx) = indexed("/t.kt", src);
-    let result = find_this_element_type_in_lines(
+    let result = find_this_element_type(
         CursorPos {
             line: 2,
             utf16_col: 9,
@@ -598,7 +585,7 @@ fn this_type_run_infers_receiver() {
     let src = "val user: User = User()\nuser.run {\n    this.\n}";
     let (u, idx) = indexed("/t.kt", src);
     assert_eq!(
-        find_this_element_type_in_lines(
+        find_this_element_type(
             CursorPos {
                 line: 2,
                 utf16_col: 9
@@ -621,7 +608,7 @@ fn this_type_apply_infers_receiver() {
     let src = "val user: User = User()\nuser.apply {\n    this.\n}";
     let (u, idx) = indexed("/t.kt", src);
     assert_eq!(
-        find_this_element_type_in_lines(
+        find_this_element_type(
             CursorPos {
                 line: 2,
                 utf16_col: 9
@@ -641,7 +628,7 @@ fn this_type_let_does_not_infer_receiver() {
     // `this` inside a let{} block should NOT resolve to User via RECEIVER_THIS_FNS.
     let src = "val user: User = User()\nuser.let {\n    this.\n}";
     let (u, idx) = indexed("/t.kt", src);
-    let result = find_this_element_type_in_lines(
+    let result = find_this_element_type(
         CursorPos {
             line: 2,
             utf16_col: 9,
@@ -661,7 +648,7 @@ fn this_type_also_does_not_infer_receiver() {
     // `also` exposes the receiver as `it`, not `this`.
     let src = "val user: User = User()\nuser.also {\n    this.\n}";
     let (u, idx) = indexed("/t.kt", src);
-    let result = find_this_element_type_in_lines(
+    let result = find_this_element_type(
         CursorPos {
             line: 2,
             utf16_col: 9,
@@ -681,14 +668,13 @@ fn it_type_let_still_infers_receiver() {
     // `user.let { it }` — `let` exposes receiver as `it` → should still infer User
     let src = "val user: User = User()\nuser.let { it }";
     let (u, idx) = indexed("/t.kt", src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // line 1: "user.let { it }" — `it` at col 11.
     let pos = crate::types::CursorPos {
         line: 1,
         utf16_col: 12,
     };
     assert_eq!(
-        find_it_element_type_in_lines(&lines, pos, &idx, &u).as_deref(),
+        find_it_element_type(pos, &idx, &u).as_deref(),
         Some("User"),
         "let: it should still resolve to User"
     );
@@ -702,13 +688,13 @@ fn it_type_let_still_infers_receiver() {
 fn it_type_indexed_inner_fn_cst_still_works() {
     let sig_src = "fun setState(block: (State) -> Unit) {}";
     let code_src = "setState { it }";
-    let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
+    let (u, idx, _lines) = indexed_with_live("/t.kt", sig_src, code_src);
     // "setState { " = 11 chars → `it` at col 11
     let pos = crate::types::CursorPos {
         line: 0,
         utf16_col: 11,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("State"),
@@ -1586,7 +1572,7 @@ suspend fun <EffectType, StateType, VMState, VMEffect> Flow<ReducedResult<Effect
         line: 1,
         utf16_col: it_offset,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u_code);
+    let result = find_it_element_type(pos, &idx, &u_code);
     assert_eq!(
         result.as_deref(),
         Some("SheetState"),
@@ -1646,7 +1632,7 @@ suspend fun <EffectType, StateType, VMState, VMEffect> Flow<ReducedResult<Effect
         line: 1,
         utf16_col: it_offset,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u_code);
+    let result = find_it_element_type(pos, &idx, &u_code);
     assert_eq!(
         result.as_deref(),
         Some("ConcreteStateType"),
@@ -1812,7 +1798,7 @@ fun oneYearOlder(resultState: ResultState.Success<Optional<FamilyAccount>>) {
     );
 }
 
-// ── classify_this_lambda_context / find_this_context_in_lines ─────────────────
+// ── classify_this_lambda_context / find_this_context ─────────────────
 
 #[test]
 fn find_this_context_apply_unresolved_is_inside_receiver() {
@@ -1824,7 +1810,7 @@ fn find_this_context_apply_unresolved_is_inside_receiver() {
         line: 1,
         utf16_col: 8,
     };
-    let result = super::find_this_context_in_lines(pos, &idx, &u);
+    let result = super::find_this_context(pos, &idx, &u);
     assert!(
         matches!(result, super::ThisContext::InsideReceiver),
         "cursor inside unknown.apply{{}} should be InsideReceiver, got: {result:?}"
@@ -1841,7 +1827,7 @@ fn find_this_context_foreach_is_not_found() {
         line: 2,
         utf16_col: 8,
     };
-    let result = super::find_this_context_in_lines(pos, &idx, &u);
+    let result = super::find_this_context(pos, &idx, &u);
     assert!(
         matches!(result, super::ThisContext::NotFound),
         "cursor inside forEach{{}} should be NotFound, got: {result:?}"
@@ -1856,7 +1842,7 @@ fn find_this_context_apply_resolved_with_live_tree() {
         line: 2,
         utf16_col: 8,
     };
-    let result = super::find_this_context_in_lines(pos, &idx, &u);
+    let result = super::find_this_context(pos, &idx, &u);
     assert!(
         matches!(result, super::ThisContext::Resolved(ref t) if t == "User"),
         "cursor inside user.apply{{}} should be Resolved(User), got: {result:?}"
@@ -1873,7 +1859,7 @@ fn find_this_context_nested_foreach_outer_apply() {
         line: 4,
         utf16_col: 12,
     };
-    let result = super::find_this_context_in_lines(pos, &idx, &u);
+    let result = super::find_this_context(pos, &idx, &u);
     assert!(
         matches!(result, super::ThisContext::InsideReceiver),
         "cursor inside forEach inside apply{{}} should be InsideReceiver, got: {result:?}"
@@ -1895,13 +1881,13 @@ fn it_type_generic_ext_fn_substitutes_type_param() {
     ]
     .join("\n");
     let code_src = "header.buttons.fastForEach { it }";
-    let (u, idx, lines) = indexed_with_live("/t.kt", &sig_src, code_src);
+    let (u, idx, _lines) = indexed_with_live("/t.kt", &sig_src, code_src);
     let col = "header.buttons.fastForEach { ".encode_utf16().count();
     let pos = crate::types::CursorPos {
         line: 0,
         utf16_col: col,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("CButtonData"),
@@ -1968,13 +1954,13 @@ fn it_type_resolves_via_function_parameter_type() {
     ]
     .join("\n");
     let code_src = "header.buttons.fastForEach { it }";
-    let (u, idx, lines) = indexed_with_live("/t.kt", &sig_src, code_src);
+    let (u, idx, _lines) = indexed_with_live("/t.kt", &sig_src, code_src);
     let col = "header.buttons.fastForEach { ".encode_utf16().count();
     let pos = crate::types::CursorPos {
         line: 0,
         utf16_col: col,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("CButtonData"),
@@ -1995,13 +1981,12 @@ fn regression_immutable_list_foreach_it_transient_parse() {
     ]
     .join("\n");
     let (u, idx) = indexed("/t.kt", &src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // line 2: "header.buttons.fastForEach { it }" — `it` at col 29.
     let pos = crate::types::CursorPos {
         line: 2,
         utf16_col: 30,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("ButtonModel"),
@@ -2042,13 +2027,12 @@ fn regression_generic_lambda_param_substituted_from_receiver_type_args() {
     ]
     .join("\n");
     let (u, idx) = indexed("/t.kt", &src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // line 3: "buttons.fastForEach { it }" — `it` at col 22.
     let pos = crate::types::CursorPos {
         line: 3,
         utf16_col: 23,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("ButtonModel"),
@@ -2136,7 +2120,7 @@ fn regression_jar_symbol_find_fun_callable_info_cst_path() {
     ]
     .join("\n");
     let code_src = "header.buttons.fastForEach { it }";
-    let (u, idx, lines) = indexed_with_live("/t.kt", &sig_src, code_src);
+    let (u, idx, _lines) = indexed_with_live("/t.kt", &sig_src, code_src);
 
     // Simulate a sidecar-indexed fastForEach with structured type metadata.
     insert_fake_jar_symbol(
@@ -2152,7 +2136,7 @@ fn regression_jar_symbol_find_fun_callable_info_cst_path() {
         line: 0,
         utf16_col: col,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("ButtonModel"),
@@ -2170,7 +2154,7 @@ fn regression_jar_symbol_wrong_receiver_falls_back_to_text_path() {
     // propagated the unsubstituted generic param as the `it` type.
     let sig_src = "val users: List<User> = listOf()";
     let code_src = "users.forEach { it }";
-    let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
+    let (u, idx, _lines) = indexed_with_live("/t.kt", sig_src, code_src);
 
     // Insert a JAR forEach with a MISMATCHING receiver (PersistentList, not List).
     insert_fake_jar_symbol(
@@ -2186,7 +2170,7 @@ fn regression_jar_symbol_wrong_receiver_falls_back_to_text_path() {
         line: 0,
         utf16_col: col,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("User"),
@@ -2208,7 +2192,7 @@ fn regression_jar_descriptive_type_param_name_not_treated_as_generic() {
     ]
     .join("\n");
     let code_src = "state.observe { it }";
-    let (u, idx, lines) = indexed_with_live("/t.kt", &sig_src, code_src);
+    let (u, idx, _lines) = indexed_with_live("/t.kt", &sig_src, code_src);
 
     // A JAR symbol whose type_param name "Effect" matches the concrete extracted type.
     // Its receiver is unrelated — substitution will return empty map.
@@ -2225,7 +2209,7 @@ fn regression_jar_descriptive_type_param_name_not_treated_as_generic() {
         line: 0,
         utf16_col: col,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("Contract.Effect"),
@@ -2253,14 +2237,14 @@ fn regression_jar_fun_param_two_level_chain_fastforeach() {
         "}",
     ]
     .join("\n");
-    let (u, idx, lines) = indexed_with_live("/t.kt", &sig_src, code_src.as_str());
+    let (u, idx, _lines) = indexed_with_live("/t.kt", &sig_src, code_src.as_str());
 
     let col = "  item.tableRows.fastForEach { ".encode_utf16().count();
     let pos = crate::types::CursorPos {
         line: 1,
         utf16_col: col,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("TableRowModel"),
@@ -2282,7 +2266,7 @@ fn regression_jar_fun_param_two_level_chain_fastforeach_jar_only() {
         "}",
     ]
     .join("\n");
-    let (u, idx, lines) = indexed_with_live("/t.kt", &sig_src, code_src.as_str());
+    let (u, idx, _lines) = indexed_with_live("/t.kt", &sig_src, code_src.as_str());
 
     insert_fake_jar_symbol(
         &idx,
@@ -2297,7 +2281,7 @@ fn regression_jar_fun_param_two_level_chain_fastforeach_jar_only() {
         line: 1,
         utf16_col: col,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("TableRowModel"),
@@ -2358,14 +2342,14 @@ fn regression_jar_nested_qualified_param_type_chain_fastforeach() {
         "}",
     ]
     .join("\n");
-    let (u, idx, lines) = indexed_with_live("/t.kt", &sig_src, code_src.as_str());
+    let (u, idx, _lines) = indexed_with_live("/t.kt", &sig_src, code_src.as_str());
 
     let col = "  item.tableRows.fastForEach { ".encode_utf16().count();
     let pos = crate::types::CursorPos {
         line: 1,
         utf16_col: col,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let result = find_it_element_type(pos, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("TableRowModel"),
@@ -2636,7 +2620,7 @@ fn this_type_apply_on_constructor_call_infers_receiver() {
     let code = "User().apply {\n    this.\n}";
     let (uri, idx, _lines) = indexed_with_live("/t.kt", "class User", code);
     assert_eq!(
-        find_this_element_type_in_lines(
+        find_this_element_type(
             CursorPos {
                 line: 1,
                 utf16_col: 9
@@ -2658,7 +2642,7 @@ fn this_type_named_argument_builder_lambda_infers_receiver() {
     let code = "Foo(content = {\n    this.\n})";
     let (uri, idx, _lines) = indexed_with_live("/t.kt", sig, code);
     assert_eq!(
-        find_this_element_type_in_lines(
+        find_this_element_type(
             CursorPos {
                 line: 1,
                 utf16_col: 9
@@ -2684,14 +2668,13 @@ fn nav_rooted_generic_chain_keeps_element_type_for_it() {
                    wrapper.items.map { it }\n\
                }";
     let (u, idx) = indexed("/NavRootGeneric.kt", src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // line 3: "wrapper.items.map { it }" (the `\`-continuation eats the
     // indent) — cursor ON `it` at col 21.
     let pos = crate::types::CursorPos {
         line: 3,
         utf16_col: 21,
     };
-    let resolved = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    let resolved = find_it_element_type(pos, &idx, &u);
     assert_eq!(resolved.as_deref(), Some("Product"));
     assert_ne!(
         resolved.as_deref(),

--- a/src/indexer/infer/mod_tests.rs
+++ b/src/indexer/infer/mod_tests.rs
@@ -160,3 +160,55 @@ fn unresolved_final_suffix_fails_the_strict_walk() {
         "receiver-position semantics unchanged"
     );
 }
+
+/// Unknown ROOT decoy: `resolve_root_node_type` falls back to `Some(name)`
+/// for an unresolvable root ident; combined with a leaking walk this used to
+/// be able to resolve a nav to the literal root string. The strict nav arm
+/// must yield None instead.
+#[test]
+fn unknown_root_nav_expression_resolves_to_none() {
+    use super::chain::resolve_root_node_type;
+
+    let uri = test_url("/UnknownRoot.kt");
+    let deps = super::deps::TestDeps::new(); // nothing indexed at all
+    let doc = live_doc_for("fun f() { foo.bar }\n");
+    let nav =
+        find_first_node_of_kind(doc.tree.root_node(), "navigation_expression").expect("nav node");
+
+    assert_eq!(resolve_root_node_type(nav, &doc.bytes, &deps, &uri), None);
+}
+
+/// Nav-arm behavioral decoy: a SCOPE-FUNCTION callee is a navigation node in
+/// root position (`resolve_call_expr_type` → `resolve_root_node_type(nav)`).
+/// The deleted text walker resolved it segment-by-segment as FIELDS only, so
+/// the trailing `.let` failed the whole walk; the segment walk's scope-fn
+/// flow-through resolves the receiver type.
+#[test]
+fn scope_fn_callee_nav_resolves_via_the_segment_walk() {
+    let source = "class Product { val price: Int = 0 }\n\
+                  class Wrapper { val items: List<Product> = listOf() }\n\
+                  fun f(wrapper: Wrapper) { wrapper.items.let { it } }\n";
+    let live_doc = live_doc_for(source);
+    let indexer = Indexer::new();
+    let uri = test_url("/ScopeFnNav.kt");
+    indexer.index_content(&uri, source);
+
+    let let_call_start = source.find("wrapper.items.let").expect("snippet");
+    let call = live_doc
+        .tree
+        .root_node()
+        .descendant_for_byte_range(
+            let_call_start,
+            let_call_start + "wrapper.items.let { it }".len(),
+        )
+        .expect("node covering the let call");
+    assert_eq!(call.kind(), "call_expression", "got {}", call.kind());
+    let resolved = CstQuery::new(call, &live_doc, &indexer, &uri, ResolveIo::NoRg)
+        .expr_type()
+        .resolved();
+    assert_eq!(
+        resolved.map(|t| t.as_type_str().to_owned()).as_deref(),
+        Some("List<Product>"),
+        "scope-fn callee nav must resolve via the segment walk"
+    );
+}

--- a/src/indexer/infer/mod_tests.rs
+++ b/src/indexer/infer/mod_tests.rs
@@ -109,3 +109,54 @@ fn resolved_type_non_nullable() {
         .expect("Int should resolve");
     assert!(!resolved.is_nullable(), "Int should not be nullable");
 }
+
+// ─── SuffixStrictness (chain forward walk) ───────────────────────────────────
+
+fn find_first_node_of_kind<'a>(
+    node: tree_sitter::Node<'a>,
+    kind: &str,
+) -> Option<tree_sitter::Node<'a>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    for i in 0..node.child_count() {
+        if let Some(found) = find_first_node_of_kind(node.child(i)?, kind) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Strictness decoy: an unresolved FINAL member must fail the walk under
+/// `Fail` (the old text walker's per-segment `?`), while `LeakReceiver`
+/// keeps today's receiver-position best-effort.
+#[test]
+fn unresolved_final_suffix_fails_the_strict_walk() {
+    use super::chain::{collect_nav_segments, resolve_segments_type, SuffixStrictness};
+
+    let uri = test_url("/Strict.kt");
+    let deps = super::deps::TestDeps::new().with_var(uri.as_str(), "wrapper", "Wrapper");
+    // NOTE: no field `unknownField` on Wrapper anywhere.
+    let doc = live_doc_for("fun f() { wrapper.unknownField }\n");
+    let nav =
+        find_first_node_of_kind(doc.tree.root_node(), "navigation_expression").expect("nav node");
+    let segments = collect_nav_segments(nav, &doc.bytes);
+
+    assert_eq!(
+        resolve_segments_type(&segments, &doc.bytes, &deps, &uri, SuffixStrictness::Fail),
+        None,
+        "unknown member must not leak the receiver's type"
+    );
+    assert_eq!(
+        resolve_segments_type(
+            &segments,
+            &doc.bytes,
+            &deps,
+            &uri,
+            SuffixStrictness::LeakReceiver
+        )
+        .as_deref(),
+        Some("Wrapper"),
+        "receiver-position semantics unchanged"
+    );
+}

--- a/src/indexer/infer/speculative.rs
+++ b/src/indexer/infer/speculative.rs
@@ -155,7 +155,7 @@ const MAX_BRACE_REPAIRS: usize = 8;
 ///
 /// The two variants keep a repaired-tree answer from silently masquerading as
 /// a normal one: any consumer that cares which tree produced the answer must
-/// match. [`crate::indexer::infer::it_this::find_it_element_type_in_lines`]
+/// match. [`crate::indexer::infer::it_this::find_it_element_type`]
 /// treats both the same because the resolution algorithm is identical either
 /// way.
 pub(crate) enum ResolutionDoc {

--- a/src/indexer/infer/speculative.rs
+++ b/src/indexer/infer/speculative.rs
@@ -5,12 +5,25 @@
 //! ([`COMPLETION_MARKER`], their `intellijRulezz`), reparse incrementally, and
 //! read the now-well-formed tree. The speculative [`LiveDoc`] is request-local
 //! and never stored.
+//!
+//! This module now hosts both transient-healed-doc constructors: marker
+//! insertion (dot-completion receiver derivation, above) and append-only
+//! brace repair (lambda resolution, [`lambda_doc_at`], below). They are
+//! co-located because both answer "give me a parseable view of a mid-typing
+//! buffer" — not merged because the transforms differ (surgical insertion vs.
+//! trailing-brace append).
 
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::Url;
 use tree_sitter::{InputEdit, Parser, Point};
 
-use crate::indexer::live_tree::{utf16_col_to_byte, LiveDoc};
-use crate::queries::{KIND_NAV_EXPR, KIND_NAV_SUFFIX};
+use crate::indexer::live_tree::{lang_for_path, parse_live, utf16_col_to_byte, LiveDoc};
+use crate::indexer::{Indexer, NodeExt};
+use crate::queries::{KIND_LAMBDA_LIT, KIND_NAV_EXPR, KIND_NAV_SUFFIX};
 use crate::types::CursorPos;
+
+use super::cst_lambda::cursor_node_at;
 
 /// Fake identifier inserted at the cursor. Any valid Kotlin identifier that
 /// will never collide with real code works; the homage is intentional.
@@ -132,6 +145,112 @@ pub(crate) fn receiver_node_for_marker(
         cur = parent;
     }
     None
+}
+
+/// Upper bound on closing braces appended during broken-syntax brace repair
+/// in [`repaired_doc_at`].
+const MAX_BRACE_REPAIRS: usize = 8;
+
+/// The parse tree an `it`/`this` resolution ran against.
+///
+/// The two variants keep a repaired-tree answer from silently masquerading as
+/// a normal one: any consumer that cares which tree produced the answer must
+/// match. [`crate::indexer::infer::it_this::find_it_element_type_in_lines`]
+/// treats both the same because the resolution algorithm is identical either
+/// way.
+pub(crate) enum ResolutionDoc {
+    /// The tree from [`Indexer::live_doc_or_parse`] — authoritative.
+    Parsed(Arc<LiveDoc>),
+    /// An append-only brace-repaired transient reparse (never cached into
+    /// `live_trees`): the original tree had an ERROR node at/above the cursor
+    /// and no enclosing `lambda_literal`.
+    Repaired(LiveDoc),
+}
+
+impl ResolutionDoc {
+    pub(crate) fn doc(&self) -> &LiveDoc {
+        match self {
+            ResolutionDoc::Parsed(doc) => doc,
+            ResolutionDoc::Repaired(doc) => doc,
+        }
+    }
+}
+
+/// Typed observation of the cursor's tree, deciding whether broken-syntax
+/// brace repair is permitted.
+enum LambdaTreeGate {
+    /// The ancestor chain contains a `lambda_literal`, or the whole tree is
+    /// error-free — resolve on this tree; its answer (including `None`) is
+    /// authoritative.
+    Resolvable,
+    /// No enclosing `lambda_literal` and the tree contains a parse error —
+    /// the missing lambda may be unrepresentable (unclosed `{`); repair is
+    /// permitted. Tree-wide, not chain-only: comments are tree-sitter extras
+    /// that attach outside the ERROR node, so a cursor remapped onto a
+    /// trailing comment has no ERROR ancestor even though the lambda is
+    /// unclosed.
+    BrokenSyntax,
+}
+
+fn lambda_tree_gate(node: tree_sitter::Node<'_>, tree_has_error: bool) -> LambdaTreeGate {
+    let mut cursor = Some(node);
+    while let Some(current) = cursor {
+        if current.kind() == KIND_LAMBDA_LIT {
+            return LambdaTreeGate::Resolvable;
+        }
+        cursor = current.parent();
+    }
+    if tree_has_error {
+        LambdaTreeGate::BrokenSyntax
+    } else {
+        LambdaTreeGate::Resolvable
+    }
+}
+
+/// Append-only brace repair for a tree whose cursor sits under an ERROR node.
+///
+/// Appending `\n}` at end-of-file shifts no existing byte offsets, so `pos`
+/// remains a valid position in every repaired candidate. Each attempt appends
+/// one more closing brace, reparses (a transient parse — never cached), and
+/// self-verifies by checking that the cursor now has an enclosing
+/// `lambda_literal`; unverified candidates are discarded. Bounded by
+/// [`MAX_BRACE_REPAIRS`]; when no candidate verifies, the caller returns the
+/// authoritative `None`.
+fn repaired_doc_at(doc: &LiveDoc, uri: &Url, pos: CursorPos) -> Option<LiveDoc> {
+    let lang = lang_for_path(uri.path())?;
+    let mut source = std::str::from_utf8(&doc.bytes).ok()?.to_owned();
+    for _ in 0..MAX_BRACE_REPAIRS {
+        source.push_str("\n}");
+        let candidate = parse_live(&source, lang.clone())?;
+        let cursor_in_lambda = cursor_node_at(&candidate, pos)
+            .and_then(|node| node.enclosing_lambda_literal())
+            .is_some();
+        if cursor_in_lambda {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Pick the tree to resolve `it`/`this` against at `pos`.
+///
+/// Normally the tree from [`Indexer::live_doc_or_parse`]. When that tree has
+/// an ERROR node at/above the cursor and no enclosing `lambda_literal`, the
+/// syntax is broken in a way the CST cannot represent — tree-sitter forms no
+/// `lambda_literal` for an unclosed `{`; the brace opens an ERROR node instead
+/// (`it` in `items.forEach { it.name` parses as `simple_identifier` →
+/// `navigation_expression` → `statements` → ERROR → `source_file`). In that
+/// case resolve against an append-only brace repair (see [`repaired_doc_at`]).
+pub(crate) fn lambda_doc_at(idx: &Indexer, uri: &Url, pos: CursorPos) -> Option<ResolutionDoc> {
+    let doc = idx.live_doc_or_parse(uri)?;
+    let node = cursor_node_at(&doc, pos)?;
+    let tree_has_error = doc.tree.root_node().has_error();
+    match lambda_tree_gate(node, tree_has_error) {
+        LambdaTreeGate::Resolvable => Some(ResolutionDoc::Parsed(doc)),
+        LambdaTreeGate::BrokenSyntax => {
+            repaired_doc_at(&doc, uri, pos).map(ResolutionDoc::Repaired)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/indexer/infer/speculative.rs
+++ b/src/indexer/infer/speculative.rs
@@ -241,8 +241,8 @@ fn repaired_doc_at(doc: &LiveDoc, uri: &Url, pos: CursorPos) -> Option<LiveDoc> 
 /// (`it` in `items.forEach { it.name` parses as `simple_identifier` →
 /// `navigation_expression` → `statements` → ERROR → `source_file`). In that
 /// case resolve against an append-only brace repair (see [`repaired_doc_at`]).
-pub(crate) fn lambda_doc_at(idx: &Indexer, uri: &Url, pos: CursorPos) -> Option<ResolutionDoc> {
-    let doc = idx.live_doc_or_parse(uri)?;
+pub(crate) fn lambda_doc_at(indexer: &Indexer, uri: &Url, pos: CursorPos) -> Option<ResolutionDoc> {
+    let doc = indexer.live_doc_or_parse(uri)?;
     let node = cursor_node_at(&doc, pos)?;
     let tree_has_error = doc.tree.root_node().has_error();
     match lambda_tree_gate(node, tree_has_error) {

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -313,7 +313,14 @@ impl Indexer {
             .tree
             .root_node()
             .descendant_for_point_range(point, point)?;
-        Some(collect_cst_lambda_params(node, &doc.bytes))
+        let params = collect_cst_lambda_params(node, &doc.bytes);
+        if params.is_empty() && doc.tree.root_node().has_error() {
+            // A broken tree may simply have failed to FORM the enclosing
+            // lambda_literal (unclosed `{`); empty here does not mean "no
+            // params" — let the caller fall through to the text scan.
+            return None;
+        }
+        Some(params)
     }
 
     fn lambda_param_scan_lines(&self, uri: &Url) -> Arc<Vec<String>> {

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -6,9 +6,8 @@ use tower_lsp::lsp_types::*;
 use tree_sitter::Point;
 
 use super::{
-    find_as_call_arg_type, find_it_element_type_in_lines, find_named_lambda_param_type,
-    find_this_context_in_lines, lambda_brace_pos_for_param, line_has_lambda_param, Indexer,
-    ThisContext,
+    find_as_call_arg_type, find_it_element_type, find_named_lambda_param_type, find_this_context,
+    lambda_brace_pos_for_param, line_has_lambda_param, Indexer, ThisContext,
 };
 use crate::indexer::live_tree::utf16_col_to_byte;
 use crate::indexer::NodeExt;
@@ -223,7 +222,7 @@ impl Indexer {
             // that data remains valid even before reindex completes.
             let lines: Arc<Vec<String>> = self.mem_lines_for(uri.as_str())?;
             let lambda_type = if name == "this" {
-                match find_this_context_in_lines(pos, self, uri) {
+                match find_this_context(pos, self, uri) {
                     ThisContext::Resolved(ty) => return Some(ty),
                     // Inside a receiver lambda but type unknown: `this` is the lambda
                     // receiver, not the enclosing class.  Do not fall back.
@@ -233,7 +232,7 @@ impl Indexer {
                     ThisContext::NotFound => None,
                 }
             } else {
-                find_it_element_type_in_lines(&lines, pos, self, uri)
+                find_it_element_type(pos, self, uri)
             };
             if lambda_type.is_some() {
                 return lambda_type;
@@ -261,7 +260,7 @@ impl Indexer {
     /// Lambda parameter names that are **in scope** at `(cursor_line, cursor_col)`.
     ///
     /// Uses the same brace-depth backward-scan algorithm as
-    /// `find_it_element_type_in_lines`: `}` increments depth, `{` decrements;
+    /// `find_it_element_type`: `}` increments depth, `{` decrements;
     /// when depth < 0 we've found an *enclosing* `{` lambda.  Sibling/inner lambdas
     /// whose closing `}` appears before their `{` in the backward scan self-balance
     /// and never trigger depth < 0, so they are correctly excluded.

--- a/src/indexer/scope_tests.rs
+++ b/src/indexer/scope_tests.rs
@@ -797,3 +797,19 @@ fn named_lambda_param_resolves_from_disk_only_file() {
         "named lambda param in a disk-only file should resolve via the transient parse, got: {result:?}"
     );
 }
+
+#[test]
+fn lambda_params_fall_back_to_the_text_scan_on_a_broken_tree() {
+    // Unclosed lambda: the CST forms no lambda_literal, so the CST path
+    // used to answer Some(vec![]) and short-circuit the text fallback —
+    // named params vanished in exactly the mid-typing states that matter.
+    let src = "fun f(items: List<Item>) {\n    items.map { item ->\n        \n";
+    let (u, indexer) = indexed("/BrokenParams.kt", src);
+    indexer.store_live_tree(&u, src);
+    indexer.set_live_lines(&u, src);
+    let params = indexer.lambda_params_at_col(&u, 2, 8);
+    assert!(
+        params.iter().any(|p| p == "item"),
+        "broken tree must fall through to the text scan; got {params:?}"
+    );
+}

--- a/src/indexer/scope_tests.rs
+++ b/src/indexer/scope_tests.rs
@@ -3,7 +3,7 @@
 use super::extract_class_decl_name;
 use crate::indexer::Indexer;
 use crate::indexer::{
-    find_it_element_type_in_lines, find_named_lambda_param_type, is_lambda_param,
+    find_it_element_type, find_named_lambda_param_type, is_lambda_param,
     lambda_brace_pos_for_param, line_has_lambda_param,
 };
 use crate::queries::KIND_LAMBDA_LIT;
@@ -21,14 +21,13 @@ fn indexed(path: &str, src: &str) -> (Url, Indexer) {
 }
 
 /// Test shim for the former single-line `find_it_element_type`: routes
-/// `before_cursor` through the production CST-first `find_it_element_type_in_lines`.
-fn find_it_element_type(before_cursor: &str, indexer: &Indexer, uri: &Url) -> Option<String> {
-    let lines = vec![before_cursor.to_owned()];
+/// `before_cursor` through the production CST-first `find_it_element_type`.
+fn it_type_at_line_end(before_cursor: &str, indexer: &Indexer, uri: &Url) -> Option<String> {
     let pos = crate::types::CursorPos {
         line: 0,
         utf16_col: before_cursor.encode_utf16().count(),
     };
-    find_it_element_type_in_lines(&lines, pos, indexer, uri)
+    find_it_element_type(pos, indexer, uri)
 }
 
 // ── word_at ──────────────────────────────────────────────────────────────
@@ -233,13 +232,12 @@ fn it_element_type_list() {
     // val items: List<Product>; `items.forEach { it }` — element type "Product".
     let src = "val items: List<Product> = emptyList()\nitems.forEach { it }";
     let (u, indexer) = indexed("/t.kt", src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // line 1: "items.forEach { it }" — `it` at col 16.
     let pos = crate::types::CursorPos {
         line: 1,
         utf16_col: 17,
     };
-    let result = find_it_element_type_in_lines(&lines, pos, &indexer, &u);
+    let result = find_it_element_type(pos, &indexer, &u);
     assert_eq!(result.as_deref(), Some("Product"));
 }
 
@@ -247,14 +245,13 @@ fn it_element_type_list() {
 fn it_element_type_flow() {
     let src = "val events: Flow<Event> = emptyFlow()\nevents.collect { it }";
     let (u, indexer) = indexed("/t.kt", src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // line 1: "events.collect { it }" — `it` at col 17.
     let pos = crate::types::CursorPos {
         line: 1,
         utf16_col: 18,
     };
     assert_eq!(
-        find_it_element_type_in_lines(&lines, pos, &indexer, &u).as_deref(),
+        find_it_element_type(pos, &indexer, &u).as_deref(),
         Some("Event")
     );
 }
@@ -266,7 +263,7 @@ fn it_element_type_state_flow() {
     let before = "_state.value.let { it."; // `value` is lowercase → chain, falls back
                                            // _state itself is StateFlow, but we ask about `value` which isn't typed here.
                                            // Just ensure no panic.
-    let _ = find_it_element_type(before, &indexer, &u);
+    let _ = it_type_at_line_end(before, &indexer, &u);
 }
 
 #[test]
@@ -274,7 +271,6 @@ fn it_scope_fn_let() {
     // val user: User — `user.let { it }` — it IS the User type
     let src = "val user: User = User()\nuser.let { it }";
     let (u, indexer) = indexed("/t.kt", src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // line 1: "user.let { it }" — `it` at col 11.
     let pos = crate::types::CursorPos {
         line: 1,
@@ -282,7 +278,7 @@ fn it_scope_fn_let() {
     };
     // User is not a collection, so returns the base type directly
     assert_eq!(
-        find_it_element_type_in_lines(&lines, pos, &indexer, &u).as_deref(),
+        find_it_element_type(pos, &indexer, &u).as_deref(),
         Some("User")
     );
 }
@@ -292,7 +288,6 @@ fn it_element_type_nullable_call() {
     // val user: User? — `user?.let { it }`
     let src = "val user: User? = null\nuser?.let { it }";
     let (u, indexer) = indexed("/t.kt", src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // line 1: "user?.let { it }" — `it` at col 12.
     let pos = crate::types::CursorPos {
         line: 1,
@@ -300,7 +295,7 @@ fn it_element_type_nullable_call() {
     };
     // `?` in `?.` is normalised away — should still find "User"
     // (`user: User?` → "User", the trailing `?` stripped at the type boundary).
-    let result = find_it_element_type_in_lines(&lines, pos, &indexer, &u);
+    let result = find_it_element_type(pos, &indexer, &u);
     assert_eq!(result.as_deref(), Some("User"));
 }
 
@@ -309,7 +304,6 @@ fn it_element_type_with_call_args() {
     // `items.mapNotNull(::transform) { it }` → strip `(::transform)` first.
     let src = "val items: List<Order> = emptyList()\nitems.mapNotNull(::transform) { it }";
     let (u, indexer) = indexed("/t.kt", src);
-    let lines: Vec<String> = src.lines().map(String::from).collect();
     // strip `(::transform)` → callee = `items.mapNotNull` → receiver = `items` → List<Order>.
     // line 1: "items.mapNotNull(::transform) { it }" — `it` at col 32.
     let pos = crate::types::CursorPos {
@@ -317,7 +311,7 @@ fn it_element_type_with_call_args() {
         utf16_col: 33,
     };
     assert_eq!(
-        find_it_element_type_in_lines(&lines, pos, &indexer, &u).as_deref(),
+        find_it_element_type(pos, &indexer, &u).as_deref(),
         Some("Order")
     );
 }
@@ -326,7 +320,7 @@ fn it_element_type_with_call_args() {
 fn it_unknown_var_returns_none() {
     let (u, indexer) = indexed("/t.kt", "");
     assert_eq!(
-        find_it_element_type("unknown.forEach { it.", &indexer, &u),
+        it_type_at_line_end("unknown.forEach { it.", &indexer, &u),
         None
     );
 }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -5266,3 +5266,33 @@ fn jar_member_enumeration_falls_back_when_the_import_points_elsewhere() {
          enumeration — got: {dot_labels:?}"
     );
 }
+
+/// Mid-typing named-param completion: multi-line lambda with BOTH braces
+/// unclosed. Exercises the whole repaired path: lambda_params_at_col
+/// broken-tree fall-through → is_lambda_param → complete_lambda_dot →
+/// find_named_lambda_param_type (repair-wired).
+#[test]
+fn named_param_completion_survives_unclosed_lambda() {
+    let idx = Indexer::new();
+    let app_uri = Url::parse("file:///app/U.kt").unwrap();
+    let src = "package app\n\
+               class Item { val price: Int = 0 }\n\
+               fun f(items: List<Item>) {\n\
+                   items.map { item ->\n\
+                       item.\n";
+    idx.index_content(&app_uri, src);
+    idx.store_live_tree(&app_uri, src);
+    idx.set_live_lines(&app_uri, src);
+    // line 4 = "item." (continuation-eaten indent), cursor after the dot.
+    let (items, _) = crate::features::completion::run_completions(
+        &idx,
+        &app_uri,
+        tower_lsp::lsp_types::Position::new(4, 5),
+        false,
+    );
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.iter().any(|l| l.starts_with("price")),
+        "named-param completion in the broken state — got: {labels:?}"
+    );
+}

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -5,9 +5,7 @@ use tower_lsp::lsp_types::{
 };
 use tree_sitter::Node;
 
-use crate::indexer::{
-    find_it_element_type_in_lines, find_this_element_type_in_lines, Indexer, LiveDoc, NodeExt,
-};
+use crate::indexer::{find_it_element_type, find_this_element_type, Indexer, LiveDoc, NodeExt};
 use crate::indexer::{CstQuery, ResolveIo};
 use crate::queries::{
     KIND_KW_AS, KIND_KW_BY, KIND_KW_CONSTRUCTOR, KIND_KW_GET, KIND_KW_IN, KIND_KW_IS, KIND_KW_SET,
@@ -192,19 +190,6 @@ fn resolve_lambda_params(
     uri: &Url,
 ) -> Vec<RawToken> {
     let mut tokens = Vec::new();
-    let lines_arc = indexer.mem_lines_for(uri.as_str());
-    let fallback;
-    let lines: &[String] = match lines_arc.as_deref() {
-        Some(l) => l,
-        None => {
-            fallback = std::str::from_utf8(&doc.bytes)
-                .unwrap_or("")
-                .lines()
-                .map(String::from)
-                .collect::<Vec<_>>();
-            &fallback
-        }
-    };
 
     visit_tree(doc.tree.root_node(), &mut |node| {
         if node.kind() == KIND_LAMBDA_LIT {
@@ -231,7 +216,7 @@ fn resolve_lambda_params(
                 utf16_col: src.col_utf16(node.start_position().row, node.start_position().column)
                     as usize,
             };
-            if find_this_element_type_in_lines(pos, indexer, uri).is_some() {
+            if find_this_element_type(pos, indexer, uri).is_some() {
                 push_token(
                     node,
                     type_index(&SemanticTokenType::KEYWORD),
@@ -258,7 +243,7 @@ fn resolve_lambda_params(
 
         if name == "it" {
             if node.enclosing_lambda_literal().is_some()
-                && find_it_element_type_in_lines(lines, pos, indexer, uri).is_some()
+                && find_it_element_type(pos, indexer, uri).is_some()
             {
                 push_token(
                     node,


### PR DESCRIPTION
## What

Slice 4 of the CST resolution unification (spec: `docs/superpowers/specs/2026-07-17-cst-chain-collapse-design.md`, independently critiqued and amended before implementation).

**Chain collapse:** `resolve_root_node_type`'s nav arm no longer flattens a CST node to text — it collects segments and runs the node-native forward walk. Deleted: `resolve_dotted_text_type` (the last `split('.')` chain resolver) and `uppercase_dotted_type_prefix` (~35 lines). Because the bare walk is *looser* than the text walker in two ways, a typed `SuffixStrictness` gate rides along: nav position = `Fail` on unresolved suffixes (the old per-segment `?` semantics), receiver positions keep today's `LeakReceiver` best-effort.

**Repair-seam hoist:** the append-only brace-repair mechanism moved from `it_this.rs` into `speculative.rs` (now home to both transient-healed-doc constructors) as the transform-agnostic `ResolutionDoc` + `lambda_doc_at` seam. Three consumers gained mid-typing resilience, each RED-first:
- the scope walk (`collect_lambda_scopes`) — lambda scope stack survives an unclosed `{`,
- `lambda_params_at_col` — `Some(vec![])` on a broken tree no longer short-circuits the text fallback (this hole would have made the next wire unreachable),
- `find_named_lambda_param_type` — repair-wired like the `it`/`this` resolvers; end-to-end `run_completions` test pins `item.` completion in a doubly-unclosed lambda.

**Carry-ins:** vestigial `_lines` params dropped (`find_it_element_type` / `find_this_context` / `find_this_element_type`; deletion cascaded through `CompletionSite.lines` and a dead semantic-tokens block, net −53 lines); stale text-path comments fixed; nested-generic-`it` element typing pinned (no gap found); EOF-remap carry-in dispositioned as already covered.

## Behavior deltas (all decoy-gated)

- Scope-function callee navs resolve (`wrapper.items.let { }` — the text walker failed on `.let`; flow-through now types the receiver).
- Generics survive nav-rooted chains (no more `List<Product>` → `List` stripping at the walker exit).
- Unknown final member / unknown root in nav position now yield `None` instead of leaking the receiver type or a capitalized literal.
- Mid-typing (unclosed-brace) states: scope stack, lambda params, and named-param typing all resolve where they previously came back empty.

## Verification

- 1537 unit tests + all integration suites; clippy dev+release `-D warnings`.
- Live probe on the real project: multiline Compose chain continuation, `?.` receiver, and the unclosed-brace broken state — all green (254–263 items).
- Note: `save_jar_cache_merges_with_on_disk_entries_instead_of_clobbering` flaked once during the run (parallel-test env interference); green in isolation and on the full-suite rerun — unrelated to this slice, recorded in the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)