### PR TITLE
feat(nav): CST-aware navigation core — classifier + go-def/goto-impl/highlight (CST slice 6a)

### DIFF
--- a/docs/superpowers/plans/2026-07-19-cst-navigation-6a.md
+++ b/docs/superpowers/plans/2026-07-19-cst-navigation-6a.md
@@ -1,0 +1,819 @@
+# CST-Aware Navigation — Sub-slice 6a Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the shared CST symbol-classification core (`classify_symbol_at` + `resolve_identity`) and wire it into go-to-definition, goto-implementation, and document-highlight — each gaining precise, receiver-typed identity while the string engine remains the guaranteed fallback.
+
+**Architecture:** Promote `semantic_tokens`' existing declaration/receiver-typing walk into a shared `indexer/infer/cst_symbol.rs` module rather than writing a new CST pass (independent-critique finding). `classify_symbol_at` uses it to produce a `SymbolAtCursor` (declaration / member-reference-with-typed-receiver / import-segment / not-a-symbol); `resolve_identity` turns that into a `NavigationSource<Definitions>` built on the existing `find_definition_qualified` lookup. Each feature tries the CST path first and falls through to its current behavior — wrapped `NameScan` — when the CST can't establish identity. Spec: `docs/superpowers/specs/2026-07-19-cst-navigation-design.md`.
+
+**Tech Stack:** Rust, tree-sitter, existing `InferDeps`/`CstQuery`/`Resolver` seams.
+
+## Global Constraints
+
+- Scope cut (documented, not silent): 6a classifies **declarations**, **member references with a receiver** (typed via `CstQuery::expr_type`), and **import segments**. Plain local `val`/`var` references and bare unqualified names continue through today's path unchanged, labeled `NameScan` — a general CST-based local-variable declaration resolver (handling nested-scope shadowing, destructuring, `when`-branch bindings) is a bigger undertaking than this sub-slice and is explicitly deferred. `it`/`this`/named-lambda-param references already have full CST + repair-wired machinery (slices 1-4) and are NOT re-derived here — they stay on their existing path (`CursorContext.contextual`), which is already correct.
+- Every feature's `NameScan` fallback must reproduce EXACTLY today's behavior — the existing test suites for `definition.rs`, `implementation.rs`, `highlight.rs` are the regression floor and must pass unchanged.
+- No feature may ERROR when the CST can't classify — `classify_symbol_at` returning `None` means "use today's path," never a failure.
+- House decoy for every wired feature: two unrelated classes with an identically-named member (`User.save()` / `File.save()`) — the CST path must never confuse them.
+- Gates per commit: `cargo test` + pre-commit clippy. Final: both clippy profiles, e2e smoke, live probe on the real project.
+- Branch: `refactor/cst-navigation`, PR → `refactor/unified-resolution`.
+
+---
+
+### Task 1: Promote the classification helpers out of `semantic_tokens`
+
+**Files:**
+- Create: `src/indexer/infer/cst_symbol.rs`
+- Modify: `src/indexer/infer/mod.rs` (add `pub(super) mod cst_symbol;` next to the other `mod` declarations; add to the `pub(crate) use self::infer::{...}` re-export block in `src/indexer.rs`)
+- Modify: `src/semantic_tokens/helpers.rs` (delete the 4 moved functions)
+- Modify: `src/semantic_tokens/resolve.rs` (update the `use super::helpers::{...}` import to pull the moved 4 from the new location)
+- Test: existing `semantic_tokens` test suites are the neutrality net — no new tests in this task.
+
+**Interfaces:**
+- Produces (later tasks rely on these exact names/signatures, unchanged from their current form in `semantic_tokens/helpers.rs`):
+```rust
+pub(crate) fn is_declaration_site(node: tree_sitter::Node<'_>) -> bool
+pub(crate) fn navigation_receiver_node(node: tree_sitter::Node<'_>) -> Option<tree_sitter::Node<'_>>
+pub(crate) fn navigation_member_ident(node: tree_sitter::Node<'_>) -> Option<tree_sitter::Node<'_>>
+pub(crate) fn is_call_callee(node: tree_sitter::Node<'_>) -> bool
+```
+
+- [ ] **Step 1: Move the code verbatim**
+
+Cut these four functions (with their doc comments) from `src/semantic_tokens/helpers.rs` — `is_declaration_site` (currently `pub(super)`, ~line 236), `navigation_receiver_node` (~361), `navigation_member_ident` (~367), `is_call_callee` (~375) — into a new file:
+
+```rust
+//! Shared CST identifier classification: declaration-vs-reference, and
+//! receiver/member extraction from a `navigation_expression`.
+//!
+//! Originally written for semantic-token coloring (`semantic_tokens/resolve.rs`);
+//! promoted here because `classify_symbol_at` (the navigation-feature
+//! classifier: go-def, goto-impl, highlight) needs the identical walk —
+//! two independent CST passes answering "declaration or reference?" and
+//! "what's the receiver of this member access?" would drift from each other.
+
+use tree_sitter::Node;
+
+use crate::indexer::NodeExt;
+use crate::queries::{
+    KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ, KIND_ENUM_ENTRY, KIND_FUN_DECL,
+    KIND_NAV_SUFFIX, KIND_OBJECT_DECL, KIND_PARAMETER, KIND_SIMPLE_IDENT, KIND_TYPE_ALIAS,
+    KIND_TYPE_IDENT, KIND_TYPE_PARAM, KIND_VAR_DECL,
+};
+
+// (paste the four functions here verbatim, changing `pub(super)` to `pub(crate)`)
+```
+
+Change every `pub(super)` on the four moved functions to `pub(crate)` (they now cross a module boundary). Keep the `KIND_*` constant imports needed by the moved bodies — check each function against `semantic_tokens/helpers.rs`'s current top-of-file imports to get the exact list (the sketch above is a best-effort list; the compiler will flag anything missing).
+
+- [ ] **Step 2: Register the module and re-export**
+
+In `src/indexer/infer/mod.rs`, add near the other `pub(super) mod` lines:
+```rust
+pub(super) mod cst_symbol;
+```
+
+In `src/indexer.rs`'s existing `pub(crate) use self::infer::{...}` block (the large one that already re-exports `speculative::{...}`, `chain`, etc.), add:
+```rust
+    cst_symbol::{is_call_callee, is_declaration_site, navigation_member_ident, navigation_receiver_node},
+```
+
+- [ ] **Step 3: Fix the semantic_tokens import**
+
+In `src/semantic_tokens/resolve.rs`, the existing line:
+```rust
+use super::helpers::{
+    is_annotation_reference, is_call_callee, is_declaration_site, is_inside_lambda_parameters,
+    is_named_argument_label, is_navigation_receiver, is_top_level_call_name, is_type_reference,
+    navigation_member_ident, navigation_receiver_node, node_text, push_token, visit_tree,
+};
+```
+becomes two imports — the four moved functions from the new home, the rest unchanged from `helpers`:
+```rust
+use crate::indexer::{is_call_callee, is_declaration_site, navigation_member_ident, navigation_receiver_node};
+use super::helpers::{
+    is_annotation_reference, is_inside_lambda_parameters, is_named_argument_label,
+    is_navigation_receiver, is_top_level_call_name, is_type_reference, node_text, push_token,
+    visit_tree,
+};
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `cargo test --bin kmp-lsp 2>&1 | grep -E "^test result|FAILED"`
+Expected: identical pass count to the pre-task baseline (`cargo test --bin kmp-lsp 2>&1 | grep "^test result"` before you start, to know the number) — this is a pure move, zero behavior change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/
+git commit -m "refactor(infer): promote CST declaration/receiver helpers out of semantic_tokens
+
+Shared home for classify_symbol_at (slice 6) — avoids a second CST pass
+answering the identical declaration-vs-reference and receiver-extraction
+questions semantic_tokens already solved."
+```
+
+---
+
+### Task 2: `SymbolAtCursor` + `classify_symbol_at`
+
+**Files:**
+- Modify: `src/indexer/infer/cst_symbol.rs` (add the classifier below the promoted helpers)
+- Test: inline `#[cfg(test)]` module in the same file.
+
+**Interfaces:**
+- Consumes: Task 1's helpers; `Indexer::live_doc_or_parse`/`lambda_doc_at` (`speculative.rs`) for tree acquisition; `cursor_node_at` (`cst_lambda.rs`); `CstQuery::new(...).expr_type()` (`infer/mod.rs`); `KIND_IMPORT_HEADER`, `KIND_NAV_EXPR`, `KIND_STRING_LITERAL`, `KIND_MULTILINE_STRING_LITERAL`, `KIND_LINE_COMMENT`/`KIND_MULTILINE_COMMENT` (check the exact comment-kind constant names in `queries.rs` — grep `COMMENT`).
+- Produces (Tasks 3-6 rely on these exact names):
+```rust
+pub(crate) struct SymbolAtCursor {
+    pub name: String,
+    pub role: SymbolRole,
+}
+
+pub(crate) enum SymbolRole {
+    Declaration,
+    /// `receiver_type` is `Some` only when the reference is a member access
+    /// (`x.name`) AND the receiver's type resolved via `CstQuery::expr_type`.
+    /// `is_call` is true when the reference is the callee of a call_expression.
+    Reference { receiver_type: Option<String>, is_call: bool },
+    ImportSegment,
+}
+
+pub(crate) fn classify_symbol_at(
+    indexer: &Indexer, uri: &Url, pos: CursorPos,
+) -> Option<SymbolAtCursor>
+```
+
+- [ ] **Step 1: Write the failing characterization tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexer::Indexer;
+    use tower_lsp::lsp_types::Url;
+
+    fn uri(path: &str) -> Url {
+        Url::parse(&format!("file:///t{path}")).unwrap()
+    }
+
+    fn indexed_with_live(path: &str, src: &str) -> (Url, Indexer) {
+        let u = uri(path);
+        let idx = Indexer::new();
+        idx.index_content(&u, src);
+        idx.store_live_tree(&u, src);
+        (u, idx)
+    }
+
+    #[test]
+    fn classifies_a_class_declaration() {
+        let (u, idx) = indexed_with_live("/D.kt", "class User { val id: Int = 0 }\n");
+        // cursor on "User"
+        let sym = classify_symbol_at(&idx, &u, CursorPos { line: 0, utf16_col: 8 }).unwrap();
+        assert_eq!(sym.name, "User");
+        assert!(matches!(sym.role, SymbolRole::Declaration));
+    }
+
+    #[test]
+    fn classifies_a_typed_member_reference() {
+        let src = "class User { fun save() {} }\nfun f(user: User) { user.save() }\n";
+        let (u, idx) = indexed_with_live("/D.kt", src);
+        // cursor on "save" in "user.save()"
+        let col = src.lines().nth(1).unwrap().find("save").unwrap() as u32;
+        let sym = classify_symbol_at(&idx, &u, CursorPos { line: 1, utf16_col: col as usize }).unwrap();
+        assert_eq!(sym.name, "save");
+        match sym.role {
+            SymbolRole::Reference { receiver_type: Some(t), is_call: true } => assert_eq!(t, "User"),
+            other => panic!("expected typed call reference, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_symbol_inside_a_string_literal() {
+        let (u, idx) = indexed_with_live("/D.kt", "fun f() { val s = \"User\" }\n");
+        let col = "fun f() { val s = \"".len() as u32;
+        assert!(classify_symbol_at(&idx, &u, CursorPos { line: 0, utf16_col: col as usize }).is_none());
+    }
+
+    #[test]
+    fn classifies_an_import_segment() {
+        let (u, idx) = indexed_with_live("/D.kt", "import com.example.User\n");
+        let col = "import com.example.".len() as u32;
+        let sym = classify_symbol_at(&idx, &u, CursorPos { line: 0, utf16_col: col as usize }).unwrap();
+        assert_eq!(sym.name, "User");
+        assert!(matches!(sym.role, SymbolRole::ImportSegment));
+    }
+
+    /// House decoy: an untypeable receiver must not silently attach a wrong
+    /// or stale receiver_type.
+    #[test]
+    fn untypeable_receiver_yields_no_receiver_type() {
+        let src = "fun f(x: Unknown) { x.save() }\n";
+        let (u, idx) = indexed_with_live("/D.kt", src);
+        let col = src.find("save").unwrap() as u32;
+        let sym = classify_symbol_at(&idx, &u, CursorPos { line: 0, utf16_col: col as usize }).unwrap();
+        match sym.role {
+            SymbolRole::Reference { receiver_type: None, .. } => {}
+            other => panic!("expected no receiver_type, got {other:?}"),
+        }
+    }
+}
+```
+
+You'll need `#[derive(Debug)]` on `SymbolRole` for the `{other:?}` panics — add it.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --bin kmp-lsp cst_symbol 2>&1 | tail -10`
+Expected: compile errors (types/fn not defined).
+
+- [ ] **Step 3: Implement**
+
+```rust
+use crate::indexer::live_tree::lang_for_path;
+use crate::indexer::{CstQuery, Indexer, Resolution, ResolveIo};
+use crate::queries::{KIND_IMPORT_HEADER, KIND_NAV_EXPR};
+use crate::types::CursorPos;
+use tower_lsp::lsp_types::Url;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SymbolAtCursor {
+    pub name: String,
+    pub role: SymbolRole,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum SymbolRole {
+    Declaration,
+    Reference {
+        receiver_type: Option<String>,
+        is_call: bool,
+    },
+    ImportSegment,
+}
+
+/// Classify the identifier under `pos`: declaration, member reference (with
+/// receiver type resolved via the CST where possible), or import segment.
+/// Returns `None` for non-identifier positions (strings, comments,
+/// whitespace) — callers treat that exactly like today's "nothing under the
+/// cursor" case, never an error.
+///
+/// Acquisition goes through `lambda_doc_at` so mid-typing states (an
+/// unclosed brace above the cursor) still classify against a repaired tree.
+pub(crate) fn classify_symbol_at(
+    indexer: &Indexer,
+    uri: &Url,
+    pos: CursorPos,
+) -> Option<SymbolAtCursor> {
+    let resolution = super::speculative::lambda_doc_at(indexer, uri, pos)?;
+    let doc = resolution.doc();
+    let node = super::cst_lambda::cursor_node_at(doc, pos)?;
+
+    if !matches!(node.kind(), crate::queries::KIND_SIMPLE_IDENT | crate::queries::KIND_TYPE_IDENT) {
+        return None;
+    }
+    let name = node.utf8_text_owned(&doc.bytes)?;
+
+    if is_declaration_site(node) {
+        return Some(SymbolAtCursor { name, role: SymbolRole::Declaration });
+    }
+
+    if node
+        .parent()
+        .is_some_and(|p| p.kind() == KIND_IMPORT_HEADER)
+    {
+        return Some(SymbolAtCursor { name, role: SymbolRole::ImportSegment });
+    }
+
+    // Member reference: the identifier is the member name of a nav_expr's suffix.
+    if let Some(nav) = node.parent().and_then(|suffix| {
+        (suffix.kind() == crate::queries::KIND_NAV_SUFFIX).then_some(suffix)
+    }).and_then(|suffix| suffix.parent()) {
+        if nav.kind() == KIND_NAV_EXPR && navigation_member_ident(nav).is_some_and(|m| m.id() == node.id()) {
+            let is_call = is_call_callee(nav);
+            let receiver_type = navigation_receiver_node(nav).and_then(|receiver| {
+                match CstQuery::new(receiver, doc, indexer, uri, ResolveIo::IndexOnly).expr_type() {
+                    Resolution::Resolved(t) => Some(t.as_type_str().to_owned()),
+                    _ => None,
+                }
+            });
+            return Some(SymbolAtCursor {
+                name,
+                role: SymbolRole::Reference { receiver_type, is_call: is_call && nav.id() == node.parent()?.parent()?.id() },
+            });
+        }
+    }
+
+    // Bare reference (local var, top-level name, etc.) — no receiver, scope
+    // resolution deferred (see Global Constraints). Callers fall through to
+    // today's NameScan path for these.
+    let is_call = node
+        .parent()
+        .is_some_and(|p| p.kind() == crate::queries::KIND_CALL_EXPR && p.child(0).map(|c| c.id()) == Some(node.id()));
+    Some(SymbolAtCursor {
+        name,
+        role: SymbolRole::Reference { receiver_type: None, is_call },
+    })
+}
+```
+
+The `is_call` computation inside the nav-suffix branch has a redundant clause (`is_call && nav.id() == ...`) from an early draft — simplify to just `is_call_callee(nav)` (that's already exactly "is this nav_expr itself the callee of an outer call_expression," which is what `is_call_callee` computes given `nav` as the node). Fix this during implementation — the characterization test `classifies_a_typed_member_reference` will catch it if wrong (expects `is_call: true` for `user.save()`).
+
+Note the string/comment case: a cursor inside a string or comment lands on a `string_literal`/`comment` node (or their content), not `simple_identifier`/`type_identifier` — the `matches!` guard at the top handles it, matching the `no_symbol_inside_a_string_literal` decoy.
+
+- [ ] **Step 4: Run and fix until green**
+
+Run: `cargo test --bin kmp-lsp cst_symbol 2>&1 | tail -20`
+Debug via `to_sexp()` dumps on any assertion mismatch (same technique used throughout slices 4-5) — tree-sitter's exact node shape for `import_header` paths and nav-suffix nesting may need one iteration to match.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/
+git commit -m "feat(infer): SymbolAtCursor + classify_symbol_at — CST symbol classification"
+```
+
+---
+
+### Task 3: `NavigationSource<T>` + `resolve_identity`
+
+**Files:**
+- Modify: `src/indexer/infer/cst_symbol.rs`
+- Test: same file's test module.
+
+**Interfaces:**
+- Consumes: Task 2's `SymbolAtCursor`/`SymbolRole`; `Indexer::find_definition_qualified(name, qualifier, uri) -> Vec<Location>` (`indexer/lookup.rs:38`).
+- Produces:
+```rust
+pub(crate) enum NavigationSource<T> {
+    CstResolved(T),
+    NameScan(T),
+}
+
+pub(crate) fn resolve_identity(
+    sym: &SymbolAtCursor, indexer: &Indexer, uri: &Url,
+) -> NavigationSource<Definitions>
+```
+(`Definitions` — `resolver/api.rs` — is already `pub(crate)`; import it.)
+
+- [ ] **Step 1: Write the failing decoy tests**
+
+```rust
+    /// House decoy: two classes with an identically-named member. A
+    /// receiver-typed reference must resolve to the RIGHT one only.
+    #[test]
+    fn typed_reference_resolves_to_the_correct_same_named_member() {
+        let src = "class User { fun save() {} }\n\
+                   class File { fun save() {} }\n\
+                   fun f(user: User) { user.save() }\n";
+        let (u, idx) = indexed_with_live("/D.kt", src);
+        let col = src.lines().nth(2).unwrap().find("save").unwrap() as u32;
+        let sym = classify_symbol_at(&idx, &u, CursorPos { line: 2, utf16_col: col as usize }).unwrap();
+        let identity = resolve_identity(&sym, &idx, &u);
+        match identity {
+            NavigationSource::CstResolved(defs) => {
+                assert_eq!(defs.len(), 1);
+                assert_eq!(defs[0].range.start.line, 0, "must resolve to User.save, not File.save");
+            }
+            NavigationSource::NameScan(_) => panic!("typed receiver should resolve CST-resolved"),
+        }
+    }
+
+    #[test]
+    fn declaration_resolves_to_its_own_location() {
+        let (u, idx) = indexed_with_live("/D.kt", "class User\n");
+        let sym = classify_symbol_at(&idx, &u, CursorPos { line: 0, utf16_col: 8 }).unwrap();
+        match resolve_identity(&sym, &idx, &u) {
+            NavigationSource::CstResolved(defs) => assert_eq!(defs.len(), 1),
+            NavigationSource::NameScan(_) => panic!("declaration must be CstResolved"),
+        }
+    }
+
+    #[test]
+    fn untyped_receiver_falls_back_to_name_scan() {
+        let src = "fun f(x: Unknown) { x.save() }\n";
+        let (u, idx) = indexed_with_live("/D.kt", src);
+        let col = src.find("save").unwrap() as u32;
+        let sym = classify_symbol_at(&idx, &u, CursorPos { line: 0, utf16_col: col as usize }).unwrap();
+        assert!(matches!(resolve_identity(&sym, &idx, &u), NavigationSource::NameScan(_)));
+    }
+```
+
+- [ ] **Step 2: Run to verify failure** — `cargo test --bin kmp-lsp resolve_identity 2>&1 | tail -10` (compile error).
+
+- [ ] **Step 3: Implement**
+
+```rust
+use crate::resolver::Definitions;
+
+#[derive(Debug)]
+pub(crate) enum NavigationSource<T> {
+    /// Identity established from the CST + index: precise, ranked first.
+    CstResolved(T),
+    /// Name-based scan: today's behavior, visibly labeled.
+    NameScan(T),
+}
+
+/// Resolve `sym`'s identity to its definition site(s).
+///
+/// `CstResolved` when the CST gave enough information to trust the result
+/// (a declaration is trivially its own definition; a receiver-typed member
+/// reference is looked up ON that type). `NameScan` for everything the CST
+/// couldn't narrow — an untyped receiver, or a bare reference resolved by
+/// today's name-based `find_definition_qualified(name, None, uri)` (which
+/// can span multiple same-named workspace symbols).
+pub(crate) fn resolve_identity(
+    sym: &SymbolAtCursor,
+    indexer: &Indexer,
+    uri: &Url,
+) -> NavigationSource<Definitions> {
+    match &sym.role {
+        SymbolRole::Declaration => {
+            NavigationSource::CstResolved(Definitions(indexer.find_definition_qualified(&sym.name, None, uri)))
+        }
+        SymbolRole::Reference { receiver_type: Some(ty), .. } => {
+            let locs = indexer.find_definition_qualified(&sym.name, Some(ty), uri);
+            if locs.is_empty() {
+                NavigationSource::NameScan(Definitions(locs))
+            } else {
+                NavigationSource::CstResolved(Definitions(locs))
+            }
+        }
+        SymbolRole::Reference { receiver_type: None, .. } | SymbolRole::ImportSegment => {
+            NavigationSource::NameScan(Definitions(indexer.find_definition_qualified(&sym.name, None, uri)))
+        }
+    }
+}
+```
+
+Note: `declaration_resolves_to_its_own_location` relies on `find_definition_qualified("User", None, uri)` finding exactly the class itself — verify this is true for a bare class name with no other `User` in the workspace (it should be, via `resolve_symbol`'s local-definitions step). If the test's assertion needs adjustment because a `Declaration`'s OWN location isn't what `find_definition_qualified` returns by name (e.g. it returns the constructor too), adjust the assertion to match observed reality — the point being pinned is "declarations are always CstResolved," not the exact count.
+
+- [ ] **Step 4: Run and fix until green.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/
+git commit -m "feat(infer): NavigationSource + resolve_identity — typed-first symbol-to-definition"
+```
+
+---
+
+### Task 4: Wire go-to-definition
+
+**Files:**
+- Modify: `src/features/definition.rs` (`find_definition`)
+- Modify: `src/backend/nav.rs` (`goto_definition_impl` — needs `position` as `CursorPos`, already has it as `Position`)
+- Test: `src/features/definition_tests.rs` if it exists, else create `src/features/definition.rs`'s `#[cfg(test)]` inline module (check which pattern the file's siblings use — `implementation.rs` has `#[path = "implementation_tests.rs"] mod tests;`; follow that).
+
+**Interfaces:**
+- Consumes: `classify_symbol_at`, `resolve_identity`, `NavigationSource` (Task 2-3), re-exported through `src/indexer.rs`.
+
+- [ ] **Step 1: Write the failing house-decoy test**
+
+```rust
+#[tokio::test]
+async fn goto_definition_disambiguates_same_named_members_via_receiver_type() {
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/D.kt").unwrap();
+    let src = "class User { fun save() {} }\n\
+               class File { fun save() {} }\n\
+               fun f(user: User) { user.save() }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+    let col = src.lines().nth(2).unwrap().find("save").unwrap() as u32;
+    let ctx = CursorContext::build(&idx, &uri, Position::new(2, col)).unwrap();
+    let response = find_definition(&ctx, &idx, &uri, Position::new(2, col)).await.unwrap();
+    let loc = match response {
+        GotoDefinitionResponse::Scalar(l) => l,
+        other => panic!("expected a single location, got {other:?}"),
+    };
+    assert_eq!(loc.range.start.line, 0, "must jump to User.save, not File.save");
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --bin kmp-lsp goto_definition_disambiguates 2>&1 | tail -15`
+Expected: FAIL — today's `find_definition` resolves `save` via `ctx.word`/`ctx.qualifier` (text `"user"`), which is NOT type-directed the same way; verify by running first whether it happens to pass already (if `find_definition_qualified("save", Some("user"), uri)` already resolves correctly via the string-qualifier path, this decoy won't be RED — in that case, use `user: User` interchangeably with a **local var whose declared type differs from its name-implied type**, e.g. rename the parameter to `x: User` so the qualifier text `"x"` carries no type information at all, forcing today's path to guess by container-name matching and get it wrong or ambiguous). Adjust the fixture until the decoy is genuinely RED before proceeding — this is required, not optional (RED-first).
+
+- [ ] **Step 3: Implement**
+
+In `src/features/definition.rs`, add near the top of `find_definition` (before the existing `this`/`super` special cases — those stay first since they're keyword-driven, not identity-classified):
+
+```rust
+pub(crate) async fn find_definition(
+    ctx: &CursorContext,
+    index: &(impl SymbolIndex + DocumentAccess + SearchAccess),
+    uri: &Url,
+    position: Position,
+) -> Option<GotoDefinitionResponse> {
+    // CST-resolved path first: precise for declarations and receiver-typed
+    // member references. Falls through to the string-first path below for
+    // everything the CST can't narrow (locals, untyped receivers, keywords).
+    if let Some(cst_response) = try_cst_resolved_definition(index, uri, position) {
+        return Some(cst_response);
+    }
+
+    // `this` → enclosing class definition.
+    ...
+```
+
+Add the helper (needs `index` to be `&Indexer` for `classify_symbol_at`/`resolve_identity` — check whether `SymbolIndex + DocumentAccess + SearchAccess` is generic enough or whether this function needs a concrete `&Indexer` parameter threaded in from the caller; `Indexer` is the only real implementor of these traits in production, and `backend/nav.rs` already has `&*self.indexer: &Indexer` — thread it through as an additional parameter rather than fighting the trait bounds):
+
+```rust
+fn try_cst_resolved_definition(
+    indexer: &crate::indexer::Indexer,
+    uri: &Url,
+    position: Position,
+) -> Option<GotoDefinitionResponse> {
+    let cursor = crate::types::CursorPos {
+        line: position.line as usize,
+        utf16_col: position.character as usize,
+    };
+    let sym = crate::indexer::classify_symbol_at(indexer, uri, cursor)?;
+    match crate::indexer::resolve_identity(&sym, indexer, uri) {
+        crate::indexer::NavigationSource::CstResolved(defs) if !defs.is_empty() => {
+            locs_to_opt_response(defs.0)
+        }
+        _ => None,
+    }
+}
+```
+
+Update the signature of `find_definition` to take `indexer: &crate::indexer::Indexer` as an explicit extra parameter (alongside the existing generic `index`), and update the one call site in `src/backend/nav.rs`:
+```rust
+let response = def::find_definition(&ctx, &*self.indexer, &self.indexer, uri, position).await;
+```
+(Passing `&*self.indexer` twice — once through the existing generic bound, once concretely — is a bit awkward; if it compiles cleanly and reads confusingly, an alternative is to change `find_definition`'s generic bound from `impl SymbolIndex + DocumentAccess + SearchAccess` to a concrete `&Indexer` throughout, since `Indexer` is the only production implementor — check whether any TEST fixture relies on a fake implementor of just those traits before making that change; if none does, the concrete-type simplification is cleaner and preferred.)
+
+Add the necessary re-exports to `src/indexer.rs`'s `pub(crate) use self::infer::{...}` block:
+```rust
+    cst_symbol::{classify_symbol_at, resolve_identity, NavigationSource, SymbolAtCursor, SymbolRole},
+```
+
+- [ ] **Step 4: Run the decoy + full suite**
+
+Run: `cargo test --bin kmp-lsp 2>&1 | grep -E "^test result|FAILED"`
+Expected: decoy passes; every existing `definition`-related test passes unchanged (NameScan parity).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/
+git commit -m "feat(definition): go-to-definition tries CST-resolved identity first"
+```
+
+---
+
+### Task 5: Wire goto-implementation (fixes the call-site gap)
+
+**Files:**
+- Modify: `src/backend/nav.rs` (`goto_implementation_impl`)
+- Modify: `src/features/implementation.rs` (`find_implementation` — new entry variant)
+- Test: `src/features/implementation_tests.rs`
+
+**Interfaces:**
+- Consumes: `classify_symbol_at` (Task 2).
+
+- [ ] **Step 1: Write the failing decoy**
+
+Confirmed gap (verified against the code): `goto_implementation_impl` always calls `find_implementation(&ctx.word, indexer, uri, position.line)`, and `declaring_class_of_method` only matches when `position.line` equals the EXACT declaration line of a method named `word` in the current file — so invoking goto-implementation from a CALL SITE (`service.load()`, not the `fun load()` declaration itself) falls through to the type-implementations path treating `"load"` as a type name, and returns nothing.
+
+```rust
+#[tokio::test]
+async fn goto_implementation_from_a_call_site_finds_overrides() {
+    let idx = Indexer::new();
+    let iface_uri = Url::parse("file:///t/IService.kt").unwrap();
+    let impl_uri = Url::parse("file:///t/RealService.kt").unwrap();
+    let call_uri = Url::parse("file:///t/Caller.kt").unwrap();
+    idx.index_content(&iface_uri, "interface IService { fun load() }\n");
+    idx.index_content(
+        &impl_uri,
+        "class RealService : IService { override fun load() {} }\n",
+    );
+    let call_src = "fun f(service: IService) { service.load() }\n";
+    idx.index_content(&call_uri, call_src);
+    idx.store_live_tree(&call_uri, call_src);
+    let col = call_src.find("load").unwrap() as u32;
+
+    let response = find_implementation_at(&idx, &call_uri, Position::new(0, col)).await;
+    let GotoDefinitionResponse::Array(locs) = response.expect("must find the override") else {
+        panic!("expected an array response");
+    };
+    assert!(locs.iter().any(|l| l.uri == impl_uri));
+}
+```
+
+(`find_implementation_at` is the new entry point this task adds — write the test against the name you're about to implement, matching the plan's Interfaces.)
+
+- [ ] **Step 2: Run to verify failure** — compile error (function doesn't exist yet) or, once stubbed to call the OLD `find_implementation(word, ...)`, a runtime failure (empty result) confirming the gap.
+
+- [ ] **Step 3: Implement**
+
+Add a new entry point in `implementation.rs` that tries CST classification first:
+
+```rust
+/// Find implementations for the symbol at `position` — CST-resolved first
+/// (works from a CALL SITE via the receiver's type, not just the declaration
+/// line), falling back to the existing name+line path.
+pub(crate) async fn find_implementation_at(
+    indexer: &crate::indexer::Indexer,
+    uri: &Url,
+    position: tower_lsp::lsp_types::Position,
+) -> Option<GotoDefinitionResponse> {
+    let cursor = crate::types::CursorPos {
+        line: position.line as usize,
+        utf16_col: position.character as usize,
+    };
+    if let Some(sym) = crate::indexer::classify_symbol_at(indexer, uri, cursor) {
+        if let crate::indexer::SymbolRole::Reference { receiver_type: Some(ty), is_call: true } = &sym.role {
+            if let Some(response) = find_method_implementations(&sym.name, ty, indexer, uri).await {
+                return Some(response);
+            }
+        }
+    }
+    let (word, _) = indexer.word_and_qualifier_at(uri, position)?;
+    find_implementation(&word, indexer, uri, position.line).await
+}
+```
+
+(`find_method_implementations` is already `pub(crate)`-visible within the module — check its current visibility is at least `pub(super)`/accessible from this new function in the same file; it is, since both live in `implementation.rs`.)
+
+Update `src/backend/nav.rs`'s `goto_implementation_impl` to call `imp::find_implementation_at(&*self.indexer, uri, position).await` instead of the old `find_implementation(&ctx.word, ...)` call — the `CursorContext::build` call above it becomes unused for this handler; check whether `ctx` is used for anything else in that function (it isn't, per the code read during planning) and remove the now-dead `CursorContext::build` call and its `let Some(ctx) = ... else { return Ok(None) }` guard, replacing the early-return with a direct `Option`-based flow through `find_implementation_at`.
+
+- [ ] **Step 4: Run and fix until green; full suite.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/
+git commit -m "feat(implementation): goto-implementation resolves from call sites via receiver type"
+```
+
+---
+
+### Task 6: Fix document-highlight scoping
+
+**Files:**
+- Modify: `src/features/highlight.rs`
+- Test: create `src/features/highlight_tests.rs` (the file currently has none) + `#[path = "highlight_tests.rs"] mod tests;` at the bottom of `highlight.rs`, matching the sibling pattern in `implementation.rs`.
+
+**Interfaces:**
+- Consumes: `classify_symbol_at` (Task 2); a new local helper `enclosing_body`.
+
+- [ ] **Step 1: Write the failing decoy (confirmed bug: today highlights the whole file)**
+
+```rust
+use super::compute_document_highlight;
+use crate::indexer::Indexer;
+use tower_lsp::lsp_types::{Position, Url};
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file:///t{path}")).unwrap()
+}
+
+fn indexed_with_live(path: &str, src: &str) -> (Url, Indexer) {
+    let u = uri(path);
+    let idx = Indexer::new();
+    idx.index_content(&u, src);
+    idx.store_live_tree(&u, src);
+    idx.set_live_lines(&u, src);
+    (u, idx)
+}
+
+/// Confirmed bug: a local variable named `total` in one function must not
+/// highlight an unrelated local ALSO named `total` in a different function.
+#[test]
+fn highlight_does_not_cross_function_boundaries() {
+    let src = "fun a() {\n    val total = 1\n    println(total)\n}\n\
+               fun b() {\n    val total = 2\n    println(total)\n}\n";
+    let (u, idx) = indexed_with_live("/H.kt", src);
+    // cursor on `total` inside fn a() (line 2, the println use).
+    let highlights = compute_document_highlight(&u, Position::new(2, 14), &idx).unwrap();
+    assert_eq!(
+        highlights.len(),
+        2,
+        "must highlight only fn a()'s two occurrences, not fn b()'s — got {highlights:?}"
+    );
+    assert!(highlights.iter().all(|h| h.range.start.line <= 2));
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --bin kmp-lsp highlight_does_not_cross 2>&1 | tail -10`
+Expected: FAIL — 4 highlights (today's whole-file word match finds both functions' `total`).
+
+- [ ] **Step 3: Implement**
+
+Add to `src/features/highlight.rs`:
+
+```rust
+/// The narrowest enclosing function/lambda body (or the whole file if
+/// neither exists) containing `node` — the boundary document-highlight
+/// searches within. Coarser than full lexical scoping (doesn't distinguish
+/// nested shadowing), but it NEVER crosses into an unrelated function, which
+/// is the bug this exists to fix.
+fn enclosing_body(node: tree_sitter::Node<'_>) -> tree_sitter::Node<'_> {
+    let mut cur = node;
+    while let Some(parent) = cur.parent() {
+        if matches!(parent.kind(), k if k == crate::queries::KIND_FUN_DECL || k == crate::queries::KIND_LAMBDA_LIT) {
+            return parent;
+        }
+        cur = parent;
+    }
+    cur
+}
+```
+
+Rewrite `compute_document_highlight` to scope the search when the CST classifies the cursor as a `Declaration` or an unqualified local `Reference` (the cases `classify_symbol_at` can place inside a specific function body), keeping today's whole-file behavior for everything else:
+
+```rust
+pub(crate) fn compute_document_highlight(
+    uri: &Url,
+    pos: Position,
+    index: &(impl SymbolIndex + DocumentAccess),
+) -> Option<Vec<DocumentHighlight>> {
+    let (name, _) = index.word_and_qualifier_at(uri, pos)?;
+    let lines = index.mem_lines_for(uri.as_str())?;
+
+    // Scope narrowing: only for the Indexer concrete type (classify_symbol_at
+    // needs it) — DocumentAccess/SymbolIndex are trait objects in tests, so
+    // this block is best-effort and falls through to the whole-file scan
+    // when a concrete Indexer isn't available. `compute_document_highlight`'s
+    // real caller (backend/handlers.rs) always passes a concrete Indexer.
+    let scope_range: Option<Range> = index
+        .as_indexer()
+        .and_then(|indexer| {
+            let cursor = crate::types::CursorPos { line: pos.line as usize, utf16_col: pos.character as usize };
+            let doc = indexer.live_doc_or_parse(uri)?;
+            let node = crate::indexer::cursor_node_at(&doc, cursor)?;
+            let body = enclosing_body(node);
+            Some(Range::new(
+                Position::new(body.start_position().row as u32, 0),
+                Position::new(body.end_position().row as u32, u32::MAX),
+            ))
+        });
+
+    let decl_lines: std::collections::HashSet<u32> = index
+        .definition_locations(&name)
+        .into_iter()
+        .filter(|loc| loc.uri == *uri)
+        .map(|loc| loc.range.start.line)
+        .collect();
+
+    let mut highlights = Vec::new();
+    for (line_idx, line) in lines.iter().enumerate() {
+        let line_idx = line_idx as u32;
+        if let Some(ref scope) = scope_range {
+            if line_idx < scope.start.line || line_idx > scope.end.line {
+                continue;
+            }
+        }
+        for abs in word_byte_offsets(line, &name) {
+            let col = utf16_column(&line[..abs]);
+            let col_end = col + utf16_column(&name);
+            let range = Range::new(Position::new(line_idx, col), Position::new(line_idx, col_end));
+            let kind = if decl_lines.contains(&line_idx) {
+                DocumentHighlightKind::WRITE
+            } else {
+                DocumentHighlightKind::READ
+            };
+            highlights.push(DocumentHighlight { range, kind: Some(kind) });
+        }
+    }
+
+    (!highlights.is_empty()).then_some(highlights)
+}
+```
+
+This references `index.as_indexer()` — check whether `SymbolIndex`/`DocumentAccess` already has a downcast-to-concrete-`Indexer` escape hatch (grep `as_indexer\|fn as_any` in `features/traits.rs`). If none exists, the simplest correct alternative (preferred — avoids inventing a new trait method for one caller) is to change `compute_document_highlight`'s signature to take `index: &crate::indexer::Indexer` directly instead of the generic bound, since — like `find_definition` in Task 4 — `Indexer` is the only production implementor; verify no test fixture needs the generic bound before doing this, then update the one call site in `src/backend/handlers.rs:157`.
+
+- [ ] **Step 4: Run and fix until green; full suite green.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/
+git commit -m "fix(highlight): scope occurrences to the enclosing function — no more cross-function bleed"
+```
+
+---
+
+### Task 7: Gates, live probe, PR
+
+- [ ] **Step 1:** `cargo test 2>&1 | tail -5 && cargo clippy --all-targets -- -D warnings 2>&1 | tail -2 && cargo clippy --release --all-targets -- -D warnings 2>&1 | tail -2 && cargo test --test lsp_smoke 2>&1 | tail -3`
+
+- [ ] **Step 2:** Build (`cargo build`) and live-probe on Moneta (adapt `scratchpad/lsp_probe_cst.py`'s harness): go-to-definition from a Compose member call (`Modifier.padding` or similar) resolves to the correct symbol; goto-implementation from a call site on an interface method (pick a real `interface`/`override` pair in the project) returns the override; document-highlight on a local variable stays within its function. BIN must point at the worktree `target/debug/kmp-lsp`.
+
+- [ ] **Step 3:** Push, open PR → `refactor/unified-resolution`. PR body: what shipped (classifier + 3 wired features), the confirmed pre-existing bugs fixed as a side effect (goto-impl-from-call-site returned nothing; highlight had zero scoping), the documented scope cut (general local-variable CST resolution deferred), decoy list, probe results.
+
+- [ ] **Step 4:** Ledger entry + memory update. Note in both: 6b (find-references) is next, building directly on `classify_symbol_at`/`resolve_identity`; 6c (rename) after that, gated on 6c's own live-probe measurement of cross-file refusal rate per the spec's flagged policy question.
+
+## Self-review notes
+
+- Spec coverage: classifier core (spec §Core) = Tasks 1-3, with Task 1 directly implementing the F1 critique fix (reuse, not reinvent) and Task 3 directly implementing the F7 critique fix (named `resolve_identity`). Go-def/goto-impl/highlight (spec §6a) = Tasks 4-6. `local_scope_occurrences` (spec/F9) is intentionally NOT built as a separate general primitive in this plan — Task 6's `enclosing_body` is a deliberately narrower, sufficient version for highlight's confirmed bug; a fuller `local_scope_occurrences` usable by 6c's local-rename fast path is deferred to 6c's own plan, which can generalize `enclosing_body` once rename's exact needs (edit-set enumeration, not just a boolean scope check) are in front of it — recorded here so 6c's planning doesn't rediscover this from scratch.
+- Documented scope cut: general local-`val`/`var` CST declaration resolution (nested shadowing, destructuring, `when`-bindings) is explicitly deferred — Global Constraints explains why (bigger than one sub-slice) and what stays on today's path in the meantime (unchanged, NameScan-labeled).
+- Type consistency: `SymbolAtCursor`/`SymbolRole`/`NavigationSource`/`classify_symbol_at`/`resolve_identity` signatures introduced in Tasks 2-3 are used identically in Tasks 4-6.
+- Known judgment points flagged for the implementer: Task 4's generic-bound-vs-concrete-`Indexer` question (resolve by checking test fixtures, prefer concrete); Task 6's `as_indexer` escape hatch (same resolution); Task 4 Step 2's RED-verification requirement (the decoy fixture must be adjusted if the naive version happens to already pass).

--- a/docs/superpowers/specs/2026-07-19-cst-navigation-design.md
+++ b/docs/superpowers/specs/2026-07-19-cst-navigation-design.md
@@ -92,7 +92,17 @@ pub(crate) fn classify_symbol_at(
 ) -> Option<SymbolAtCursor>
 ```
 
-Classification is one CST pass at the cursor node:
+**Reuse, not a fresh pass (independent critique finding):** `semantic_tokens/helpers.rs`
+already classifies every token as declaration-vs-reference (`is_declaration_site`, keyed on
+the identical parent-node-kind test this classifier needs) and already extracts + types
+receivers (`resolve.rs::resolve_member_access` via `CstQuery::expr_type`,
+`navigation_receiver_node`/`navigation_member_ident`). Promote these four helpers out of
+`semantic_tokens` into a shared home (`indexer/infer` — they're already `CstQuery`-shaped)
+and have `classify_symbol_at` call them instead of re-deriving the same walk. This also stops
+semantic_tokens and the navigation classifier from silently drifting on what counts as a
+declaration site.
+
+Classification is one CST pass at the cursor node, built on the promoted helpers:
 - **Declaration**: the identifier is the name child of a declaration node
   (`class_declaration`, `object_declaration`, `function_declaration`, `property_declaration`,
   parameter, lambda parameter).
@@ -106,8 +116,22 @@ Classification is one CST pass at the cursor node:
   tree; classification never triggers the marker-insertion transform (the cursor sits on an
   existing token, not a completion gap).
 
-The classifier produces IDENTITY, not locations — each feature keeps its own lookup, keyed
-by that identity, and wraps results in `NavigationSource`.
+The classifier produces IDENTITY, not locations. A second shared function resolves identity
+to a definition — named up front (independent critique finding) because all three
+sub-slices need it and would otherwise each hand-roll it: 6a's go-def jump, 6b's per-candidate
+declaring-type lookup, and 6c's "does this reference resolve uniquely" uniqueness test are the
+same call:
+
+```rust
+pub(crate) fn resolve_identity<D: InferDeps>(
+    sym: &SymbolAtCursor, deps: &D, uri: &Url,
+) -> NavigationSource<Definitions>
+```
+
+Built on the existing `resolve_member`/`find_definition_qualified` family
+(`resolver/api.rs`, `indexer/lookup.rs`) — this function does the IO-bounded work
+(`ResolveIo`-gated), which is why it stays separate from the cheap pure-CST
+`classify_symbol_at`.
 
 ### 6a — go-def, goto-impl, document-highlight
 
@@ -119,9 +143,20 @@ by that identity, and wraps results in `NavigationSource`.
   Ranking: `CstResolved` results first when both exist.
 - **goto-impl**: same identity feeds the existing subtype lookup; receiver-typed identity
   filters same-named interfaces.
-- **highlight** (54 lines): for locals/params, highlight only occurrences within the
-  declaration's scope subtree (pure CST walk — no index needed); everything else keeps
-  today's behavior via `NameScan`.
+- **highlight** (54 lines): today highlights every text match across the WHOLE FILE — no
+  scoping at all (confirmed: `word_byte_offsets` over the full document), so same-named
+  locals in unrelated functions currently bleed together. Fixed via a new shared function,
+  named up front because 6c needs the identical walk (independent critique finding):
+
+  ```rust
+  pub(crate) fn local_scope_occurrences(
+      doc: &LiveDoc, decl_node: tree_sitter::Node,
+  ) -> Vec<(Range, SymbolRole)>
+  ```
+
+  Pure CST subtree walk from the declaration node — no index, no rg. Highlight calls it for
+  `Declaration`/local-`Reference` roles; everything else keeps today's whole-file behavior
+  via `NameScan`.
 
 ### 6b — find-references
 
@@ -136,9 +171,19 @@ concatenates `CstResolved` first, then surviving `NameScan` entries.
 
 ### 6c — rename
 
-1. Classify the cursor symbol: must be `CstResolved` identity (a `Declaration`, or a
-   `Reference` whose definition resolves uniquely in the workspace). Jar/library-defined
-   symbols refuse ("defined in a library").
+**Local-variable fast path** (independent critique finding — also defuses the refusal-rate
+risk below for the common case): when the symbol is a local/lambda-param whose declaration
+and every reference live in one file, rename via `local_scope_occurrences` directly —
+single-file CST subtree walk, no rg, no index, no cross-file verification. Every occurrence
+from this walk is `CstResolved` by construction, so this path never refuses on receiver-type
+gaps. This is also a strict improvement over today: today's local rename
+(`rename.rs::enclosing_scope`) is a brace-depth **text** scan over lines, not a CST walk —
+exactly the string-parsing class the parent design eliminates.
+
+**Cross-file path** (member functions/properties referenced across files):
+1. Classify the cursor symbol: must be `CstResolved` identity via `resolve_identity` (a
+   `Declaration`, or a `Reference` whose definition resolves uniquely in the workspace).
+   Jar/library-defined symbols refuse ("defined in a library").
 2. Collect 6b's verified reference set. If ANY candidate in the set is `NameScan`
    (unverifiable), refuse: the edit would gamble.
 3. Override ambiguity: if the symbol participates in an override relationship (existing
@@ -146,6 +191,21 @@ concatenates `CstResolved` first, then surviving `NameScan` entries.
    non-goals).
 4. Refusal = LSP request error with a human-readable reason string (Helix shows it in the
    status line). Success = `WorkspaceEdit` over exactly the verified set.
+
+**Policy gate (independent critique finding, unresolved by design — resolved during 6c, not
+before):** "any `NameScan` residue ⇒ refuse" is deliberately strict, and its real cost is
+unmeasured — receiver types genuinely fail to resolve through scope-function lambdas
+(`apply`/`let`/`also`/`with`), deep generics, and extension-receiver chains, which are common
+in real Kotlin/Compose call sites, not edge cases. Today's cross-file rename does ZERO
+per-occurrence verification (a literal whole-word replace across every rg/index candidate),
+so the strict policy is unambiguously safer — but if refusal turns out to be the *common*
+case for cross-file member renames, that's a regression worth knowing about, not shipping
+silently. **Before locking the policy**, 6c's live probe (below) must measure the refusal
+rate on a real multi-call-site member rename in the actual project. If refusal is rare, ship
+as specified. If refusal is common, the fallback is to soften verification (e.g., accept a
+`NameScan` candidate when the existing scope/qualifier narrowing in `references.rs` also
+agrees, rather than requiring full receiver-type resolution) — a decision point flagged here,
+not resolved here, because it needs real data the spec-writing stage doesn't have.
 
 ### Error handling
 

--- a/docs/superpowers/specs/2026-07-19-cst-navigation-design.md
+++ b/docs/superpowers/specs/2026-07-19-cst-navigation-design.md
@@ -1,0 +1,170 @@
+# CST-Aware Navigation — Design (Slice 6)
+
+Status: **approved design** (brainstormed with the user 2026-07-19; decisions: three sub-slices
+under one spec; rename refuses unless CST-resolved). Slice 6 of
+[CST resolution unification](2026-06-30-cst-resolution-unification-design.md), expanding the
+sketch in `docs/superpowers/plans/2026-07-05-post-fable-roadmap-refinements.md` §6.
+Branch: `refactor/cst-navigation` off `refactor/unified-resolution` (post-#224).
+Sub-slices land as separate PRs: 6a → 6b → 6c, each live-verified before the next.
+
+## Context (why)
+
+The symbol-identity navigation family — go-to-definition, goto-implementation,
+find-references, document-highlight, rename — answers "which symbol does this identifier
+refer to?" name-based today. Same-named members on unrelated types collide, locals bleed
+across scopes, and rename is a silent gamble in ambiguous states. The CST engine built up
+through slices 1-4 (receiver typing via `CstQuery::expr_type`, uri-threaded member lookup,
+repair-wired tree acquisition via `lambda_doc_at`) can now answer identity precisely — the
+features just don't ask it.
+
+Current surfaces: `features/definition.rs` (195 lines), `references.rs` (616),
+`rename.rs` (476), `highlight.rs` (54), `implementation.rs` (219). Shared per-request context:
+`backend/cursor.rs::CursorContext` — string-first (`word_and_qualifier_at` text scan) with a
+CST bridge for contextual receivers.
+
+## Decisions locked with the user
+
+- **Decomposition:** one spec, three implementation cycles: 6a = shared core + read-only
+  features (go-def, goto-impl, document-highlight); 6b = find-references; 6c = rename.
+- **Rename policy:** rename requires `CstResolved` identity; any `NameScan` residue in the
+  edit set ⇒ typed refusal surfaced as an LSP error with a human-readable reason. Never
+  text-rename on a name-scan source.
+- **Approach:** new classification layer in the CST domain (not an extension of
+  `CursorContext`, not a hover rewrite). `CursorContext` stays for hover; goto-def migrates
+  off it in 6a. The string engine remains the guaranteed fallback for every feature — cold
+  start, unsynced projects, and agent find must keep working exactly as today.
+
+## Goals / non-goals
+
+**Goals**
+
+1. One classifier: `classify_symbol_at(indexer, uri, pos) -> Option<SymbolAtCursor>` in the
+   CST domain, reusing `cursor_node_at`, `lambda_doc_at`, and `CstQuery` resolution.
+2. Typed provenance: `NavigationSource::{CstResolved, NameScan}` on every navigation result
+   path — the fallback is visible in code, rankable, and testable.
+3. 6a: precise jumps + scope-correct highlight. 6b: receiver-verified references without
+   losing recall. 6c: rename that is either right or refuses with a reason.
+4. Existing navigation behavior is the floor: `NameScan` reproduces today's results wherever
+   the CST cannot establish identity.
+
+**Non-goals**
+
+- Hover, document-symbol, workspace-symbols — not in the identity family.
+- Deleting `CursorContext` (hover keeps it; shrinking it is post-6a cleanup, own change).
+- Unifying the string engine's internals (locked non-goal of the parent design).
+- Cross-file type-hierarchy-wide rename semantics (e.g. renaming an override renames the
+  base): follow Kotlin LSP conventions later; 6c renames the exact identity under the
+  cursor and its verified references only, refusing when override relationships make the
+  edit set ambiguous (detected via the existing supertype machinery).
+
+## Design
+
+### Core (built in 6a): `SymbolAtCursor` + `NavigationSource`
+
+```rust
+// indexer/infer/symbol_at_cursor.rs (new module, catalogued in infer/mod.rs)
+pub(crate) struct SymbolAtCursor {
+    pub name: String,
+    pub role: SymbolRole,
+    /// Receiver TYPE for member references (`user.save` → "User"), resolved via
+    /// `CstQuery::expr_type` on the receiver subtree. `None` for bare names.
+    pub receiver_type: Option<String>,
+}
+
+pub(crate) enum SymbolRole {
+    /// The name token of a declaration; `kind` from the declaration node.
+    Declaration { kind: DeclarationKind },   // Class | Function | Property | LambdaParam | …
+    /// An identifier in expression/type position.
+    Reference,
+    /// A segment of an import path (navigation targets the imported symbol).
+    ImportSegment,
+}
+
+pub(crate) enum NavigationSource<T> {
+    /// Identity established from the CST + index: precise, ranked first.
+    CstResolved(T),
+    /// Name-based scan (string engine / rg): today's behavior, visibly labeled.
+    NameScan(T),
+}
+
+pub(crate) fn classify_symbol_at(
+    indexer: &Indexer, uri: &Url, pos: CursorPos,
+) -> Option<SymbolAtCursor>
+```
+
+Classification is one CST pass at the cursor node:
+- **Declaration**: the identifier is the name child of a declaration node
+  (`class_declaration`, `object_declaration`, `function_declaration`, `property_declaration`,
+  parameter, lambda parameter).
+- **Reference**: identifier in expression or type position; if its parent is a
+  `navigation_suffix`, extract the receiver subtree and type it via `CstQuery::expr_type`
+  (the #222/#224 machinery — uri-threaded member lookup included).
+- **ImportSegment**: identifier inside an `import_header` path.
+- **`None` (not a symbol)**: cursor in a string literal (non-interpolated part), comment, or
+  whitespace — navigation features return no result instead of name-scanning strings.
+- Acquisition through `lambda_doc_at`, so mid-typing states classify against the repaired
+  tree; classification never triggers the marker-insertion transform (the cursor sits on an
+  existing token, not a completion gap).
+
+The classifier produces IDENTITY, not locations — each feature keeps its own lookup, keyed
+by that identity, and wraps results in `NavigationSource`.
+
+### 6a — go-def, goto-impl, document-highlight
+
+- **go-def**: `Reference` with `receiver_type` → receiver-typed member lookup (the
+  `method_return_type`/`resolve_member` family) → `CstResolved` jump. Local/lambda-param
+  references → the declaration node found by walking enclosing scopes in the CST.
+  `Declaration` role → the symbol IS the definition (return self-location, matching LSP
+  convention). Anything unresolvable → today's path (index by name + rg), wrapped `NameScan`.
+  Ranking: `CstResolved` results first when both exist.
+- **goto-impl**: same identity feeds the existing subtype lookup; receiver-typed identity
+  filters same-named interfaces.
+- **highlight** (54 lines): for locals/params, highlight only occurrences within the
+  declaration's scope subtree (pure CST walk — no index needed); everything else keeps
+  today's behavior via `NameScan`.
+
+### 6b — find-references
+
+Recall engine unchanged: the name scan (index + rg) still FINDS candidate sites. The
+classifier then VERIFIES each candidate: run `classify_symbol_at` at the candidate position;
+a member reference matches only if its `receiver_type` agrees with the query identity (via
+the existing supertype walk for inherited members); declarations match only their own scope.
+Cost is bounded: one transient parse per candidate FILE (`live_doc_or_parse` reuses
+live/indexed content), candidates only. Unverifiable candidates (parse failed, receiver
+untypeable) are KEPT and labeled `NameScan` — recall never drops below today's. The response
+concatenates `CstResolved` first, then surviving `NameScan` entries.
+
+### 6c — rename
+
+1. Classify the cursor symbol: must be `CstResolved` identity (a `Declaration`, or a
+   `Reference` whose definition resolves uniquely in the workspace). Jar/library-defined
+   symbols refuse ("defined in a library").
+2. Collect 6b's verified reference set. If ANY candidate in the set is `NameScan`
+   (unverifiable), refuse: the edit would gamble.
+3. Override ambiguity: if the symbol participates in an override relationship (existing
+   supertype machinery detects it), refuse with that reason (deferred semantics, see
+   non-goals).
+4. Refusal = LSP request error with a human-readable reason string (Helix shows it in the
+   status line). Success = `WorkspaceEdit` over exactly the verified set.
+
+### Error handling
+
+- Classifier returns `None` → features fall back exactly as today (never an error).
+- Repair-bounded acquisition inherited from `lambda_doc_at`; classification on a broken tree
+  that repair can't fix degrades to `NameScan`, never wrong-identity.
+- Rename refusals are errors BY DESIGN and carry reasons; all other features never error.
+
+### Testing
+
+House decoy for every sub-slice — two classes with identically-named members
+(`User.save()` / `File.save()`):
+- 6a: go-def from `user.save()` hits `User.save` only (decoy: `assert` the `File.save`
+  location is absent); local highlight does not light the same name in another function.
+- 6b: find-refs on `User.save` excludes `File.save` call sites; unverifiable site stays in
+  the result as `NameScan` (recall pin).
+- 6c: rename refuses on an untypeable receiver (assert the error reason), renames exactly
+  the verified set in the clean fixture, refuses on jar symbols and overrides.
+- Cursor in string/comment → no navigation result (noise-kill pin).
+- Existing navigation suites are the floor — `NameScan` parity means they pass unchanged.
+- Live probe per sub-slice on the real project before its merge (go-def on a Compose member
+  chain; find-refs on a same-named workspace member; rename refusal on a jar symbol).

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -19,7 +19,7 @@ impl Backend {
             return Ok(None);
         };
 
-        let response = def::find_definition(&ctx, &*self.indexer, uri, position).await;
+        let response = def::find_definition(&ctx, &self.indexer, uri, position).await;
         Ok(self.rewrite_jar_targets_off_thread(response).await)
     }
 

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -31,12 +31,7 @@ impl Backend {
         let uri = &pp.text_document.uri;
         let position = pp.position;
 
-        let Some(ctx) = CursorContext::build(&self.indexer, uri, position) else {
-            return Ok(None);
-        };
-
-        let response =
-            imp::find_implementation(&ctx.word, &*self.indexer, uri, position.line).await;
+        let response = imp::find_implementation_at(&self.indexer, uri, position).await;
         Ok(self.rewrite_jar_targets_off_thread(response).await)
     }
 

--- a/src/features/definition.rs
+++ b/src/features/definition.rs
@@ -8,6 +8,7 @@ use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, Url};
 
 use crate::backend::cursor::CursorContext;
 use crate::features::traits::{DocumentAccess, SearchAccess, SymbolIndex};
+use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
 use crate::rg;
 
@@ -121,6 +122,33 @@ pub(crate) async fn goto_super_method(
     goto_super_class(index, uri, row).await
 }
 
+// ─── CST-resolved path ────────────────────────────────────────────────────────
+
+/// Classify the identifier under `position` via the CST and, when the CST
+/// gave enough information to trust the result (a declaration, or a
+/// receiver-typed member reference), resolve it to its definition site(s).
+///
+/// Returns `None` — never an error — whenever the CST can't classify the
+/// cursor position, or classification succeeds but only reaches `NameScan`
+/// confidence; both cases mean "fall through to the string-first path below."
+fn try_cst_resolved_definition(
+    indexer: &Indexer,
+    uri: &Url,
+    position: Position,
+) -> Option<GotoDefinitionResponse> {
+    let cursor = crate::types::CursorPos {
+        line: position.line as usize,
+        utf16_col: position.character as usize,
+    };
+    let sym = crate::indexer::classify_symbol_at(indexer, uri, cursor)?;
+    match crate::indexer::resolve_identity(&sym, indexer, uri) {
+        crate::indexer::NavigationSource::CstResolved(defs) if !defs.is_empty() => {
+            locs_to_opt_response(defs.0)
+        }
+        _ => None,
+    }
+}
+
 // ─── Main entry point ─────────────────────────────────────────────────────────
 
 /// Resolve goto-definition for the given cursor context.
@@ -129,10 +157,17 @@ pub(crate) async fn goto_super_method(
 /// direct qualified lookups, and rg fallback — in that priority order.
 pub(crate) async fn find_definition(
     ctx: &CursorContext,
-    index: &(impl SymbolIndex + DocumentAccess + SearchAccess),
+    index: &Indexer,
     uri: &Url,
     position: Position,
 ) -> Option<GotoDefinitionResponse> {
+    // CST-resolved path first: precise for declarations and receiver-typed
+    // member references. Falls through to the string-first path below for
+    // everything the CST can't narrow (locals, untyped receivers, keywords).
+    if let Some(cst_response) = try_cst_resolved_definition(index, uri, position) {
+        return Some(cst_response);
+    }
+
     // `this` → enclosing class definition.
     if ctx.qualifier.is_none() && ctx.word == "this" {
         if let Some(class_name) = index.enclosing_class_at(uri, position.line) {
@@ -193,3 +228,7 @@ pub(crate) async fn find_definition(
     let rg_locs = rg_resolve(index, uri, &ctx.word).await;
     locs_to_opt_response(rg_locs)
 }
+
+#[cfg(test)]
+#[path = "definition_tests.rs"]
+mod tests;

--- a/src/features/definition_tests.rs
+++ b/src/features/definition_tests.rs
@@ -1,0 +1,41 @@
+//! Tests for [`find_definition`] — CST-resolved-first, NameScan-fallback.
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Position, Url};
+
+use crate::backend::cursor::CursorContext;
+use crate::features::definition::find_definition;
+use crate::indexer::Indexer;
+
+/// House decoy: a call-expression receiver (`getUser().save()`). The
+/// string/word-based qualifier extraction (`word_and_qualifier_at`) only
+/// captures a simple identifier immediately before the dot — it can't
+/// capture `getUser()` as a qualifier at all (the char before the dot is
+/// `)`, not an identifier char), so today's path treats `save` as a BARE,
+/// receiver-less reference and falls through to an unqualified same-name
+/// scan that can't distinguish `User.save` from `Admin.save`. The CST path
+/// walks the actual `navigation_expression` and resolves the call
+/// receiver's return type directly, so it must land on `User.save` only.
+#[tokio::test]
+async fn goto_definition_resolves_call_expression_receiver_via_cst() {
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/D.kt").unwrap();
+    let src = "class User { fun save() {} }\n\
+               class Admin { fun save() {} }\n\
+               fun getUser(): User = User()\n\
+               fun f() { getUser().save() }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+    let col = src.lines().nth(3).unwrap().find("save").unwrap() as u32;
+    let ctx = CursorContext::build(&idx, &uri, Position::new(3, col)).unwrap();
+    let response = find_definition(&ctx, &idx, &uri, Position::new(3, col))
+        .await
+        .unwrap();
+    let loc = match response {
+        GotoDefinitionResponse::Scalar(l) => l,
+        other => panic!("expected a single location, got {other:?}"),
+    };
+    assert_eq!(
+        loc.range.start.line, 0,
+        "must jump to User.save, not Admin.save"
+    );
+}

--- a/src/features/highlight.rs
+++ b/src/features/highlight.rs
@@ -3,18 +3,58 @@
 use tower_lsp::lsp_types::{DocumentHighlight, DocumentHighlightKind, Position, Range, Url};
 
 use super::text_utils::{utf16_column, word_byte_offsets};
-use super::traits::{DocumentAccess, SymbolIndex};
+
+/// The narrowest enclosing function/lambda body (or the whole file if
+/// neither exists) containing `node` — the boundary document-highlight
+/// searches within. Coarser than full lexical scoping (doesn't distinguish
+/// nested shadowing), but it NEVER crosses into an unrelated function, which
+/// is the bug this exists to fix.
+fn enclosing_body(node: tree_sitter::Node<'_>) -> tree_sitter::Node<'_> {
+    let mut cur = node;
+    while let Some(parent) = cur.parent() {
+        if matches!(
+            parent.kind(),
+            k if k == crate::queries::KIND_FUN_DECL || k == crate::queries::KIND_LAMBDA_LIT
+        ) {
+            return parent;
+        }
+        cur = parent;
+    }
+    cur
+}
 
 /// Compute all highlight ranges for the symbol under `pos` in `uri`.
 ///
 /// Definition sites are marked as `Write`; all other occurrences as `Read`.
 /// Returns `None` when the cursor is not on a word or the file has no lines.
+///
+/// When the CST can resolve the cursor to a node inside a function/lambda
+/// body, the search is scoped to that body — this is what stops a local
+/// variable in one function from highlighting an unrelated same-named local
+/// in another function. When the CST can't resolve a node (or `index` isn't
+/// a concrete `Indexer`, which the sole production caller always passes),
+/// this falls through to today's whole-file scan exactly.
 pub(crate) fn compute_document_highlight(
     uri: &Url,
-    pos: tower_lsp::lsp_types::Position,
-    index: &(impl SymbolIndex + DocumentAccess),
+    pos: Position,
+    index: &crate::indexer::Indexer,
 ) -> Option<Vec<DocumentHighlight>> {
     let (name, _) = index.word_and_qualifier_at(uri, pos)?;
+    let lines = index.mem_lines_for(uri.as_str())?;
+
+    let scope_range: Option<Range> = (|| {
+        let cursor = crate::types::CursorPos {
+            line: pos.line as usize,
+            utf16_col: pos.character as usize,
+        };
+        let doc = index.live_doc_or_parse(uri)?;
+        let node = crate::indexer::cursor_node_at(&doc, cursor)?;
+        let body = enclosing_body(node);
+        Some(Range::new(
+            Position::new(body.start_position().row as u32, 0),
+            Position::new(body.end_position().row as u32, u32::MAX),
+        ))
+    })();
 
     let decl_lines: std::collections::HashSet<u32> = index
         .definition_locations(&name)
@@ -23,18 +63,23 @@ pub(crate) fn compute_document_highlight(
         .map(|loc| loc.range.start.line)
         .collect();
 
-    let lines = index.mem_lines_for(uri.as_str())?;
     let mut highlights = Vec::new();
 
     for (line_idx, line) in lines.iter().enumerate() {
+        let line_idx = line_idx as u32;
+        if let Some(ref scope) = scope_range {
+            if line_idx < scope.start.line || line_idx > scope.end.line {
+                continue;
+            }
+        }
         for abs in word_byte_offsets(line, &name) {
             let col = utf16_column(&line[..abs]);
             let col_end = col + utf16_column(&name);
             let range = Range::new(
-                Position::new(line_idx as u32, col),
-                Position::new(line_idx as u32, col_end),
+                Position::new(line_idx, col),
+                Position::new(line_idx, col_end),
             );
-            let kind = if decl_lines.contains(&(line_idx as u32)) {
+            let kind = if decl_lines.contains(&line_idx) {
                 DocumentHighlightKind::WRITE
             } else {
                 DocumentHighlightKind::READ
@@ -52,3 +97,7 @@ pub(crate) fn compute_document_highlight(
         Some(highlights)
     }
 }
+
+#[cfg(test)]
+#[path = "highlight_tests.rs"]
+mod tests;

--- a/src/features/highlight.rs
+++ b/src/features/highlight.rs
@@ -4,23 +4,27 @@ use tower_lsp::lsp_types::{DocumentHighlight, DocumentHighlightKind, Position, R
 
 use super::text_utils::{utf16_column, word_byte_offsets};
 
-/// The narrowest enclosing function/lambda body (or the whole file if
-/// neither exists) containing `node` — the boundary document-highlight
-/// searches within. Coarser than full lexical scoping (doesn't distinguish
-/// nested shadowing), but it NEVER crosses into an unrelated function, which
-/// is the bug this exists to fix.
-fn enclosing_body(node: tree_sitter::Node<'_>) -> tree_sitter::Node<'_> {
+/// The narrowest enclosing function/lambda body containing `node` — the
+/// boundary document-highlight searches within. Coarser than full lexical
+/// scoping (doesn't distinguish nested shadowing), but it NEVER crosses into
+/// an unrelated function, which is the bug this exists to fix.
+///
+/// Returns `None` when `node` has no enclosing function/lambda ancestor
+/// (e.g. it's a top-level declaration, or nested only inside a class body) —
+/// callers use this to tell "genuinely local" from "possibly file-wide"
+/// apart, since narrowing to a body is only safe in the former case.
+fn enclosing_body(node: tree_sitter::Node<'_>) -> Option<tree_sitter::Node<'_>> {
     let mut cur = node;
     while let Some(parent) = cur.parent() {
         if matches!(
             parent.kind(),
             k if k == crate::queries::KIND_FUN_DECL || k == crate::queries::KIND_LAMBDA_LIT
         ) {
-            return parent;
+            return Some(parent);
         }
         cur = parent;
     }
-    cur
+    None
 }
 
 /// Compute all highlight ranges for the symbol under `pos` in `uri`.
@@ -42,24 +46,69 @@ pub(crate) fn compute_document_highlight(
     let (name, _) = index.word_and_qualifier_at(uri, pos)?;
     let lines = index.mem_lines_for(uri.as_str())?;
 
-    let scope_range: Option<Range> = (|| {
-        let cursor = crate::types::CursorPos {
-            line: pos.line as usize,
-            utf16_col: pos.character as usize,
-        };
-        let doc = index.live_doc_or_parse(uri)?;
-        let node = crate::indexer::cursor_node_at(&doc, cursor)?;
-        let body = enclosing_body(node);
-        Some(Range::new(
-            Position::new(body.start_position().row as u32, 0),
-            Position::new(body.end_position().row as u32, u32::MAX),
-        ))
-    })();
-
-    let decl_lines: std::collections::HashSet<u32> = index
+    let decl_locations: Vec<_> = index
         .definition_locations(&name)
         .into_iter()
         .filter(|loc| loc.uri == *uri)
+        .collect();
+
+    // Narrowing to the enclosing function/lambda body is only safe when
+    // EVERY declaration site of `name` is itself nested inside some
+    // function/lambda body. A top-level function or class member can
+    // legitimately be referenced from anywhere in the file — narrowing to
+    // the click site's enclosing function would silently drop both the
+    // declaration and any call sites in other functions (task-6 review
+    // finding). If any declaration site has no enclosing body, skip
+    // narrowing entirely and fall back to a whole-file scan for this name.
+    let any_top_level_decl = decl_locations.iter().any(|loc| {
+        (|| -> Option<bool> {
+            let doc = index.live_doc_or_parse(uri)?;
+            let node = crate::indexer::cursor_node_at(&doc, loc.range.start.into())?;
+            // `node` here is the declaration's OWN name identifier (the
+            // `selection_range` the index stores). For a `function_declaration`,
+            // that identifier is a *direct* child of the function_declaration
+            // node it names — the Kotlin `KOTLIN_DEFINITIONS` query captures it
+            // positionally, e.g. `(function_declaration (simple_identifier) @name)`
+            // (see src/queries.rs patterns 7-10), with no field annotation to
+            // distinguish it from an unrelated identifier. But a Kotlin
+            // `function_declaration`'s only direct `simple_identifier` child IS
+            // its own name (parameters live inside a separate
+            // `function_value_parameters` child) — so `node`'s immediate parent
+            // being a FUN_DECL unambiguously means `node` is that function's own
+            // name, not a use nested in its body. Climbing from the bare name
+            // would otherwise immediately "find" the function as its own
+            // enclosing scope, mistaking a top-level `fun foo()` for being
+            // nested inside itself. Start the enclosing-scope search from the
+            // declaration node instead of the name in that case.
+            let decl_node = match node.parent() {
+                Some(p) if p.kind() == crate::queries::KIND_FUN_DECL => p,
+                _ => node,
+            };
+            Some(enclosing_body(decl_node).is_none())
+        })()
+        .unwrap_or(false)
+    });
+
+    let scope_range: Option<Range> = if any_top_level_decl {
+        None
+    } else {
+        (|| {
+            let cursor = crate::types::CursorPos {
+                line: pos.line as usize,
+                utf16_col: pos.character as usize,
+            };
+            let doc = index.live_doc_or_parse(uri)?;
+            let node = crate::indexer::cursor_node_at(&doc, cursor)?;
+            let body = enclosing_body(node)?;
+            Some(Range::new(
+                Position::new(body.start_position().row as u32, 0),
+                Position::new(body.end_position().row as u32, u32::MAX),
+            ))
+        })()
+    };
+
+    let decl_lines: std::collections::HashSet<u32> = decl_locations
+        .iter()
         .map(|loc| loc.range.start.line)
         .collect();
 

--- a/src/features/highlight_tests.rs
+++ b/src/features/highlight_tests.rs
@@ -1,0 +1,33 @@
+use super::compute_document_highlight;
+use crate::indexer::Indexer;
+use tower_lsp::lsp_types::{Position, Url};
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file:///t{path}")).unwrap()
+}
+
+fn indexed_with_live(path: &str, src: &str) -> (Url, Indexer) {
+    let u = uri(path);
+    let idx = Indexer::new();
+    idx.index_content(&u, src);
+    idx.store_live_tree(&u, src);
+    idx.set_live_lines(&u, src);
+    (u, idx)
+}
+
+/// Confirmed bug: a local variable named `total` in one function must not
+/// highlight an unrelated local ALSO named `total` in a different function.
+#[test]
+fn highlight_does_not_cross_function_boundaries() {
+    let src = "fun a() {\n    val total = 1\n    println(total)\n}\n\
+               fun b() {\n    val total = 2\n    println(total)\n}\n";
+    let (u, idx) = indexed_with_live("/H.kt", src);
+    // cursor on `total` inside fn a() (line 2, the println use).
+    let highlights = compute_document_highlight(&u, Position::new(2, 14), &idx).unwrap();
+    assert_eq!(
+        highlights.len(),
+        2,
+        "must highlight only fn a()'s two occurrences, not fn b()'s — got {highlights:?}"
+    );
+    assert!(highlights.iter().all(|h| h.range.start.line <= 2));
+}

--- a/src/features/highlight_tests.rs
+++ b/src/features/highlight_tests.rs
@@ -31,3 +31,30 @@ fn highlight_does_not_cross_function_boundaries() {
     );
     assert!(highlights.iter().all(|h| h.range.start.line <= 2));
 }
+
+/// Confirmed bug (task-6 review finding): a top-level function called from
+/// MULTIPLE functions in the same file must NOT have its highlight narrowed
+/// to the enclosing function of the click site — that silently drops the
+/// declaration site and any call sites in other functions.
+#[test]
+fn highlight_does_not_narrow_top_level_function_used_across_functions() {
+    let src = "fun helper() {\n    println(1)\n}\n\
+               fun a() {\n    helper()\n}\n\
+               fun b() {\n    helper()\n}\n";
+    let (u, idx) = indexed_with_live("/H.kt", src);
+    // cursor on `helper()` call inside fn a() (line 4, col 6).
+    let highlights = compute_document_highlight(&u, Position::new(4, 6), &idx).unwrap();
+    assert_eq!(
+        highlights.len(),
+        3,
+        "must highlight declaration + both call sites, not just the click site — got {highlights:?}"
+    );
+    assert!(
+        highlights.iter().any(|h| h.range.start.line == 0),
+        "declaration on line 0 must not be dropped — got {highlights:?}"
+    );
+    assert!(
+        highlights.iter().any(|h| h.range.start.line == 7),
+        "call site in fn b() on line 7 must not be dropped — got {highlights:?}"
+    );
+}

--- a/src/features/implementation.rs
+++ b/src/features/implementation.rs
@@ -11,12 +11,45 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, SymbolKind, Url};
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, SymbolKind, Url};
 
 use crate::features::definition::locs_to_opt_response;
 use crate::features::traits::{DocumentAccess, SearchAccess, SymbolIndex};
+use crate::indexer::{classify_symbol_at, Indexer, SymbolRole};
 use crate::rg;
-use crate::types::FileData;
+use crate::types::{CursorPos, FileData};
+
+/// Find implementations for the symbol at `position` — CST-resolved first
+/// (works from a CALL SITE via the receiver's type, not just the declaration
+/// line), falling back to the existing name+line path.
+///
+/// Returns `None` — never an error — whenever the CST can't classify the
+/// cursor position, or classification succeeds but doesn't land on a typed
+/// call reference; either case means "fall through to the string-first path
+/// below."
+pub(crate) async fn find_implementation_at(
+    indexer: &Indexer,
+    uri: &Url,
+    position: Position,
+) -> Option<GotoDefinitionResponse> {
+    let cursor = CursorPos {
+        line: position.line as usize,
+        utf16_col: position.character as usize,
+    };
+    if let Some(sym) = classify_symbol_at(indexer, uri, cursor) {
+        if let SymbolRole::Reference {
+            receiver_type: Some(ty),
+            is_call: true,
+        } = &sym.role
+        {
+            if let Some(response) = find_method_implementations(&sym.name, ty, indexer, uri).await {
+                return Some(response);
+            }
+        }
+    }
+    let (word, _) = indexer.word_and_qualifier_at(uri, position)?;
+    find_implementation(&word, indexer, uri, position.line).await
+}
 
 /// Find all implementations/subtypes of the symbol under the cursor at `uri`.
 ///

--- a/src/features/implementation_tests.rs
+++ b/src/features/implementation_tests.rs
@@ -14,9 +14,9 @@
 
 use std::sync::Arc;
 
-use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Url};
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, Url};
 
-use crate::features::implementation::find_implementation;
+use crate::features::implementation::{find_implementation, find_implementation_at};
 use crate::indexer::Indexer;
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -161,6 +161,49 @@ async fn goto_implementation_interface_type_unbroken() {
     assert!(
         files.iter().any(|f| f == "Impl.kt"),
         "Impl.kt must appear (implements IService); got: {:?}",
+        files
+    );
+}
+
+/// Confirmed gap: `find_implementation` only matches a method when the
+/// cursor sits on its own declaration line. Invoking goto-implementation from
+/// a CALL SITE (`service.load()`) must still find the overrides, by using the
+/// receiver's CST-resolved type to identify the declaring interface/class.
+///
+/// The interface/impl sources are deliberately multi-line (like every other
+/// test in this file) rather than crammed onto one line: `extract_detail`
+/// (`src/parser.rs`) is line-index-based, not column-aware, so a method
+/// declared on the SAME source line as its enclosing class's own `{` has its
+/// detail truncated at the class's brace before it ever reaches "override" —
+/// an unrelated pre-existing limitation, not the call-site gap this test
+/// targets.
+///
+/// Asserted via `response_files` (like every other test here) rather than a
+/// literal `GotoDefinitionResponse::Array` match: with exactly one override
+/// site, `locs_to_opt_response` returns `Scalar`, not `Array` (see its match
+/// arms above) — a plain single-implementor scenario, not a response-shape
+/// bug.
+#[tokio::test]
+async fn goto_implementation_from_a_call_site_finds_overrides() {
+    let idx = Indexer::new();
+    let iface_uri = Url::parse("file:///t/IService.kt").unwrap();
+    let impl_uri = Url::parse("file:///t/RealService.kt").unwrap();
+    let call_uri = Url::parse("file:///t/Caller.kt").unwrap();
+    idx.index_content(&iface_uri, "interface IService {\n    fun load()\n}\n");
+    idx.index_content(
+        &impl_uri,
+        "class RealService : IService {\n    override fun load() {}\n}\n",
+    );
+    let call_src = "fun f(service: IService) { service.load() }\n";
+    idx.index_content(&call_uri, call_src);
+    idx.store_live_tree(&call_uri, call_src);
+    let col = call_src.find("load").unwrap() as u32;
+
+    let response = find_implementation_at(&idx, &call_uri, Position::new(0, col)).await;
+    let files = response_files(response);
+    assert!(
+        files.iter().any(|f| f == "RealService.kt"),
+        "RealService.kt (implements IService.load) must appear; got: {:?}",
         files
     );
 }

--- a/src/features/implementation_tests.rs
+++ b/src/features/implementation_tests.rs
@@ -185,16 +185,25 @@ async fn goto_implementation_interface_type_unbroken() {
 /// bug.
 #[tokio::test]
 async fn goto_implementation_from_a_call_site_finds_overrides() {
+    // Real temp-file URIs (like every other test in this file), not
+    // hand-rolled `file:///t/...` ones: `response_files`' `to_file_path()`
+    // requires a drive letter on Windows, which a synthetic driveless URI
+    // never has — the LSP response itself was always correct, only the
+    // test's own filename extraction silently dropped it on that platform.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
     let idx = Indexer::new();
-    let iface_uri = Url::parse("file:///t/IService.kt").unwrap();
-    let impl_uri = Url::parse("file:///t/RealService.kt").unwrap();
-    let call_uri = Url::parse("file:///t/Caller.kt").unwrap();
-    idx.index_content(&iface_uri, "interface IService {\n    fun load()\n}\n");
-    idx.index_content(
-        &impl_uri,
-        "class RealService : IService {\n    override fun load() {}\n}\n",
+    let (_, iface_uri) = write(
+        root,
+        "IService.kt",
+        "interface IService {\n    fun load()\n}\n",
     );
+    idx.index_content(&iface_uri, "interface IService {\n    fun load()\n}\n");
+    let impl_src = "class RealService : IService {\n    override fun load() {}\n}\n";
+    let (_, impl_uri) = write(root, "RealService.kt", impl_src);
+    idx.index_content(&impl_uri, impl_src);
     let call_src = "fun f(service: IService) { service.load() }\n";
+    let (_, call_uri) = write(root, "Caller.kt", call_src);
     idx.index_content(&call_uri, call_src);
     idx.store_live_tree(&call_uri, call_src);
     let col = call_src.find("load").unwrap() as u32;

--- a/src/features/traits.rs
+++ b/src/features/traits.rs
@@ -158,6 +158,7 @@ pub(crate) trait DocumentAccess {
     // TODO(per-rule-5): Split into separate functions (e.g. extract_word and extract_qualifier)
 
     /// Extract the identifier and optional dot-qualifier at `pos`.
+    #[allow(dead_code)]
     fn word_and_qualifier_at(&self, uri: &Url, pos: Position) -> Option<(String, Option<String>)>;
 
     /// Extract just the identifier token at `pos`.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -37,7 +37,8 @@ pub(crate) use self::infer::{
     cst_cursor::{cst_call_info, cst_cursor_is_local_var, cst_outer_call_info, CallInfo},
     cst_lambda::{cursor_node_at, LambdaScopeInfo},
     cst_symbol::{
-        is_call_callee, is_declaration_site, navigation_member_ident, navigation_receiver_node,
+        classify_symbol_at, is_call_callee, is_declaration_site, navigation_member_ident,
+        navigation_receiver_node, resolve_identity, NavigationSource, SymbolAtCursor, SymbolRole,
     },
     deps::{CallableInfo, InferDeps, OuterScopedParams},
     expr_type::infer_expr_type,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -36,6 +36,9 @@ pub(crate) use self::infer::{
     args::{extract_first_arg, find_as_call_arg_type, find_named_param_type_in_sig},
     cst_cursor::{cst_call_info, cst_cursor_is_local_var, cst_outer_call_info, CallInfo},
     cst_lambda::{cursor_node_at, LambdaScopeInfo},
+    cst_symbol::{
+        is_call_callee, is_declaration_site, navigation_member_ident, navigation_receiver_node,
+    },
     deps::{CallableInfo, InferDeps, OuterScopedParams},
     expr_type::infer_expr_type,
     it_this::{

--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -1,0 +1,64 @@
+//! Shared CST identifier classification: declaration-vs-reference, and
+//! receiver/member extraction from a `navigation_expression`.
+//!
+//! Originally written for semantic-token coloring (`semantic_tokens/resolve.rs`);
+//! promoted here because `classify_symbol_at` (the navigation-feature
+//! classifier: go-def, goto-impl, highlight) needs the identical walk —
+//! two independent CST passes answering "declaration or reference?" and
+//! "what's the receiver of this member access?" would drift from each other.
+
+use tree_sitter::Node;
+
+use crate::queries::{
+    KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ, KIND_ENUM_ENTRY, KIND_FUN_DECL,
+    KIND_OBJECT_DECL, KIND_PARAMETER, KIND_SIMPLE_IDENT, KIND_TYPE_ALIAS, KIND_TYPE_IDENT,
+    KIND_TYPE_PARAM, KIND_VAR_DECL,
+};
+
+pub(crate) fn is_declaration_site(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    let pk = parent.kind();
+    if pk == KIND_CLASS_DECL
+        || pk == KIND_OBJECT_DECL
+        || pk == KIND_COMPANION_OBJ
+        || pk == KIND_TYPE_ALIAS
+    {
+        return node.kind() == KIND_TYPE_IDENT;
+    }
+    if pk == KIND_FUN_DECL
+        || pk == KIND_PARAMETER
+        || pk == KIND_ENUM_ENTRY
+        || pk == KIND_VAR_DECL
+        || pk == KIND_CLASS_PARAM
+    {
+        return node.kind() == KIND_SIMPLE_IDENT;
+    }
+    if pk == KIND_TYPE_PARAM {
+        return node.kind() == KIND_SIMPLE_IDENT || node.kind() == KIND_TYPE_IDENT;
+    }
+    false
+}
+
+pub(crate) fn navigation_receiver_node(node: Node<'_>) -> Option<Node<'_>> {
+    (0..node.child_count())
+        .filter_map(|i| node.child(i))
+        .find(|child| child.is_named() && child.kind() != crate::queries::KIND_NAV_SUFFIX)
+}
+
+pub(crate) fn navigation_member_ident(node: Node<'_>) -> Option<Node<'_>> {
+    use crate::indexer::NodeExt;
+    let suffix = node.first_child_of_kind(crate::queries::KIND_NAV_SUFFIX)?;
+    (0..suffix.child_count())
+        .filter_map(|i| suffix.child(i))
+        .find(|child| child.kind() == KIND_SIMPLE_IDENT || child.kind() == KIND_TYPE_IDENT)
+}
+
+pub(crate) fn is_call_callee(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    parent.kind() == crate::queries::KIND_CALL_EXPR
+        && parent.child(0).map(|child| child.id()) == Some(node.id())
+}

--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -16,6 +16,7 @@ use crate::queries::{
     KIND_OBJECT_DECL, KIND_PARAMETER, KIND_SIMPLE_IDENT, KIND_TYPE_ALIAS, KIND_TYPE_IDENT,
     KIND_TYPE_PARAM, KIND_VAR_DECL,
 };
+use crate::resolver::api::Definitions;
 use crate::types::CursorPos;
 use tower_lsp::lsp_types::Url;
 
@@ -199,6 +200,56 @@ pub(crate) fn classify_symbol_at(
     })
 }
 
+/// A definitions lookup result, tagged by how much confidence its identity
+/// carries.
+#[allow(dead_code)] // wiring seam for later navigation-feature tasks (slice 6a, tasks 4-6)
+#[derive(Debug)]
+pub(crate) enum NavigationSource<T> {
+    /// Identity established from the CST + index: precise, ranked first.
+    CstResolved(T),
+    /// Name-based scan: today's behavior, visibly labeled.
+    NameScan(T),
+}
+
+/// Resolve `sym`'s identity to its definition site(s).
+///
+/// `CstResolved` when the CST gave enough information to trust the result
+/// (a declaration is trivially its own definition; a receiver-typed member
+/// reference is looked up ON that type). `NameScan` for everything the CST
+/// couldn't narrow — an untyped receiver, or a bare reference resolved by
+/// today's name-based `find_definition_qualified(name, None, uri)` (which
+/// can span multiple same-named workspace symbols).
+#[allow(dead_code)] // wiring seam for later navigation-feature tasks (slice 6a, tasks 4-6)
+pub(crate) fn resolve_identity(
+    sym: &SymbolAtCursor,
+    indexer: &Indexer,
+    uri: &Url,
+) -> NavigationSource<Definitions> {
+    match &sym.role {
+        SymbolRole::Declaration => NavigationSource::CstResolved(Definitions(
+            indexer.find_definition_qualified(&sym.name, None, uri),
+        )),
+        SymbolRole::Reference {
+            receiver_type: Some(ty),
+            ..
+        } => {
+            let locs = indexer.find_definition_qualified(&sym.name, Some(ty), uri);
+            if locs.is_empty() {
+                NavigationSource::NameScan(Definitions(locs))
+            } else {
+                NavigationSource::CstResolved(Definitions(locs))
+            }
+        }
+        SymbolRole::Reference {
+            receiver_type: None,
+            ..
+        }
+        | SymbolRole::ImportSegment => NavigationSource::NameScan(Definitions(
+            indexer.find_definition_qualified(&sym.name, None, uri),
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -375,5 +426,74 @@ mod tests {
             } => {}
             other => panic!("expected no receiver_type, got {other:?}"),
         }
+    }
+
+    /// House decoy: two classes with an identically-named member. A
+    /// receiver-typed reference must resolve to the RIGHT one only.
+    #[test]
+    fn typed_reference_resolves_to_the_correct_same_named_member() {
+        let src = "class User { fun save() {} }\n\
+                   class File { fun save() {} }\n\
+                   fun f(user: User) { user.save() }\n";
+        let (u, idx) = indexed_with_live("/D.kt", src);
+        let col = src.lines().nth(2).unwrap().find("save").unwrap() as u32;
+        let sym = classify_symbol_at(
+            &idx,
+            &u,
+            CursorPos {
+                line: 2,
+                utf16_col: col as usize,
+            },
+        )
+        .unwrap();
+        let identity = resolve_identity(&sym, &idx, &u);
+        match identity {
+            NavigationSource::CstResolved(defs) => {
+                assert_eq!(defs.len(), 1);
+                assert_eq!(
+                    defs[0].range.start.line, 0,
+                    "must resolve to User.save, not File.save"
+                );
+            }
+            NavigationSource::NameScan(_) => panic!("typed receiver should resolve CST-resolved"),
+        }
+    }
+
+    #[test]
+    fn declaration_resolves_to_its_own_location() {
+        let (u, idx) = indexed_with_live("/D.kt", "class User\n");
+        let sym = classify_symbol_at(
+            &idx,
+            &u,
+            CursorPos {
+                line: 0,
+                utf16_col: 8,
+            },
+        )
+        .unwrap();
+        match resolve_identity(&sym, &idx, &u) {
+            NavigationSource::CstResolved(defs) => assert_eq!(defs.len(), 1),
+            NavigationSource::NameScan(_) => panic!("declaration must be CstResolved"),
+        }
+    }
+
+    #[test]
+    fn untyped_receiver_falls_back_to_name_scan() {
+        let src = "fun f(x: Unknown) { x.save() }\n";
+        let (u, idx) = indexed_with_live("/D.kt", src);
+        let col = src.find("save").unwrap() as u32;
+        let sym = classify_symbol_at(
+            &idx,
+            &u,
+            CursorPos {
+                line: 0,
+                utf16_col: col as usize,
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            resolve_identity(&sym, &idx, &u),
+            NavigationSource::NameScan(_)
+        ));
     }
 }

--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -9,11 +9,18 @@
 
 use tree_sitter::Node;
 
+use crate::indexer::{CstQuery, Indexer, NodeExt, Resolution, ResolveIo};
 use crate::queries::{
-    KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ, KIND_ENUM_ENTRY, KIND_FUN_DECL,
+    KIND_CALL_EXPR, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ, KIND_ENUM_ENTRY,
+    KIND_FUN_DECL, KIND_IDENTIFIER, KIND_IMPORT_HEADER, KIND_NAV_EXPR, KIND_NAV_SUFFIX,
     KIND_OBJECT_DECL, KIND_PARAMETER, KIND_SIMPLE_IDENT, KIND_TYPE_ALIAS, KIND_TYPE_IDENT,
     KIND_TYPE_PARAM, KIND_VAR_DECL,
 };
+use crate::types::CursorPos;
+use tower_lsp::lsp_types::Url;
+
+use super::deps::InferDeps as _;
+use super::speculative::ResolutionDoc;
 
 pub(crate) fn is_declaration_site(node: Node<'_>) -> bool {
     let Some(parent) = node.parent() else {
@@ -48,7 +55,6 @@ pub(crate) fn navigation_receiver_node(node: Node<'_>) -> Option<Node<'_>> {
 }
 
 pub(crate) fn navigation_member_ident(node: Node<'_>) -> Option<Node<'_>> {
-    use crate::indexer::NodeExt;
     let suffix = node.first_child_of_kind(crate::queries::KIND_NAV_SUFFIX)?;
     (0..suffix.child_count())
         .filter_map(|i| suffix.child(i))
@@ -61,4 +67,252 @@ pub(crate) fn is_call_callee(node: Node<'_>) -> bool {
     };
     parent.kind() == crate::queries::KIND_CALL_EXPR
         && parent.child(0).map(|child| child.id()) == Some(node.id())
+}
+
+/// The classified identifier under the cursor, produced by [`classify_symbol_at`].
+#[allow(dead_code)] // wiring seam for later navigation-feature tasks (slice 6a, tasks 3-6)
+#[derive(Debug, Clone)]
+pub(crate) struct SymbolAtCursor {
+    pub name: String,
+    pub role: SymbolRole,
+}
+
+#[allow(dead_code)] // wiring seam for later navigation-feature tasks (slice 6a, tasks 3-6)
+#[derive(Debug, Clone)]
+pub(crate) enum SymbolRole {
+    Declaration,
+    /// `receiver_type` is `Some` only when the reference is a member access
+    /// (`x.name`) AND the receiver's type resolved via `CstQuery::expr_type`.
+    /// `is_call` is true when the reference is the callee of a call_expression.
+    Reference {
+        receiver_type: Option<String>,
+        is_call: bool,
+    },
+    ImportSegment,
+}
+
+/// Classify the identifier under `pos`: declaration, member reference (with
+/// receiver type resolved via the CST where possible), or import segment.
+/// Returns `None` for non-identifier positions (strings, comments,
+/// whitespace) — callers treat that exactly like today's "nothing under the
+/// cursor" case, never an error.
+///
+/// Acquisition goes through `lambda_doc_at` so mid-typing states (an
+/// unclosed brace above the cursor) still classify against a repaired tree.
+/// `lambda_doc_at` gates brace repair on `tree.has_error()` *tree-wide* (see
+/// its docs) — a MISSING-semicolon node anywhere in the file (a common
+/// tree-sitter-kotlin artifact for single-line bodies, e.g. `class User {
+/// val id: Int = 0 }`) trips that gate even when the cursor sits nowhere near
+/// it, and repair then fails to find an enclosing `lambda_literal` and
+/// returns `None`. Unlike the narrower it/this callers, a failed repair isn't
+/// authoritative here: fall back to the unrepaired live/parsed tree so an
+/// unrelated error elsewhere in the file doesn't blind classification at the
+/// cursor.
+#[allow(dead_code)] // wiring seam for later navigation-feature tasks (slice 6a, tasks 3-6)
+pub(crate) fn classify_symbol_at(
+    indexer: &Indexer,
+    uri: &Url,
+    pos: CursorPos,
+) -> Option<SymbolAtCursor> {
+    let resolution = super::speculative::lambda_doc_at(indexer, uri, pos)
+        .or_else(|| indexer.live_doc_or_parse(uri).map(ResolutionDoc::Parsed))?;
+    let doc = resolution.doc();
+    let node = super::cst_lambda::cursor_node_at(doc, pos)?;
+
+    if !matches!(node.kind(), KIND_SIMPLE_IDENT | KIND_TYPE_IDENT) {
+        return None;
+    }
+    let name = node.utf8_text_owned(&doc.bytes)?;
+
+    if is_declaration_site(node) {
+        return Some(SymbolAtCursor {
+            name,
+            role: SymbolRole::Declaration,
+        });
+    }
+
+    // Import path segments are flat `simple_identifier` children of a single
+    // `identifier` node (`import a.b.C` → `identifier(simple_identifier x3)`),
+    // not directly nested one-per-dot — check both the node's parent (in case
+    // the grammar ever emits a bare single-segment import directly under
+    // `import_header`) and its grandparent through that `identifier` wrapper.
+    let is_import_segment = node.parent().is_some_and(|p| {
+        p.kind() == KIND_IMPORT_HEADER
+            || (p.kind() == KIND_IDENTIFIER
+                && p.parent().is_some_and(|gp| gp.kind() == KIND_IMPORT_HEADER))
+    });
+    if is_import_segment {
+        return Some(SymbolAtCursor {
+            name,
+            role: SymbolRole::ImportSegment,
+        });
+    }
+
+    // Member reference: the identifier is the member name of a nav_expr's suffix.
+    if let Some(nav) = node
+        .parent()
+        .and_then(|suffix| (suffix.kind() == KIND_NAV_SUFFIX).then_some(suffix))
+        .and_then(|suffix| suffix.parent())
+    {
+        if nav.kind() == KIND_NAV_EXPR
+            && navigation_member_ident(nav).is_some_and(|m| m.id() == node.id())
+        {
+            let is_call = is_call_callee(nav);
+            // `expr_type` for a parameter/variable receiver echoes back its
+            // syntactic type annotation verbatim (see `infer_ident_type` /
+            // `find_var_type`) without checking that the annotated name is an
+            // actual known type — `x: Unknown` resolves to `Some("Unknown")`
+            // even though `Unknown` is declared nowhere. Gate on
+            // `has_type_definition` so a made-up/unresolvable annotation
+            // doesn't silently masquerade as a real receiver type (house
+            // decoy: `untypeable_receiver_yields_no_receiver_type`).
+            let receiver_type = navigation_receiver_node(nav).and_then(|receiver| {
+                match CstQuery::new(receiver, doc, indexer, uri, ResolveIo::IndexOnly).expr_type() {
+                    Resolution::Resolved(t) if indexer.has_type_definition(t.as_type_str()) => {
+                        Some(t.as_type_str().to_owned())
+                    }
+                    _ => None,
+                }
+            });
+            return Some(SymbolAtCursor {
+                name,
+                role: SymbolRole::Reference {
+                    receiver_type,
+                    is_call,
+                },
+            });
+        }
+    }
+
+    // Bare reference (local var, top-level name, etc.) — no receiver, scope
+    // resolution deferred (see Global Constraints). Callers fall through to
+    // today's NameScan path for these.
+    let is_call = node.parent().is_some_and(|p| {
+        p.kind() == KIND_CALL_EXPR && p.child(0).map(|c| c.id()) == Some(node.id())
+    });
+    Some(SymbolAtCursor {
+        name,
+        role: SymbolRole::Reference {
+            receiver_type: None,
+            is_call,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indexer::Indexer;
+    use tower_lsp::lsp_types::Url;
+
+    fn uri(path: &str) -> Url {
+        Url::parse(&format!("file:///t{path}")).unwrap()
+    }
+
+    fn indexed_with_live(path: &str, src: &str) -> (Url, Indexer) {
+        let u = uri(path);
+        let idx = Indexer::new();
+        idx.index_content(&u, src);
+        idx.store_live_tree(&u, src);
+        (u, idx)
+    }
+
+    #[test]
+    fn classifies_a_class_declaration() {
+        let (u, idx) = indexed_with_live("/D.kt", "class User { val id: Int = 0 }\n");
+        // cursor on "User"
+        let sym = classify_symbol_at(
+            &idx,
+            &u,
+            CursorPos {
+                line: 0,
+                utf16_col: 8,
+            },
+        )
+        .unwrap();
+        assert_eq!(sym.name, "User");
+        assert!(matches!(sym.role, SymbolRole::Declaration));
+    }
+
+    #[test]
+    fn classifies_a_typed_member_reference() {
+        let src = "class User { fun save() {} }\nfun f(user: User) { user.save() }\n";
+        let (u, idx) = indexed_with_live("/D.kt", src);
+        // cursor on "save" in "user.save()"
+        let col = src.lines().nth(1).unwrap().find("save").unwrap() as u32;
+        let sym = classify_symbol_at(
+            &idx,
+            &u,
+            CursorPos {
+                line: 1,
+                utf16_col: col as usize,
+            },
+        )
+        .unwrap();
+        assert_eq!(sym.name, "save");
+        match sym.role {
+            SymbolRole::Reference {
+                receiver_type: Some(t),
+                is_call: true,
+            } => assert_eq!(t, "User"),
+            other => panic!("expected typed call reference, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_symbol_inside_a_string_literal() {
+        let (u, idx) = indexed_with_live("/D.kt", "fun f() { val s = \"User\" }\n");
+        let col = "fun f() { val s = \"".len() as u32;
+        assert!(classify_symbol_at(
+            &idx,
+            &u,
+            CursorPos {
+                line: 0,
+                utf16_col: col as usize
+            }
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn classifies_an_import_segment() {
+        let (u, idx) = indexed_with_live("/D.kt", "import com.example.User\n");
+        let col = "import com.example.".len() as u32;
+        let sym = classify_symbol_at(
+            &idx,
+            &u,
+            CursorPos {
+                line: 0,
+                utf16_col: col as usize,
+            },
+        )
+        .unwrap();
+        assert_eq!(sym.name, "User");
+        assert!(matches!(sym.role, SymbolRole::ImportSegment));
+    }
+
+    /// House decoy: an untypeable receiver must not silently attach a wrong
+    /// or stale receiver_type.
+    #[test]
+    fn untypeable_receiver_yields_no_receiver_type() {
+        let src = "fun f(x: Unknown) { x.save() }\n";
+        let (u, idx) = indexed_with_live("/D.kt", src);
+        let col = src.find("save").unwrap() as u32;
+        let sym = classify_symbol_at(
+            &idx,
+            &u,
+            CursorPos {
+                line: 0,
+                utf16_col: col as usize,
+            },
+        )
+        .unwrap();
+        match sym.role {
+            SymbolRole::Reference {
+                receiver_type: None,
+                ..
+            } => {}
+            other => panic!("expected no receiver_type, got {other:?}"),
+        }
+    }
 }

--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -11,10 +11,10 @@ use tree_sitter::Node;
 
 use crate::indexer::{CstQuery, Indexer, NodeExt, Resolution, ResolveIo};
 use crate::queries::{
-    KIND_CALL_EXPR, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ, KIND_ENUM_ENTRY,
-    KIND_FUN_DECL, KIND_IDENTIFIER, KIND_IMPORT_HEADER, KIND_NAV_EXPR, KIND_NAV_SUFFIX,
-    KIND_OBJECT_DECL, KIND_PARAMETER, KIND_SIMPLE_IDENT, KIND_TYPE_ALIAS, KIND_TYPE_IDENT,
-    KIND_TYPE_PARAM, KIND_VAR_DECL,
+    KIND_BINDING_PATTERN_KIND, KIND_CALL_EXPR, KIND_CLASS_DECL, KIND_CLASS_PARAM,
+    KIND_COMPANION_OBJ, KIND_ENUM_ENTRY, KIND_FUN_DECL, KIND_IDENTIFIER, KIND_IMPORT_HEADER,
+    KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_OBJECT_DECL, KIND_PARAMETER, KIND_SIMPLE_IDENT,
+    KIND_TYPE_ALIAS, KIND_TYPE_IDENT, KIND_TYPE_PARAM, KIND_VAR_DECL,
 };
 use crate::resolver::api::Definitions;
 use crate::types::CursorPos;
@@ -49,6 +49,42 @@ pub(crate) fn is_declaration_site(node: Node<'_>) -> bool {
     false
 }
 
+/// Whether a declaration-site identifier (as classified by
+/// [`is_declaration_site`]) names a symbol `KOTLIN_DEFINITIONS`
+/// (`queries.rs`) actually indexes into `f.symbols`.
+///
+/// Most declaration parents (`class`/`object`/`companion`/`typealias`/`fun`/
+/// `val`/`var`/enum entry) map straight onto a `KOTLIN_DEFINITIONS` pattern.
+/// Three don't:
+/// - `KIND_PARAMETER` — a bare function parameter; never indexed.
+/// - `KIND_TYPE_PARAM` — a generic type parameter (`<T>`); never indexed.
+/// - `KIND_CLASS_PARAM` — a primary-constructor parameter; indexed only when
+///   it carries an explicit `val`/`var` (`KOTLIN_DEFINITIONS` patterns 18/19
+///   require a `binding_pattern_kind` child). Without one it's a plain
+///   constructor parameter, not a property, and stays unindexed.
+///
+/// These three are locally-scoped names a name-based
+/// `find_definition_qualified` lookup can't safely resolve: nothing in the
+/// workspace symbol index anchors the lookup to the cursor's specific
+/// declaration, so it either falls through to `find_local_declaration`'s
+/// unanchored same-file text scan or a full workspace-wide scan. Callers must
+/// treat these as `NameScan`, not `CstResolved`.
+///
+/// Precondition: `is_declaration_site(node)` is `true` (so `node.parent()` is
+/// known to exist and be one of the recognized declaration-parent kinds).
+pub(crate) fn is_indexed_declaration_site(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    match parent.kind() {
+        k if k == KIND_PARAMETER || k == KIND_TYPE_PARAM => false,
+        k if k == KIND_CLASS_PARAM => parent
+            .first_child_of_kind(KIND_BINDING_PATTERN_KIND)
+            .is_some(),
+        _ => true,
+    }
+}
+
 pub(crate) fn navigation_receiver_node(node: Node<'_>) -> Option<Node<'_>> {
     (0..node.child_count())
         .filter_map(|i| node.child(i))
@@ -81,7 +117,15 @@ pub(crate) struct SymbolAtCursor {
 #[allow(dead_code)] // wiring seam for later navigation-feature tasks (slice 6a, tasks 3-6)
 #[derive(Debug, Clone)]
 pub(crate) enum SymbolRole {
-    Declaration,
+    /// `indexed` is `true` when this declaration's name is captured by
+    /// `KOTLIN_DEFINITIONS` (`queries.rs`) — see
+    /// [`is_indexed_declaration_site`] for exactly which node kinds qualify.
+    /// `false` for locally-scoped declaration sites (bare function
+    /// parameters, val/var-less constructor parameters, generic type
+    /// parameters) that never make it into `f.symbols`.
+    Declaration {
+        indexed: bool,
+    },
     /// `receiver_type` is `Some` only when the reference is a member access
     /// (`x.name`) AND the receiver's type resolved via `CstQuery::expr_type`.
     /// `is_call` is true when the reference is the callee of a call_expression.
@@ -128,7 +172,9 @@ pub(crate) fn classify_symbol_at(
     if is_declaration_site(node) {
         return Some(SymbolAtCursor {
             name,
-            role: SymbolRole::Declaration,
+            role: SymbolRole::Declaration {
+                indexed: is_indexed_declaration_site(node),
+            },
         });
     }
 
@@ -226,9 +272,19 @@ pub(crate) fn resolve_identity(
     uri: &Url,
 ) -> NavigationSource<Definitions> {
     match &sym.role {
-        SymbolRole::Declaration => NavigationSource::CstResolved(Definitions(
-            indexer.find_definition_qualified(&sym.name, None, uri),
-        )),
+        SymbolRole::Declaration { indexed } => {
+            let locs = Definitions(indexer.find_definition_qualified(&sym.name, None, uri));
+            // Only declarations `KOTLIN_DEFINITIONS` actually indexes can be
+            // trusted CST-resolved; an unindexed one (bare param, val/var-less
+            // constructor param, type param) falls through to an unanchored
+            // same-file scan or workspace-wide scan — label it NameScan (see
+            // `is_indexed_declaration_site`).
+            if *indexed {
+                NavigationSource::CstResolved(locs)
+            } else {
+                NavigationSource::NameScan(locs)
+            }
+        }
         SymbolRole::Reference {
             receiver_type: Some(ty),
             ..
@@ -282,7 +338,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(sym.name, "User");
-        assert!(matches!(sym.role, SymbolRole::Declaration));
+        assert!(matches!(
+            sym.role,
+            SymbolRole::Declaration { indexed: true }
+        ));
     }
 
     #[test]
@@ -474,6 +533,48 @@ mod tests {
         match resolve_identity(&sym, &idx, &u) {
             NavigationSource::CstResolved(defs) => assert_eq!(defs.len(), 1),
             NavigationSource::NameScan(_) => panic!("declaration must be CstResolved"),
+        }
+    }
+
+    /// Reviewer-reported gap (task-3 review): a bare function parameter is a
+    /// `Declaration` per `is_declaration_site`, but `KOTLIN_DEFINITIONS`
+    /// (`queries.rs`) never indexes plain `parameter` nodes into `f.symbols`
+    /// — only class/object/interface/fun/property/enum-entry/companion/
+    /// type-alias and `val`/`var` constructor params are indexed. A
+    /// name-based lookup for an unindexed declaration falls through to
+    /// `find_local_declaration`'s same-file first-textual-match scan, which
+    /// isn't anchored to the cursor: with two functions that both declare a
+    /// parameter named `id`, the cursor on the SECOND function's `id`
+    /// parameter must not be silently resolved (as `CstResolved`) to the
+    /// FIRST function's `id`.
+    #[test]
+    fn unindexed_param_declaration_is_namescan_not_cst_resolved() {
+        let src = "fun a(id: Int) {}\nfun b(id: String) { println(id) }\n";
+        let (u, idx) = indexed_with_live("/D.kt", src);
+        // cursor on the declaration-site "id" of `b`'s parameter (first
+        // occurrence on line 1 — the parameter, not the `println(id)` usage).
+        let col = src.lines().nth(1).unwrap().find("id").unwrap() as u32;
+        let sym = classify_symbol_at(
+            &idx,
+            &u,
+            CursorPos {
+                line: 1,
+                utf16_col: col as usize,
+            },
+        )
+        .unwrap();
+        assert_eq!(sym.name, "id");
+        assert!(
+            matches!(sym.role, SymbolRole::Declaration { indexed: false }),
+            "expected an unindexed Declaration, got {:?}",
+            sym.role
+        );
+        match resolve_identity(&sym, &idx, &u) {
+            NavigationSource::NameScan(_) => {}
+            NavigationSource::CstResolved(defs) => panic!(
+                "unindexed param declaration must not be CstResolved (got line {:?}, expected NameScan)",
+                defs.first().map(|d| d.range.start.line)
+            ),
         }
     }
 

--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -291,6 +291,67 @@ mod tests {
         assert!(matches!(sym.role, SymbolRole::ImportSegment));
     }
 
+    /// The cursor's own ancestor chain sits inside an `ERROR` node — deeply
+    /// nested unclosed call args (`foo(bar(baz(qux`), not just an unrelated
+    /// MISSING-semicolon artifact elsewhere in the file. `lambda_doc_at`'s
+    /// brace-repair only accepts a candidate whose cursor gains an enclosing
+    /// `lambda_literal`; none of these unclosed parens can ever become one
+    /// (they're call-argument lists, not lambda braces), so repair exhausts
+    /// `MAX_BRACE_REPAIRS` and `lambda_doc_at` returns `None` — the raw-tree
+    /// fallback in `classify_symbol_at` is what actually serves this request.
+    /// Verified empirically (see fix report): `lambda_doc_at` returns `None`
+    /// for this exact snippet/position, and the cursor's ancestor chain is
+    /// `["simple_identifier", "value_argument", "ERROR"]`.
+    ///
+    /// Every check in `classify_symbol_at` after acquiring the doc is an
+    /// exact `node.kind() == ...` match against the identifier's *parent*
+    /// kind; here that parent is `ERROR`, which matches none of them, so the
+    /// function falls closed to the bare-reference case with no fabricated
+    /// receiver/call info — never a wrong classification.
+    #[test]
+    fn safely_degrades_when_cursor_sits_inside_an_error_node() {
+        let src = "class User {\nfun f() {\nif (foo(bar(baz(qux\n";
+        let (u, idx) = indexed_with_live("/D.kt", src);
+        let col = src.lines().nth(2).unwrap().find("qux").unwrap();
+        let pos = CursorPos {
+            line: 2,
+            utf16_col: col,
+        };
+
+        // Empirical precondition: lambda_doc_at must actually fail here, or
+        // this test isn't exercising the raw-tree fallback at all.
+        assert!(
+            super::super::speculative::lambda_doc_at(&idx, &u, pos).is_none(),
+            "expected lambda_doc_at to return None (brace repair exhausted) \
+             so classify_symbol_at's raw-tree fallback is what's under test"
+        );
+
+        // Empirical precondition: the cursor's own node sits inside an ERROR
+        // node, not just somewhere unrelated in the tree.
+        let doc = idx.live_doc_or_parse(&u).unwrap();
+        let node = super::super::cst_lambda::cursor_node_at(&doc, pos).unwrap();
+        assert_eq!(node.kind(), KIND_SIMPLE_IDENT);
+        assert_eq!(node.utf8_text(&doc.bytes).unwrap(), "qux");
+        assert_eq!(node.parent().unwrap().parent().unwrap().kind(), "ERROR");
+
+        // The actual behavior under test: no panic, and no fabricated
+        // classification. `qux`'s immediate parent is `value_argument`
+        // inside the ERROR node — none of is_declaration_site's or the
+        // member-reference branch's exact-kind checks match an ERROR
+        // ancestor, so this falls through to the bare-reference case with
+        // name echoed verbatim and nothing fabricated (no receiver, not
+        // marked as a call).
+        let sym = classify_symbol_at(&idx, &u, pos).expect("falls to bare reference, not None");
+        assert_eq!(sym.name, "qux");
+        match sym.role {
+            SymbolRole::Reference {
+                receiver_type: None,
+                is_call: false,
+            } => {}
+            other => panic!("expected bare, unfabricated reference, got {other:?}"),
+        }
+    }
+
     /// House decoy: an untypeable receiver must not silently attach a wrong
     /// or stale receiver_type.
     #[test]

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -30,6 +30,7 @@ pub(super) mod args;
 pub(super) mod chain;
 pub(super) mod cst_cursor;
 pub(super) mod cst_lambda;
+pub(super) mod cst_symbol;
 pub(super) mod deps;
 pub(super) mod expr_type;
 pub(super) mod it_this;

--- a/src/semantic_tokens/helpers.rs
+++ b/src/semantic_tokens/helpers.rs
@@ -3,12 +3,10 @@
 use tree_sitter::Node;
 
 use crate::queries::{
-    KIND_ANNOTATION, KIND_CLASS_BODY, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ,
-    KIND_CONSTRUCTOR_INVOCATION, KIND_ENUM_CLASS_BODY, KIND_ENUM_ENTRY, KIND_FUN_DECL,
-    KIND_IDENTIFIER, KIND_INTERFACE_BODY, KIND_INTERFACE_DECL, KIND_MODIFIERS,
-    KIND_MULTI_ANNOTATION, KIND_OBJECT_BODY, KIND_OBJECT_DECL, KIND_PARAMETER, KIND_PREFIX_EXPR,
-    KIND_SIMPLE_IDENT, KIND_SOURCE_FILE, KIND_TYPE_ALIAS, KIND_TYPE_IDENT, KIND_TYPE_PARAM,
-    KIND_USER_TYPE, KIND_VAR_DECL,
+    KIND_ANNOTATION, KIND_CLASS_BODY, KIND_CLASS_DECL, KIND_COMPANION_OBJ,
+    KIND_CONSTRUCTOR_INVOCATION, KIND_ENUM_CLASS_BODY, KIND_IDENTIFIER, KIND_INTERFACE_BODY,
+    KIND_INTERFACE_DECL, KIND_MODIFIERS, KIND_MULTI_ANNOTATION, KIND_OBJECT_BODY, KIND_OBJECT_DECL,
+    KIND_PREFIX_EXPR, KIND_SIMPLE_IDENT, KIND_SOURCE_FILE, KIND_TYPE_IDENT, KIND_USER_TYPE,
 };
 
 use super::{RawToken, Source};
@@ -233,32 +231,6 @@ pub(super) fn push_token(
     });
 }
 
-pub(super) fn is_declaration_site(node: Node<'_>) -> bool {
-    let Some(parent) = node.parent() else {
-        return false;
-    };
-    let pk = parent.kind();
-    if pk == KIND_CLASS_DECL
-        || pk == KIND_OBJECT_DECL
-        || pk == KIND_COMPANION_OBJ
-        || pk == KIND_TYPE_ALIAS
-    {
-        return node.kind() == KIND_TYPE_IDENT;
-    }
-    if pk == KIND_FUN_DECL
-        || pk == KIND_PARAMETER
-        || pk == KIND_ENUM_ENTRY
-        || pk == KIND_VAR_DECL
-        || pk == KIND_CLASS_PARAM
-    {
-        return node.kind() == KIND_SIMPLE_IDENT;
-    }
-    if pk == KIND_TYPE_PARAM {
-        return node.kind() == KIND_SIMPLE_IDENT || node.kind() == KIND_TYPE_IDENT;
-    }
-    false
-}
-
 pub(super) fn visit_tree(node: Node<'_>, f: &mut impl FnMut(Node<'_>)) {
     f(node);
     let mut cursor = node.walk();
@@ -356,26 +328,4 @@ pub(super) fn is_navigation_receiver(node: Node<'_>) -> bool {
         && parent
             .named_child(0)
             .is_some_and(|first_child| first_child.id() == node.id())
-}
-
-pub(super) fn navigation_receiver_node(node: Node<'_>) -> Option<Node<'_>> {
-    (0..node.child_count())
-        .filter_map(|i| node.child(i))
-        .find(|child| child.is_named() && child.kind() != crate::queries::KIND_NAV_SUFFIX)
-}
-
-pub(super) fn navigation_member_ident(node: Node<'_>) -> Option<Node<'_>> {
-    use crate::indexer::NodeExt;
-    let suffix = node.first_child_of_kind(crate::queries::KIND_NAV_SUFFIX)?;
-    (0..suffix.child_count())
-        .filter_map(|i| suffix.child(i))
-        .find(|child| child.kind() == KIND_SIMPLE_IDENT || child.kind() == KIND_TYPE_IDENT)
-}
-
-pub(super) fn is_call_callee(node: Node<'_>) -> bool {
-    let Some(parent) = node.parent() else {
-        return false;
-    };
-    parent.kind() == crate::queries::KIND_CALL_EXPR
-        && parent.child(0).map(|child| child.id()) == Some(node.id())
 }

--- a/src/semantic_tokens/params.rs
+++ b/src/semantic_tokens/params.rs
@@ -10,10 +10,9 @@ use crate::queries::{
     KIND_VAR_DECL,
 };
 
-use super::helpers::{
-    child_ident, first_child_of_kind, is_declaration_site, push_token, visit_tree,
-};
+use super::helpers::{child_ident, first_child_of_kind, push_token, visit_tree};
 use super::{type_index, RawToken, Source};
+use crate::indexer::is_declaration_site;
 
 /// Emit PARAMETER tokens for every use of a function parameter within its body.
 pub(super) fn emit_kotlin_param_uses(root: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -16,11 +16,14 @@ use crate::resolver::infer::find_field_type_in_class;
 use crate::Language;
 
 use super::helpers::{
-    is_annotation_reference, is_call_callee, is_declaration_site, is_inside_lambda_parameters,
-    is_named_argument_label, is_navigation_receiver, is_top_level_call_name, is_type_reference,
-    navigation_member_ident, navigation_receiver_node, node_text, push_token, visit_tree,
+    is_annotation_reference, is_inside_lambda_parameters, is_named_argument_label,
+    is_navigation_receiver, is_top_level_call_name, is_type_reference, node_text, push_token,
+    visit_tree,
 };
 use super::{modifier_bit, type_index, RawToken, Source};
+use crate::indexer::{
+    is_call_callee, is_declaration_site, navigation_member_ident, navigation_receiver_node,
+};
 
 /// Walk non-declaration identifiers and resolve them against the index.
 pub(super) fn walk_references(


### PR DESCRIPTION
## What

Slice 6a of the CST resolution unification (spec: `docs/superpowers/specs/2026-07-19-cst-navigation-design.md`, independently critiqued and amended before implementation; plan: `docs/superpowers/plans/2026-07-19-cst-navigation-6a.md`).

**New shared core** (`src/indexer/infer/cst_symbol.rs`):
- Promoted `is_declaration_site`/`navigation_receiver_node`/`navigation_member_ident`/`is_call_callee` out of `semantic_tokens` (reuse, not reinvention — the critique's finding).
- `classify_symbol_at(indexer, uri, pos) -> Option<SymbolAtCursor>`: classifies the cursor as a `Declaration` (with an `indexed: bool` split — see below), a receiver-typed `Reference`, or an `ImportSegment`. Never errors; `None` means "fall through to today's path."
- `resolve_identity(sym, indexer, uri) -> NavigationSource<Definitions>`: turns a classification into `CstResolved` (trustworthy) or `NameScan` (today's behavior, unchanged).

**Wired into three features, each trying the CST path first and falling through unchanged for everything else:**
- **go-to-definition** (`definition.rs`) — receiver-typed member references resolve precisely; a decoy (`getUser().save()` vs a same-named `Admin.save`) proved the string engine is genuinely ambiguous here today and the CST path isn't.
- **goto-implementation** (`implementation.rs`) — **fixes a confirmed pre-existing bug**: invoking goto-implementation from a call site (`service.load()`) returned nothing, because the old code only matched when the cursor sat exactly on the method's declaration line. Now resolves via the call's receiver type.
- **document-highlight** (`highlight.rs`) — **fixes a confirmed pre-existing bug**: highlighting had zero scoping and matched a word across the entire file, so a local variable in one function lit up an unrelated same-named local in another function. Now scopes to the enclosing function/lambda when the CST resolves.

## Review process (subagent-driven, task-scoped gates)

Every one of the 6 implementation tasks went through implement → review → (fix → re-review if needed). Three tasks needed a fix round after review caught a real issue:
- **Task 2** (classifier): added a characterization test proving the raw-tree fallback degrades safely (no fabricated classification) when the cursor sits inside a genuinely broken `ERROR` node — not just a tree-wide-but-unrelated error.
- **Task 3** (`resolve_identity`): the `Declaration` arm was labeling bare function parameters, val/var-less class parameters, and generic type parameters as `CstResolved` even though their name-based lookup is an unanchored same-file scan — reviewer reproduced a concrete wrong-jump case. Fixed by splitting `Declaration` into indexed (safe, `CstResolved`) vs. unindexed-local (`NameScan`).
- **Task 6** (highlight): the initial scoping fix over-corrected — narrowing applied to *any* resolvable identifier, so a top-level function/class called from multiple places in one file lost its other call sites *and* its declaration highlight. Fixed with a per-declaration-site CST check (skip narrowing if any declaration of the name has no enclosing function/lambda), which also surfaced a real Kotlin grammar wrinkle (a function's own name node's immediate parent *is* the `function_declaration`, requiring a parent-kind special case).

## Verification

- 1551 unit tests, clippy dev+release `-D warnings`, e2e smoke.
- Live probe on the real project (Moneta): go-to-definition on `cacheManager.clearAllCaches()`, goto-implementation from that same call site (the exact bug class fixed here), and document-highlight on a local variable — all three correct against the real, fully-scanned workspace.

## Scope and follow-ups (documented, not silent)

- General local-`val`/`var` CST declaration resolution (nested shadowing, destructuring, `when`-bindings) is explicitly deferred — bare local references still go through today's `NameScan` path.
- `lambda_doc_at`'s `has_error()` gate is tree-wide, not cursor-local — an unrelated syntax artifact anywhere in a file can blind classification everywhere in that file. `classify_symbol_at` works around it locally; the two other existing callers (`it_this.rs`, `completion_context.rs`, from slice 4) are untouched and may share the same latent gap. Flagged for a future fix, not blocking here.
- `has_type_definition` (used to gate `receiver_type`) excludes stdlib types (`String`/`Int`/`List`/...) since it only recognizes workspace/jar-indexed class-like symbols — stdlib-typed receivers fall to `NameScan` for now, a completeness gap not a regression.

## Next

Slice 6b (find-references) builds directly on this core. Slice 6c (rename) is gated on 6c's own live-probe measurement of cross-file refusal rate, per the spec's flagged policy question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)