### PR TITLE
feat(references): find-references verification layer (CST slice 6b)

### DIFF
--- a/docs/superpowers/plans/2026-07-20-cst-find-references-6b.md
+++ b/docs/superpowers/plans/2026-07-20-cst-find-references-6b.md
@@ -1,0 +1,810 @@
+# Find-References Verification Layer Implementation Plan (Slice 6b)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a CST-based verification pass over find-references' existing rg-found candidates — proven-unrelated candidates get rejected (tracked, not silently dropped), everything else is labeled `CstResolved`/`NameScan` and kept, recall never regresses.
+
+**Architecture:** A shared `classify_cursor` prologue (extracted from two already-duplicated call sites) feeds a new `receiver_type_agreement` primitive in `resolver/hierarchy.rs` (exact match, or an ascending supertype walk for inherited members). A new `features/references_verify.rs` module runs this per rg-found candidate under one request-scoped IO budget, producing a `VerifiedReferences { kept, rejected }` that `references.rs` flattens to the LSP's `Vec<Location>` at the very end. Spec: `docs/superpowers/specs/2026-07-20-cst-find-references-design.md`.
+
+**Tech Stack:** Rust, tree-sitter, existing `InferDeps`/`classify_symbol_at`/`walk_hierarchy` seams.
+
+## Global Constraints
+
+- Recall is untouched: the existing rg + index candidate search (`rg_locations`, `add_current_file_locations`) produces the exact same candidate set as today. Verification runs strictly after.
+- IO budget covers BOTH a candidate's disk-read fallback (uncommon — candidates are workspace files the scan usually already indexes) AND supertype-walk sidecar IPC (the real risk — `walk_hierarchy` self-limits to 3 JAR promotions per walk, but a find-references request can trigger many walks) under ONE request-scoped counter. Once exhausted, remaining candidates stay `NameScan` — budget exhaustion is never evidence of unrelatedness and must never move a candidate to `rejected`.
+- Only a *proven* `Unrelated` agreement moves a candidate to `rejected`; every other outcome (`Exact`, `Inherited`, `Unresolvable`, budget-skipped) stays in `kept`.
+- `rejected` is test/tracing-only — never surfaced to the LSP client.
+- No abbreviated names (project rule — `ty`, `sym`-as-a-fresh-binding-name, etc. are banned; use `receiver_type`, `symbol`, full words throughout).
+- Gates per commit: `cargo test` + pre-commit clippy. Final: both clippy profiles, e2e smoke, live probe.
+- Branch: `refactor/cst-navigation-6b` (already exists, has 2 commits: the spec and a pre-emptive AGENTS.md compliance fix on 6a's shipped code) → PR to `refactor/unified-resolution`.
+
+---
+
+### Task 1: Extract `classify_cursor`; migrate `definition.rs` and `implementation.rs`
+
+**Files:**
+- Modify: `src/indexer/infer/cst_symbol.rs` (add `classify_cursor`)
+- Modify: `src/indexer.rs` (add to the `cst_symbol::{...}` re-export list)
+- Modify: `src/features/definition.rs:134-150` (`try_cst_resolved_definition`)
+- Modify: `src/features/implementation.rs:30-54` (`find_implementation_at`)
+- Test: existing suites in both files are the neutrality net — no new tests this task.
+
+**Interfaces:**
+- Produces:
+```rust
+// cst_symbol.rs — needs `use tower_lsp::lsp_types::Position;` added to its imports
+pub(crate) fn classify_cursor(
+    indexer: &Indexer,
+    uri: &Url,
+    position: Position,
+) -> Option<SymbolAtCursor>
+```
+
+- [ ] **Step 1: Implement `classify_cursor`**
+
+In `src/indexer/infer/cst_symbol.rs`, add `use tower_lsp::lsp_types::Position;` to the top imports, then add just above `classify_symbol_at`:
+
+```rust
+/// `classify_symbol_at`, but taking an LSP `Position` directly — the
+/// `Position → CursorPos` conversion every navigation-feature call site
+/// otherwise repeats.
+pub(crate) fn classify_cursor(
+    indexer: &Indexer,
+    uri: &Url,
+    position: Position,
+) -> Option<SymbolAtCursor> {
+    classify_symbol_at(
+        indexer,
+        uri,
+        CursorPos {
+            line: position.line as usize,
+            utf16_col: position.character as usize,
+        },
+    )
+}
+```
+
+- [ ] **Step 2: Re-export it**
+
+In `src/indexer.rs`'s `cst_symbol::{...}` re-export line (added in slice 6a), add `classify_cursor` to the list.
+
+- [ ] **Step 3: Migrate `definition.rs`**
+
+Replace `try_cst_resolved_definition`'s body in `src/features/definition.rs`:
+
+```rust
+fn try_cst_resolved_definition(
+    indexer: &Indexer,
+    uri: &Url,
+    position: Position,
+) -> Option<GotoDefinitionResponse> {
+    let sym = crate::indexer::classify_cursor(indexer, uri, position)?;
+    match crate::indexer::resolve_identity(&sym, indexer, uri) {
+        crate::indexer::NavigationSource::CstResolved(defs) if !defs.is_empty() => {
+            locs_to_opt_response(defs.0)
+        }
+        _ => None,
+    }
+}
+```
+
+(Drops the manual `CursorPos` construction entirely — `classify_cursor` does it.)
+
+- [ ] **Step 4: Migrate `implementation.rs`**
+
+In `src/features/implementation.rs`, replace the top of `find_implementation_at`:
+
+```rust
+pub(crate) async fn find_implementation_at(
+    indexer: &Indexer,
+    uri: &Url,
+    position: Position,
+) -> Option<GotoDefinitionResponse> {
+    if let Some(sym) = classify_cursor(indexer, uri, position) {
+        if let SymbolRole::Reference {
+            receiver_type: Some(receiver_type),
+            is_call: true,
+        } = &sym.role
+        {
+            if let Some(response) =
+                find_method_implementations(&sym.name, receiver_type, indexer, uri).await
+            {
+                return Some(response);
+            }
+        }
+    }
+    let (word, _) = indexer.word_and_qualifier_at(uri, position)?;
+    find_implementation(&word, indexer, uri, position.line).await
+}
+```
+
+Update the import line: `use crate::indexer::{classify_cursor, Indexer, SymbolRole};` (drop `classify_symbol_at`, `CursorPos` becomes unused — remove it from the `crate::types::{CursorPos, FileData}` import too if the compiler flags it; `FileData` stays).
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `cargo test --bin kmp-lsp 2>&1 | grep -E "^test result|FAILED"`
+Expected: identical pass count to before this task (pure extraction, zero behavior change) — 1551 passed per the current baseline.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A src/
+git commit -m "refactor(nav): extract classify_cursor — shared Position-taking prologue
+
+definition.rs and implementation.rs both hand-rolled the identical
+Position->CursorPos->classify_symbol_at prologue; slice 6b's own query-
+identity code would have been a third copy (independent-critique finding)."
+```
+
+---
+
+### Task 2: `ReceiverTypeAgreement` + `supertype_chain_contains` + `receiver_type_agreement`
+
+**Files:**
+- Modify: `src/resolver/hierarchy.rs`
+- Test: create `src/resolver/hierarchy_tests.rs`, wire with `#[cfg(test)] #[path = "hierarchy_tests.rs"] mod tests;` at the bottom of `hierarchy.rs` (check whether this file already has a test module — if `hierarchy.rs` currently has none, this is a new file per the project's per-file test convention seen in `implementation_tests.rs`/`highlight_tests.rs`).
+
+**Interfaces:**
+- Consumes: `walk_hierarchy`, `CallerContext` (already in this file); `Indexer::has_type_definition` (via `crate::indexer::InferDeps`, needs importing).
+- Produces:
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReceiverTypeAgreement {
+    Exact,
+    Inherited,
+    Unrelated,
+    Unresolvable,
+}
+
+pub(crate) fn supertype_chain_contains(
+    indexer: &Indexer,
+    candidate_type: &str,
+    candidate_uri: &str,
+    target_type: &str,
+) -> bool
+
+pub(crate) fn receiver_type_agreement(
+    indexer: &Indexer,
+    candidate_type: &str,
+    candidate_uri: &str,
+    target_type: &str,
+) -> ReceiverTypeAgreement
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+// src/resolver/hierarchy_tests.rs
+use super::{receiver_type_agreement, supertype_chain_contains, ReceiverTypeAgreement};
+use crate::indexer::Indexer;
+use tower_lsp::lsp_types::Url;
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file:///t{path}")).unwrap()
+}
+
+fn indexed(path: &str, src: &str) -> (Url, Indexer) {
+    let u = uri(path);
+    let idx = Indexer::new();
+    idx.index_content(&u, src);
+    (u, idx)
+}
+
+#[test]
+fn exact_type_match_is_exact() {
+    let (u, idx) = indexed("/D.kt", "class User\n");
+    assert_eq!(
+        receiver_type_agreement(&idx, "User", u.as_str(), "User"),
+        ReceiverTypeAgreement::Exact
+    );
+}
+
+#[test]
+fn subtype_of_target_is_inherited() {
+    let (u, idx) = indexed("/D.kt", "open class User\nclass DerivedUser : User()\n");
+    assert!(supertype_chain_contains(&idx, "DerivedUser", u.as_str(), "User"));
+    assert_eq!(
+        receiver_type_agreement(&idx, "DerivedUser", u.as_str(), "User"),
+        ReceiverTypeAgreement::Inherited
+    );
+}
+
+#[test]
+fn unrelated_indexed_type_is_unrelated() {
+    let (u, idx) = indexed("/D.kt", "class User\nclass File\n");
+    assert!(!supertype_chain_contains(&idx, "File", u.as_str(), "User"));
+    assert_eq!(
+        receiver_type_agreement(&idx, "File", u.as_str(), "User"),
+        ReceiverTypeAgreement::Unrelated
+    );
+}
+
+#[test]
+fn unindexed_type_is_unresolvable_not_unrelated() {
+    let (u, idx) = indexed("/D.kt", "class User\n");
+    // "Ghost" is never declared anywhere — has_type_definition fails, so we
+    // must NOT claim to have proven it's unrelated to User.
+    assert_eq!(
+        receiver_type_agreement(&idx, "Ghost", u.as_str(), "User"),
+        ReceiverTypeAgreement::Unresolvable
+    );
+}
+
+/// House decoy: a two-level hierarchy — the target is a grandparent, not the
+/// immediate supertype.
+#[test]
+fn transitive_supertype_is_inherited() {
+    let (u, idx) = indexed(
+        "/D.kt",
+        "open class Base\nopen class Middle : Base()\nclass Leaf : Middle()\n",
+    );
+    assert_eq!(
+        receiver_type_agreement(&idx, "Leaf", u.as_str(), "Base"),
+        ReceiverTypeAgreement::Inherited
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --bin kmp-lsp hierarchy 2>&1 | tail -15`
+Expected: compile errors (types/fns not defined).
+
+- [ ] **Step 3: Implement**
+
+Add to `src/resolver/hierarchy.rs` (needs `use crate::indexer::InferDeps;` added to its imports if not already present — check the top of the file first):
+
+```rust
+/// How a candidate receiver's type relates to a target (query) declaring
+/// type. `Exact`/`Inherited` are the two ways a candidate is *proven* to
+/// belong; `Unrelated` is a proven exclusion; `Unresolvable` means the
+/// index doesn't have enough data to prove anything either way (the
+/// candidate type itself isn't indexed) — never treat this as `Unrelated`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReceiverTypeAgreement {
+    Exact,
+    Inherited,
+    Unrelated,
+    Unresolvable,
+}
+
+/// Ascending walk from `candidate_type`: does `target_type` appear among
+/// its supertypes? Same mechanism `resolve_from_class_hierarchy` already
+/// uses for the string engine's inherited-member lookups, applied in
+/// reverse — not "find the member," but "does this ancestor chain contain
+/// that type."
+pub(crate) fn supertype_chain_contains(
+    indexer: &Indexer,
+    candidate_type: &str,
+    candidate_uri: &str,
+    target_type: &str,
+) -> bool {
+    walk_hierarchy(
+        indexer,
+        candidate_type,
+        candidate_uri,
+        CallerContext::default(),
+        12,
+        |_, super_name, _, _| if super_name == target_type { vec![()] } else { vec![] },
+    )
+    .into_iter()
+    .next()
+    .is_some()
+}
+
+/// The full receiver-type-agreement decision: exact match (cheap, no walk),
+/// else — only if `candidate_type` is genuinely indexed, so a negative
+/// result is trustworthy — an ascending supertype walk.
+pub(crate) fn receiver_type_agreement(
+    indexer: &Indexer,
+    candidate_type: &str,
+    candidate_uri: &str,
+    target_type: &str,
+) -> ReceiverTypeAgreement {
+    if candidate_type == target_type {
+        return ReceiverTypeAgreement::Exact;
+    }
+    if !indexer.has_type_definition(candidate_type) {
+        return ReceiverTypeAgreement::Unresolvable;
+    }
+    if supertype_chain_contains(indexer, candidate_type, candidate_uri, target_type) {
+        ReceiverTypeAgreement::Inherited
+    } else {
+        ReceiverTypeAgreement::Unrelated
+    }
+}
+```
+
+- [ ] **Step 4: Run and fix until green**
+
+Run: `cargo test --bin kmp-lsp hierarchy 2>&1 | tail -20`
+If `walk_hierarchy`'s `collect` closure signature doesn't match (check the real signature in this file first — it's `Fn(&Indexer, &str, &str, CallerContext<'_>) -> Vec<T>`, confirm parameter order against the actual file before assuming the sketch above is exactly right), adjust the closure. Use `to_sexp()`-style debugging (print the walk's visited set) if `subtype_of_target_is_inherited` doesn't pass on the first try — check `derive_supertypes`/how `class DerivedUser : User()` gets indexed as a supertype relationship (this is existing, working machinery reused, not new — the test should pass once wired correctly).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/
+git commit -m "feat(resolver): ReceiverTypeAgreement + supertype_chain_contains"
+```
+
+---
+
+### Task 3: `VerifiedReferences` + budgeted per-candidate verification
+
+**Files:**
+- Create: `src/features/references_verify.rs`
+- Modify: `src/features/mod.rs` (or wherever `references` is declared as a module — check the exact declaration site first) to add `mod references_verify;`
+- Test: inline `#[cfg(test)]` module in the new file.
+
+**Interfaces:**
+- Consumes: `classify_cursor` (Task 1), `ReceiverTypeAgreement`/`receiver_type_agreement` (Task 2), `ReceiverType::from_raw` (`crate::resolver::ReceiverType`), `NavigationSource<T>` (`crate::indexer::NavigationSource`).
+- Produces (Task 4 relies on these exact names):
+```rust
+pub(crate) struct VerifiedReferences {
+    pub kept: Vec<crate::indexer::NavigationSource<Location>>,
+    pub rejected: Vec<Location>,
+}
+
+pub(crate) fn verify_candidates(
+    indexer: &Indexer,
+    query_declaring_type: Option<&str>,
+    candidates: Vec<Location>,
+) -> VerifiedReferences
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+//! Per-candidate CST verification for find-references — see
+//! `docs/superpowers/specs/2026-07-20-cst-find-references-design.md`.
+
+use tower_lsp::lsp_types::{Location, Position, Range, Url};
+
+use crate::indexer::{Indexer, NavigationSource};
+use crate::resolver::{receiver_type_agreement, ReceiverType, ReceiverTypeAgreement};
+
+/// Per-request cap on IO-costed verification steps (a candidate's file
+/// needing a fresh disk read, or a supertype walk that may spend blocking
+/// JAR-sidecar IPC). Once exhausted, remaining candidates stay `NameScan`
+/// unverified — never dropped, never rejected on budget grounds alone.
+const MAX_VERIFICATION_IO_OPERATIONS: usize = 48;
+
+pub(crate) struct VerifiedReferences {
+    pub kept: Vec<NavigationSource<Location>>,
+    pub rejected: Vec<Location>,
+}
+
+pub(crate) fn verify_candidates(
+    indexer: &Indexer,
+    query_declaring_type: Option<&str>,
+    candidates: Vec<Location>,
+) -> VerifiedReferences {
+    let Some(query_declaring_type) = query_declaring_type else {
+        // No query identity — every candidate is exactly today's behavior.
+        return VerifiedReferences {
+            kept: candidates.into_iter().map(NavigationSource::NameScan).collect(),
+            rejected: Vec::new(),
+        };
+    };
+    let query_declaring_type = ReceiverType::from_raw(query_declaring_type.to_owned()).leaf;
+
+    let mut kept = Vec::new();
+    let mut rejected = Vec::new();
+    let mut io_budget = MAX_VERIFICATION_IO_OPERATIONS;
+
+    for candidate in candidates {
+        if io_budget == 0 {
+            kept.push(NavigationSource::NameScan(candidate));
+            continue;
+        }
+        let file_already_indexed = indexer.files.contains_key(candidate.uri.as_str())
+            || indexer.live_lines.contains_key(candidate.uri.as_str());
+        if !file_already_indexed {
+            io_budget -= 1;
+        }
+        let Some(symbol) = crate::indexer::classify_symbol_at(
+            indexer,
+            &candidate.uri,
+            crate::types::CursorPos {
+                line: candidate.range.start.line as usize,
+                utf16_col: candidate.range.start.character as usize,
+            },
+        ) else {
+            kept.push(NavigationSource::NameScan(candidate));
+            continue;
+        };
+        match &symbol.role {
+            crate::indexer::SymbolRole::Reference {
+                receiver_type: Some(receiver_type),
+                ..
+            } => {
+                let candidate_type = ReceiverType::from_raw(receiver_type.clone()).leaf;
+                // The supertype walk (Inherited case) may spend sidecar IPC —
+                // charge it against the same budget before running it.
+                if io_budget == 0 {
+                    kept.push(NavigationSource::NameScan(candidate));
+                    continue;
+                }
+                io_budget -= 1;
+                match receiver_type_agreement(
+                    indexer,
+                    &candidate_type,
+                    candidate.uri.as_str(),
+                    &query_declaring_type,
+                ) {
+                    ReceiverTypeAgreement::Exact | ReceiverTypeAgreement::Inherited => {
+                        kept.push(NavigationSource::CstResolved(candidate));
+                    }
+                    ReceiverTypeAgreement::Unrelated => rejected.push(candidate),
+                    ReceiverTypeAgreement::Unresolvable => {
+                        kept.push(NavigationSource::NameScan(candidate));
+                    }
+                }
+            }
+            crate::indexer::SymbolRole::Declaration { .. } => {
+                // Verified by exact (name, enclosing class) match — see
+                // Task 3 Step 3's full implementation; the initial RED test
+                // below only exercises the Reference path.
+                kept.push(NavigationSource::NameScan(candidate));
+            }
+            _ => kept.push(NavigationSource::NameScan(candidate)),
+        }
+    }
+
+    VerifiedReferences { kept, rejected }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uri(path: &str) -> Url {
+        Url::parse(&format!("file:///t{path}")).unwrap()
+    }
+
+    fn location(uri: &Url, line: u32, col_start: u32, col_end: u32) -> Location {
+        Location {
+            uri: uri.clone(),
+            range: Range::new(Position::new(line, col_start), Position::new(line, col_end)),
+        }
+    }
+
+    /// House decoy: a candidate on `File.save()` must be REJECTED (present
+    /// in `rejected`, absent from `kept`) when the query's declaring type
+    /// is `User`.
+    #[test]
+    fn unrelated_candidate_is_rejected_not_dropped_silently() {
+        let src = "class User { fun save() {} }\n\
+                   class File { fun save() {} }\n\
+                   fun f(file: File) { file.save() }\n";
+        let u = uri("/D.kt");
+        let idx = Indexer::new();
+        idx.index_content(&u, src);
+        idx.store_live_tree(&u, src);
+        let col = src.lines().nth(2).unwrap().find("save").unwrap() as u32;
+        let candidate = location(&u, 2, col, col + 4);
+
+        let result = verify_candidates(&idx, Some("User"), vec![candidate.clone()]);
+        assert!(result.kept.is_empty(), "must not be kept, got {:?}", result.kept.len());
+        assert_eq!(result.rejected, vec![candidate], "must be in rejected, not silently absent");
+    }
+
+    /// House decoy, positive: an inherited-member reference through a
+    /// subtype instance must be kept as `CstResolved`.
+    #[test]
+    fn inherited_candidate_is_kept_as_cst_resolved() {
+        let src = "open class User { fun save() {} }\n\
+                   class DerivedUser : User()\n\
+                   fun f(derived: DerivedUser) { derived.save() }\n";
+        let u = uri("/D.kt");
+        let idx = Indexer::new();
+        idx.index_content(&u, src);
+        idx.store_live_tree(&u, src);
+        let col = src.lines().nth(2).unwrap().find("save").unwrap() as u32;
+        let candidate = location(&u, 2, col, col + 4);
+
+        let result = verify_candidates(&idx, Some("User"), vec![candidate.clone()]);
+        assert!(result.rejected.is_empty());
+        assert!(matches!(
+            result.kept.as_slice(),
+            [NavigationSource::CstResolved(loc)] if *loc == candidate
+        ));
+    }
+
+    #[test]
+    fn no_query_identity_passes_every_candidate_through_as_name_scan() {
+        let u = uri("/D.kt");
+        let idx = Indexer::new();
+        let candidate = location(&u, 0, 0, 4);
+        let result = verify_candidates(&idx, None, vec![candidate.clone()]);
+        assert!(result.rejected.is_empty());
+        assert!(matches!(
+            result.kept.as_slice(),
+            [NavigationSource::NameScan(loc)] if *loc == candidate
+        ));
+    }
+
+    /// Budget decoy: once the IO budget is exhausted, remaining candidates
+    /// stay in `kept` as `NameScan` — never moved to `rejected`, even when
+    /// they WOULD have been proven unrelated with more budget.
+    #[test]
+    fn budget_exhaustion_never_rejects_only_skips_verification() {
+        let src = "class User { fun save() {} }\nclass File { fun save() {} }\n";
+        let u = uri("/D.kt");
+        let idx = Indexer::new();
+        idx.index_content(&u, src);
+        idx.store_live_tree(&u, src);
+        // Many candidates on unindexed files so every one costs a disk-read
+        // budget unit; with MAX_VERIFICATION_IO_OPERATIONS candidates all
+        // needing 2 units each (disk read + agreement check), the tail
+        // exhausts the budget.
+        let candidates: Vec<Location> = (0..(MAX_VERIFICATION_IO_OPERATIONS as u32 + 5))
+            .map(|line| location(&u, line, 0, 4))
+            .collect();
+        let result = verify_candidates(&idx, Some("User"), candidates.clone());
+        assert!(
+            result.rejected.len() < candidates.len(),
+            "budget exhaustion must leave some candidates unverified, not reject them all"
+        );
+        assert_eq!(
+            result.kept.len() + result.rejected.len(),
+            candidates.len(),
+            "no candidate may vanish — every one is either kept or rejected"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --bin kmp-lsp references_verify 2>&1 | tail -20`
+Expected: compile errors first (module not registered / imports not resolving), then real assertion failures once it compiles.
+
+- [ ] **Step 3: Register the module and implement the Declaration-role verification branch**
+
+Add `mod references_verify;` to wherever `mod references;` is declared (grep `mod references;` in `src/features.rs` or `src/features/mod.rs` first to find the exact spot, and match its visibility — likely `pub(crate) mod references_verify;` alongside the sibling).
+
+Replace the `SymbolRole::Declaration` arm's placeholder from Step 1 with the real check: a declaration-role candidate is kept as `CstResolved` only when its own enclosing class matches the query's declaring type (both already normalized), otherwise it's a different declaration and is treated as `Unresolvable` (kept, not rejected — this is a *weaker* signal than a proven type mismatch, since two same-named unrelated declarations aren't the "wrong receiver type" case `ReceiverTypeAgreement` models; err toward keeping, per the "only proven Unrelated rejects" global constraint):
+
+```rust
+            crate::indexer::SymbolRole::Declaration { .. } => {
+                let enclosing_class = indexer.enclosing_class_at(&candidate.uri, candidate.range.start.line);
+                let matches_query = enclosing_class
+                    .as_deref()
+                    .map(|class_name| ReceiverType::from_raw(class_name.to_owned()).leaf)
+                    == Some(query_declaring_type.clone());
+                if matches_query {
+                    kept.push(NavigationSource::CstResolved(candidate));
+                } else {
+                    kept.push(NavigationSource::NameScan(candidate));
+                }
+            }
+```
+
+(`indexer.enclosing_class_at` is already used elsewhere in this codebase — `src/features/definition.rs` — confirm the exact trait/inherent-method path compiles; it's available directly on `&Indexer`.)
+
+- [ ] **Step 4: Run and fix until green**
+
+Run: `cargo test --bin kmp-lsp references_verify 2>&1 | tail -25`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/
+git commit -m "feat(references): VerifiedReferences + budgeted per-candidate verification"
+```
+
+---
+
+### Task 4: Wire into `find_references_with_qualifier`
+
+**Files:**
+- Modify: `src/features/references.rs` (`find_references_with_qualifier`)
+- Modify: `src/backend/handlers.rs` (the one production call site, ~line 55)
+- Modify: `src/features/references_tests.rs` (27 call sites — mechanical signature update)
+
+**Interfaces:**
+- Consumes: `classify_cursor` (Task 1), `verify_candidates`/`VerifiedReferences` (Task 3).
+- Produces: `find_references_with_qualifier`'s signature changes from `line: u32` to `position: Position` (the 4th parameter) — everywhere else unchanged.
+
+- [ ] **Step 1: Change the signature and thread `position` through**
+
+In `src/features/references.rs`, change:
+
+```rust
+pub(crate) async fn find_references_with_qualifier(
+    name: &str,
+    qualifier: Option<&str>,
+    uri: &Url,
+    line: u32,
+    include_decl: bool,
+    index: &(impl SymbolIndex + DocumentAccess + ScopeQuery + SearchAccess + Send + Sync),
+) -> Vec<Location> {
+```
+
+to:
+
+```rust
+pub(crate) async fn find_references_with_qualifier(
+    name: &str,
+    qualifier: Option<&str>,
+    uri: &Url,
+    position: Position,
+    include_decl: bool,
+    index: &(impl SymbolIndex + DocumentAccess + ScopeQuery + SearchAccess + Send + Sync),
+) -> Vec<Location> {
+    let line = position.line;
+```
+
+as the function's first line (everything below that already uses `line` keeps compiling unchanged — pure rename-and-derive, verify by reading the rest of the function body for every existing `line` use before assuming nothing else needs touching).
+
+At the very end of the function, after the existing `add_current_file_locations` call (which currently returns `locations` directly), insert the verification pass. Read the function's current tail (the last ~10 lines, after `let mut locations = rg_locations(...)`) to see the exact variable name and structure before editing — the sketch below assumes the final local is named `locations: Vec<Location>`:
+
+```rust
+    let query_declaring_type = match crate::indexer::classify_cursor(index_as_indexer, uri, position) {
+        // Note: `index` here is the generic trait-bounded parameter — this
+        // function needs a concrete `&Indexer` for classify_cursor. Check
+        // whether `index` in THIS function is already `&Indexer` (it may be,
+        // since `find_references_with_qualifier`'s only production caller
+        // passes `&*self.indexer`) or whether the generic bound needs the
+        // same simplification Tasks 4/5/6 of slice 6a already applied to
+        // definition.rs/implementation.rs/highlight.rs — grep
+        // `impl SymbolIndex for` / `impl DocumentAccess for` /
+        // `impl ScopeQuery for` / `impl SearchAccess for` across src/ first;
+        // if Indexer is still the only implementor (it was for the other
+        // three traits as of 6a), simplify this function's signature to a
+        // concrete `index: &Indexer` parameter instead of threading a
+        // second parameter — same precedent, same reasoning.
+        Some(symbol) => match &symbol.role {
+            crate::indexer::SymbolRole::Declaration { .. } => index_as_indexer.enclosing_class_at(uri, line),
+            crate::indexer::SymbolRole::Reference { receiver_type: Some(receiver_type), .. } => {
+                Some(receiver_type.clone())
+            }
+            _ => None,
+        },
+        None => None,
+    };
+
+    let verified = crate::features::references_verify::verify_candidates(
+        index_as_indexer,
+        query_declaring_type.as_deref(),
+        locations,
+    );
+    let mut resolved_first: Vec<Location> = Vec::with_capacity(verified.kept.len());
+    let mut name_scanned: Vec<Location> = Vec::new();
+    for source in verified.kept {
+        match source {
+            crate::indexer::NavigationSource::CstResolved(location) => resolved_first.push(location),
+            crate::indexer::NavigationSource::NameScan(location) => name_scanned.push(location),
+        }
+    }
+    resolved_first.append(&mut name_scanned);
+    resolved_first
+```
+
+Resolve the `index_as_indexer` placeholder per the comment above during implementation: either the function already has concrete `&Indexer` access, or its signature needs simplifying — investigate and document the decision in the task report, matching how Tasks 4/5/6 of slice 6a each investigated and recorded this same question.
+
+- [ ] **Step 2: Update the backend call site**
+
+In `src/backend/handlers.rs` (~line 55), change:
+
+```rust
+        let locations = crate::features::references::find_references_with_qualifier(
+            &ctx.word,
+            ctx.qualifier.as_deref(),
+            uri,
+            position.line,
+            params.context.include_declaration,
+            &*self.indexer,
+        )
+        .await;
+```
+
+to pass `position` instead of `position.line`:
+
+```rust
+        let locations = crate::features::references::find_references_with_qualifier(
+            &ctx.word,
+            ctx.qualifier.as_deref(),
+            uri,
+            position,
+            params.context.include_declaration,
+            &*self.indexer,
+        )
+        .await;
+```
+
+- [ ] **Step 3: Mechanically update the 27 test call sites**
+
+Run: `grep -n "find_references_with_qualifier(" src/features/references_tests.rs` to get the exact list. For each call site, the argument that was `line_number` (a bare `u32` literal or variable, e.g. `1`, `3`, `4`) becomes `Position::new(line_number, 0)` — column 0 is a safe, behavior-preserving default: these tests predate query-identity classification, and `classify_cursor` at column 0 on a line written for a DIFFERENT purpose (locating an rg scope, not landing precisely on the queried identifier) will typically classify nothing useful, so `query_declaring_type` comes back `None` and verification passes every candidate through unchanged — exactly what these tests currently assert. Add `use tower_lsp::lsp_types::Position;` to `references_tests.rs`'s imports if not already present (it likely already imports `Position` given the file uses `Location`/`Range` — check first).
+
+This is mechanical (find each `, <number>,` 4th-argument slot, wrap it) — dispatch to a subagent with these exact instructions rather than hand-editing 27 sites, or use Serena's `replace_content` for a systematic regex-driven pass per the project's own tooling preference (see `AGENTS.md`).
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `cargo test --bin kmp-lsp 2>&1 | grep -E "^test result|FAILED"`
+Expected: identical pass count to before this task — the 27 existing tests assert on recall (candidate presence), which is untouched; only labeling/filtering changed, and none of these fixtures have a query-identity-classifiable cursor precise enough to trigger a rejection.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/
+git commit -m "feat(references): wire CST verification into find_references_with_qualifier"
+```
+
+---
+
+### Task 5: End-to-end house decoys at the `find_references_with_qualifier` level
+
+**Files:**
+- Modify: `src/features/references_tests.rs`
+
+**Interfaces:** none new — pure integration tests over Task 4's wiring.
+
+- [ ] **Step 1: Write the tests**
+
+```rust
+/// End-to-end house decoy: find-references on `User.save` (invoked from a
+/// call site) must exclude `File.save()`'s call site entirely from the
+/// returned Vec<Location> — the actual precision proof at the public API
+/// boundary, not just verify_candidates' internal VerifiedReferences.
+#[tokio::test]
+async fn find_references_excludes_unrelated_same_named_member() {
+    let idx = Indexer::new();
+    let user_uri = Url::parse("file:///t/User.kt").unwrap();
+    let file_uri = Url::parse("file:///t/File.kt").unwrap();
+    let caller_uri = Url::parse("file:///t/Caller.kt").unwrap();
+    idx.index_content(&user_uri, "class User { fun save() {} }\n");
+    idx.index_content(&file_uri, "class File { fun save() {} }\n");
+    let caller_src = "fun f(user: User, file: File) {\n    user.save()\n    file.save()\n}\n";
+    idx.index_content(&caller_uri, caller_src);
+    idx.store_live_tree(&caller_uri, caller_src);
+    let col = caller_src.lines().nth(1).unwrap().find("save").unwrap() as u32;
+
+    let locations = find_references_with_qualifier(
+        "save",
+        None,
+        &caller_uri,
+        Position::new(1, col),
+        false,
+        &idx,
+    )
+    .await;
+
+    assert!(
+        locations.iter().all(|location| location.uri != file_uri || location.range.start.line != 2),
+        "File.save() call site must not appear; got: {:?}",
+        locations
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify failure or success**
+
+Run: `cargo test --bin kmp-lsp find_references_excludes_unrelated 2>&1 | tail -15`
+This is RED-first in spirit but may already pass depending on whether rg's own scope narrowing happens to separate `User.kt` and `File.kt` for this fixture (both are separate files with no shared package/import linking them to `Caller.kt`'s bare-word `save` query) — if it passes immediately, that's fine (it still pins the end-to-end behavior); if it's genuinely RED, that confirms the wiring is load-bearing for this exact scenario. Record which in the task report either way — do not weaken the assertion to force a RED result artificially.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A src/
+git commit -m "test(references): end-to-end house decoy for unrelated-member exclusion"
+```
+
+---
+
+### Task 6: Gates, live probe, PR
+
+- [ ] **Step 1:** `cargo test 2>&1 | tail -5 && cargo clippy --all-targets -- -D warnings 2>&1 | tail -2 && cargo clippy --release --all-targets -- -D warnings 2>&1 | tail -2 && cargo test --test lsp_smoke 2>&1 | tail -3`
+
+- [ ] **Step 2:** Build (`cargo build`) and live-probe on Moneta (adapt `scratchpad/lsp_probe_nav6a.py`'s harness): find-references on a same-named member across two unrelated real classes in the project, and on an inherited member accessed through a subtype instance. BIN must point at the worktree `target/debug/kmp-lsp`.
+
+- [ ] **Step 3:** Push, open PR → `refactor/unified-resolution`. PR body: what shipped (verification layer + the classify_cursor extraction that came out of the pre-implementation critique), the typed rejection trail, the IO budget rationale, decoy results, probe results.
+
+- [ ] **Step 4:** Ledger entry + memory update. Note: 6c (rename) is next, gated on 6c's own live-probe measurement of cross-file refusal rate per the spec's flagged policy question (F5 in the original slice-6 critique).
+
+## Self-review notes
+
+- Spec coverage: "Shared prologue" = Task 1; "Type normalization" + "Verification outcome" = Task 2; "Per-candidate verification" + "Result type" = Task 3; "Query identity" + wiring = Task 4; "Testing" section's house/budget decoys = Tasks 3 (unit-level) and 5 (end-to-end); live probe = Task 6.
+- Type consistency: `ReceiverTypeAgreement`/`supertype_chain_contains`/`receiver_type_agreement` (Task 2) used identically in Task 3; `VerifiedReferences`/`verify_candidates` (Task 3) used identically in Task 4; `classify_cursor` (Task 1) used in Tasks 1, 3 (indirectly via `classify_symbol_at` for per-candidate, which intentionally does NOT go through `classify_cursor` since candidates start from `Location`/`Range`, not an LSP `Position` — this is correct, not an inconsistency: `classify_cursor` exists specifically for the `Position`-shaped call sites).
+- Known judgment points flagged for the implementer: Task 4 Step 1's generic-bound-vs-concrete-`Indexer` question for `find_references_with_qualifier` (same investigate-and-decide pattern as slice 6a Tasks 4-6); Task 4's CstResolved-first ordering implementation is sketched loosely on purpose — any clear implementation satisfying "resolved first, scanned after" is acceptable, avoid abbreviated names in whatever shape is chosen; Task 5's RED-vs-already-green uncertainty is called out explicitly rather than papered over.

--- a/docs/superpowers/specs/2026-07-20-cst-find-references-design.md
+++ b/docs/superpowers/specs/2026-07-20-cst-find-references-design.md
@@ -3,7 +3,8 @@
 Status: **approved design** (brainstormed with the user 2026-07-20; rechecked twice against
 `AGENTS.md` and the parent CST design's "Type-driven correctness" section — once for this
 design, once for slice 6a's already-shipped code, surfacing two real fixes applied ahead of
-this slice, see "Retrofit" below). Slice 6b of
+this slice; independently critiqued and amended 3× before implementation, see "Critique
+findings applied" below). Slice 6b of
 [CST resolution unification](2026-06-30-cst-resolution-unification-design.md), continuing
 [slice 6's navigation design](2026-07-19-cst-navigation-design.md). Branch:
 `refactor/cst-navigation-6b` off `refactor/unified-resolution` (post-#227).
@@ -18,6 +19,38 @@ identity verification — two unrelated classes with a same-named member (`User.
 `File.save()`) can both surface in one `save` query if rg's scope narrowing doesn't separate
 them, exactly the class of false positive the CST classifier built in 6a exists to eliminate
 for go-to-definition, goto-implementation, and highlight.
+
+## Critique findings applied
+
+An independent adversarial critique (before implementation, same discipline as slices 4 and
+6a) verified every claim in this spec against the actual code and found three issues, now
+folded into the design below:
+
+1. **The original "Retrofit" goal was dropped — its motivating scenario is unreachable.**
+   The critique traced two independent layers that already prevent a generic-typed raw string
+   from ever reaching `resolve_identity`'s `Reference` arm: `classify_symbol_at`'s own
+   `has_type_definition` gate does an exact-string lookup that a `"List<String>"`-shaped type
+   would already fail (falling to `receiver_type: None` before `resolve_identity` runs at
+   all), and *upstream* of that, `infer_ident_type` (`indexer/infer/expr_type.rs`) already
+   strips generics before the type string is produced, with a comment explaining exactly why.
+   6a has no bug here to retrofit. `ReceiverType::from_raw` is still reused for normalization
+   in 6b's own new comparison code (dotted nested types, trailing `?`), just not framed as
+   fixing a pre-existing defect.
+2. **Query-identity classification would have been a third hand-rolled copy of the same
+   prologue.** `definition.rs::try_cst_resolved_definition` and
+   `implementation.rs::find_implementation_at` (both slice 6a) already open with the identical
+   `Position → CursorPos` conversion + `classify_symbol_at` call + `SymbolRole` match. 6b adds
+   a shared `classify_cursor(indexer, uri, position) -> Option<SymbolAtCursor>` helper in
+   `cst_symbol.rs` and migrates all three call sites onto it — consistent with how slice 6's
+   own design already named and extracted `resolve_identity`/`local_scope_occurrences` for the
+   identical reason.
+3. **Rejected candidates were being silently dropped with no typed trace.** The grandparent
+   design's "Type-driven correctness" rule #1 and slice 6's own "typed provenance ... testable"
+   goal both argue against a *proven* fact (this candidate belongs to an unrelated type)
+   disappearing into array-absence, indistinguishable from a future regression that
+   misclassifies an `Inherited` candidate as `Unrelated`. The verification pass now produces a
+   typed audit trail for rejections (see "Result type" below) so exclusion is a directly
+   assertable fact, not an inference from what's missing.
 
 ## Decisions locked with the user
 
@@ -39,11 +72,13 @@ for go-to-definition, goto-implementation, and highlight.
 
 1. Verify each rg-found candidate's identity via `classify_symbol_at` (reused, unchanged) +
    a new receiver-type agreement check, budgeted on IO.
-2. Reject candidates the CST *proves* belong to an unrelated type — the actual precision gain.
+2. Reject candidates the CST *proves* belong to an unrelated type — the actual precision gain,
+   tracked through a typed rejection trail (see "Result type"), not a silent drop.
 3. Never reduce recall: every candidate that isn't proven unrelated stays in the result,
    labeled by how it was determined (`NavigationSource<Location>` internally).
-4. Retrofit 6a's own `resolve_identity` `Reference` arm to use the same type normalization 6b
-   introduces (see "Retrofit").
+4. Extract the `classify_symbol_at` + `Position→CursorPos` + `SymbolRole` prologue —
+   already duplicated in `definition.rs` and `implementation.rs` — into one shared
+   `classify_cursor` helper, and migrate both existing call sites onto it.
 
 **Non-goals**
 
@@ -54,10 +89,24 @@ for go-to-definition, goto-implementation, and highlight.
 
 ## Design
 
+### Shared prologue: `classify_cursor`
+
+New in `cst_symbol.rs`, extracted from the identical prologue already duplicated in
+`definition.rs::try_cst_resolved_definition` and `implementation.rs::find_implementation_at`:
+
+```rust
+pub(crate) fn classify_cursor(
+    indexer: &Indexer, uri: &Url, position: Position,
+) -> Option<SymbolAtCursor>
+```
+
+Does the `Position → CursorPos` conversion once and calls `classify_symbol_at`. Both existing
+6a call sites migrate onto it (behavior-neutral — pure extraction) as part of this slice.
+
 ### Query identity
 
 Thread `position.character` through to `find_references_with_qualifier` (today only `.line` is
-passed) and call `classify_symbol_at(indexer, uri, cursor)` on the request's own cursor —
+passed) and call `classify_cursor(indexer, uri, position)` on the request's own cursor —
 reusing 6a exactly, symmetric with how it verifies candidates below. The result gives a
 **query declaring type**:
 - `SymbolRole::Declaration { .. }` → the query's own enclosing class (via the existing
@@ -74,15 +123,10 @@ Both the query declaring type and every candidate's `receiver_type` go through
 `ReceiverType::from_raw(raw).leaf` (or `.qualified` when a dotted nested-type match matters)
 before comparison — the exact type `resolver/infer.rs` already defines for this precise
 purpose (raw/qualified/outer/leaf/nullable breakdown). No new normalization type is invented.
-
-**Retrofit**: 6a's `resolve_identity` `Reference` arm currently passes the raw `receiver_type`
-string straight into `find_definition_qualified` — for a generic-typed receiver
-(`items: List<String>`, `items.someExtension()`) this looks up a class literally named
-`"List<String>"`, finds nothing, and falls back to `NameScan` (safe — the `locs.is_empty()`
-guard catches it, never a wrong jump, just a missed precision opportunity). 6b's
-normalization pass fixes this at its source: `resolve_identity` normalizes via
-`ReceiverType::from_raw(receiver_type).leaf` before the lookup, so both 6a's own precision and
-6b's new verification share one normalization path.
+(Confirmed during critique: `classify_symbol_at`'s `receiver_type` is already generics-free
+by construction — `infer_ident_type` strips generics upstream, and `has_type_definition`'s
+exact-match gate would reject a generic-shaped string anyway — so this normalization step
+exists for dotted-nested-type and nullable-suffix handling, not generics.)
 
 ### Verification outcome (named, not left as if/else)
 
@@ -115,11 +159,12 @@ For each candidate `Location` from the *unchanged* recall set:
 2. If classification isn't a `Reference` with a resolvable `receiver_type` (or the candidate
    is a `Declaration` — handled separately below), it's inconclusive: `NavigationSource::NameScan(candidate)`, unchanged from today.
 3. Otherwise compute `ReceiverTypeAgreement` against the query declaring type. `Inherited`
-   requires `type_extends_or_equals`, which may spend hierarchy-walk IO
+   requires `supertype_chain_contains`, which may spend hierarchy-walk IO
    (budget-metered — this is the sidecar-IPC-costed path, not the disk-read one, but shares
    the SAME request-scoped budget counter per the locked decision above).
-4. Map the outcome: `Exact`/`Inherited` → `NavigationSource::CstResolved(candidate)`;
-   `Unrelated` → dropped from the result entirely; `Unresolvable` → `NavigationSource::NameScan(candidate)`.
+4. Map the outcome: `Exact`/`Inherited` → kept as `NavigationSource::CstResolved(candidate)`;
+   `Unresolvable` → kept as `NavigationSource::NameScan(candidate)`; `Unrelated` → moved to the
+   rejection trail (see "Result type" below), not silently dropped.
 5. Once the IO budget is exhausted, every remaining candidate is left as
    `NavigationSource::NameScan(candidate)` without attempting further classification —
    recall never drops because of the budget, only additional precision stops accruing.
@@ -132,31 +177,50 @@ declaration and is correctly excluded, matching how other LSPs scope find-refere
 
 ### Result type and the LSP boundary
 
-The verification pass produces `Vec<NavigationSource<Location>>` — carried as a real type
-through the whole internal pipeline, never an implicit "resolved ones happen to be sorted
-first" convention (the flaw caught rechecking this design against the base plan the first
-time). Exactly one explicit, named flatten step at the very end converts this to the
-`Vec<Location>` the LSP wire format requires, `CstResolved` entries first: this mirrors
-`resolve_identity` → `locs_to_opt_response` in 6a — a deliberate, documented ordering decision
-made once at the boundary, not a fact a caller has to infer from array position.
+The verification pass returns a single struct, not a bare `Vec`, so accepted results and
+rejections are each their own typed field rather than one collapsing into the absence of the
+other:
+
+```rust
+pub(crate) struct VerifiedReferences {
+    pub kept: Vec<NavigationSource<Location>>,
+    /// Candidates the CST *proved* belong to an unrelated type — the actual
+    /// precision gain, kept as an assertable fact (critique finding: a
+    /// proven exclusion silently collapsing to array-absence is exactly
+    /// what the project's "one outcome enum, never empty-Vec overloading"
+    /// rule targets). Never surfaced to the LSP client.
+    pub rejected: Vec<Location>,
+}
+```
+
+`kept` is carried as a real type through the whole internal pipeline, never an implicit
+"resolved ones happen to be sorted first" convention (the flaw caught rechecking this design
+against the base plan the first time). Exactly one explicit, named flatten step at the very
+end converts `kept` to the `Vec<Location>` the LSP wire format requires, `CstResolved` entries
+first: this mirrors `resolve_identity` → `locs_to_opt_response` in 6a — a deliberate,
+documented ordering decision made once at the boundary, not a fact a caller has to infer from
+array position. `rejected` is test/tracing-only — a house decoy asserts a specific location
+appears there, not merely that it's absent from `kept`.
 
 ### Error handling
 
-- Classification failure, unresolvable types, and budget exhaustion all degrade to `NameScan`
-  — never an error, never a dropped-without-cause result.
-- Only a *proven* `Unrelated` agreement drops a candidate. Every other outcome keeps it.
+- Classification failure, unresolvable types, and budget exhaustion all keep the candidate in
+  `kept` as `NameScan` — never an error, never an unaccounted-for result.
+- Only a *proven* `Unrelated` agreement moves a candidate to `rejected`. Every other outcome
+  stays in `kept`.
 
 ### Testing
 
 - House decoy, extended: `User.save()` / `File.save()`, find-references on `User.save` must
-  exclude every `File.save()` call site (the actual precision proof) while an inherited
-  reference through a `DerivedUser : User` subtype instance must still appear (`Inherited`
-  proof).
+  put every `File.save()` call site in `VerifiedReferences::rejected` (asserted directly, not
+  inferred from `kept`'s absence) while an inherited reference through a `DerivedUser : User`
+  subtype instance must appear in `kept` as `CstResolved` (`Inherited` proof).
 - Budget decoy: construct a request where the IO cap is hit before all candidates are
-  verified; assert the un-verified tail is present as `NameScan`, never dropped.
-- Retrofit decoy: a generic-typed receiver (`items: List<String>`, calling a workspace
-  extension function on it) resolves `CstResolved` via go-to-definition after the
-  normalization retrofit, where it previously fell back to `NameScan`.
+  verified; assert the un-verified tail is present in `kept` as `NameScan`, never dropped and
+  never in `rejected` (budget exhaustion is not evidence of unrelatedness).
+- `classify_cursor` extraction decoy: `definition.rs`'s and `implementation.rs`'s existing
+  test suites must pass unchanged after migrating both onto the shared helper — pure
+  extraction, zero behavior change.
 - Existing `references.rs` test suite is the recall-parity floor — every existing test's
   candidate SET must be unchanged; only intra-set labeling/filtering changes.
 - Live probe on the real project before merge: find-references on a same-named member across

--- a/docs/superpowers/specs/2026-07-20-cst-find-references-design.md
+++ b/docs/superpowers/specs/2026-07-20-cst-find-references-design.md
@@ -1,0 +1,163 @@
+# Find-References Verification Layer — Design (Slice 6b)
+
+Status: **approved design** (brainstormed with the user 2026-07-20; rechecked twice against
+`AGENTS.md` and the parent CST design's "Type-driven correctness" section — once for this
+design, once for slice 6a's already-shipped code, surfacing two real fixes applied ahead of
+this slice, see "Retrofit" below). Slice 6b of
+[CST resolution unification](2026-06-30-cst-resolution-unification-design.md), continuing
+[slice 6's navigation design](2026-07-19-cst-navigation-design.md). Branch:
+`refactor/cst-navigation-6b` off `refactor/unified-resolution` (post-#227).
+
+## Context (why)
+
+Today's `find_references_with_qualifier` (`features/references.rs`) is a pure recall engine:
+resolve a scope once (`parent_class`/`declared_pkg`, derived from the cursor's word/qualifier
+text), then let `rg` text-search that scope and return every match, filtered only by
+line-level qualifier heuristics (`has_wrong_qualifier_at_col`). It does no per-occurrence
+identity verification — two unrelated classes with a same-named member (`User.save()` /
+`File.save()`) can both surface in one `save` query if rg's scope narrowing doesn't separate
+them, exactly the class of false positive the CST classifier built in 6a exists to eliminate
+for go-to-definition, goto-implementation, and highlight.
+
+## Decisions locked with the user
+
+- **Recall is untouched.** The existing rg + index candidate search stays exactly as today —
+  6b adds a verification pass on top, never changes what candidates get found.
+- **Budget is about IO, not candidate count.** Verifying a candidate can require two IO-costed
+  operations: a disk read (when the candidate's file isn't already indexed/open — the common
+  case for a candidate rg found is already in-memory, so this is rare) and a blocking JAR
+  sidecar IPC round trip (when the supertype walk needs an ancestor class from a
+  not-yet-materialized JAR — `walk_hierarchy` already self-limits this to
+  `MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK = 3` per walk, but that cap is *per walk*, and a
+  find-references request can trigger many walks). The concern, stated directly: avoid a
+  bulk/agent-driven query (e.g. a startup workspace scan) silently spawning large numbers of
+  these IO operations. One request-scoped budget covers both.
+
+## Goals / non-goals
+
+**Goals**
+
+1. Verify each rg-found candidate's identity via `classify_symbol_at` (reused, unchanged) +
+   a new receiver-type agreement check, budgeted on IO.
+2. Reject candidates the CST *proves* belong to an unrelated type — the actual precision gain.
+3. Never reduce recall: every candidate that isn't proven unrelated stays in the result,
+   labeled by how it was determined (`NavigationSource<Location>` internally).
+4. Retrofit 6a's own `resolve_identity` `Reference` arm to use the same type normalization 6b
+   introduces (see "Retrofit").
+
+**Non-goals**
+
+- General local-variable verification — same scope cut as 6a; bare/local reference candidates
+  are unaffected by this slice.
+- Changing rg's scope-narrowing inputs (`parent_class`/`declared_pkg`/`owner_class`) — those
+  stay exactly as today; verification is a pass *after* recall, not a replacement for it.
+
+## Design
+
+### Query identity
+
+Thread `position.character` through to `find_references_with_qualifier` (today only `.line` is
+passed) and call `classify_symbol_at(indexer, uri, cursor)` on the request's own cursor —
+reusing 6a exactly, symmetric with how it verifies candidates below. The result gives a
+**query declaring type**:
+- `SymbolRole::Declaration { .. }` → the query's own enclosing class (via the existing
+  `enclosing_class_at`).
+- `SymbolRole::Reference { receiver_type: Some(receiver_type), .. }` → `receiver_type`,
+  normalized (see below).
+- Anything else (classification fails, bare reference, import segment) → no query identity;
+  verification is skipped entirely and the recall set passes through unchanged, exactly like
+  today. This is the same "CST can't narrow it" fallback shape 6a already established.
+
+### Type normalization (reused, not reinvented)
+
+Both the query declaring type and every candidate's `receiver_type` go through
+`ReceiverType::from_raw(raw).leaf` (or `.qualified` when a dotted nested-type match matters)
+before comparison — the exact type `resolver/infer.rs` already defines for this precise
+purpose (raw/qualified/outer/leaf/nullable breakdown). No new normalization type is invented.
+
+**Retrofit**: 6a's `resolve_identity` `Reference` arm currently passes the raw `receiver_type`
+string straight into `find_definition_qualified` — for a generic-typed receiver
+(`items: List<String>`, `items.someExtension()`) this looks up a class literally named
+`"List<String>"`, finds nothing, and falls back to `NameScan` (safe — the `locs.is_empty()`
+guard catches it, never a wrong jump, just a missed precision opportunity). 6b's
+normalization pass fixes this at its source: `resolve_identity` normalizes via
+`ReceiverType::from_raw(receiver_type).leaf` before the lookup, so both 6a's own precision and
+6b's new verification share one normalization path.
+
+### Verification outcome (named, not left as if/else)
+
+```rust
+enum ReceiverTypeAgreement {
+    Exact,
+    Inherited,     // candidate type is a subtype of the query's declaring type
+    Unrelated,     // confirmed different type — reject
+    Unresolvable,  // stays NameScan
+}
+```
+
+`Exact` is a plain normalized string-equality check — no hierarchy walk. `Inherited` covers a
+subtype accessing an inherited member and is checked only when `Exact` fails, via a new
+`resolver::hierarchy::supertype_chain_contains(indexer, candidate_type, candidate_uri,
+target_type) -> bool` — an ascending `walk_hierarchy` call from the candidate's type, checking
+whether the query's declaring type appears among its supertypes (the exact mechanism
+`resolve_from_class_hierarchy` already uses for the string engine's own inherited-member
+lookups, applied here in the reverse direction: not "find the member," but "does this
+ancestor chain contain that type").
+
+### Per-candidate verification, IO-budgeted
+
+For each candidate `Location` from the *unchanged* recall set:
+
+1. Classify it: `classify_symbol_at(indexer, &candidate.uri, candidate.range.start.into())`.
+   Acquisition (`live_doc_or_parse`) is free when the candidate's file is already
+   indexed/open — the common case, since rg found it inside the workspace the scan already
+   covers — and costs one disk read (budget-metered) otherwise.
+2. If classification isn't a `Reference` with a resolvable `receiver_type` (or the candidate
+   is a `Declaration` — handled separately below), it's inconclusive: `NavigationSource::NameScan(candidate)`, unchanged from today.
+3. Otherwise compute `ReceiverTypeAgreement` against the query declaring type. `Inherited`
+   requires `type_extends_or_equals`, which may spend hierarchy-walk IO
+   (budget-metered — this is the sidecar-IPC-costed path, not the disk-read one, but shares
+   the SAME request-scoped budget counter per the locked decision above).
+4. Map the outcome: `Exact`/`Inherited` → `NavigationSource::CstResolved(candidate)`;
+   `Unrelated` → dropped from the result entirely; `Unresolvable` → `NavigationSource::NameScan(candidate)`.
+5. Once the IO budget is exhausted, every remaining candidate is left as
+   `NavigationSource::NameScan(candidate)` without attempting further classification —
+   recall never drops because of the budget, only additional precision stops accruing.
+
+**Declaration-role candidates** (a candidate that is itself a declaration site — an override
+in a subclass, say): verified by exact `(name, enclosing class)` match against the query's own
+`(name, declaring type)` — no hierarchy walk. An override in a subclass is a *different*
+declaration and is correctly excluded, matching how other LSPs scope find-references
+(goto-implementation, already shipped in 6a, is the feature for "show me every override").
+
+### Result type and the LSP boundary
+
+The verification pass produces `Vec<NavigationSource<Location>>` — carried as a real type
+through the whole internal pipeline, never an implicit "resolved ones happen to be sorted
+first" convention (the flaw caught rechecking this design against the base plan the first
+time). Exactly one explicit, named flatten step at the very end converts this to the
+`Vec<Location>` the LSP wire format requires, `CstResolved` entries first: this mirrors
+`resolve_identity` → `locs_to_opt_response` in 6a — a deliberate, documented ordering decision
+made once at the boundary, not a fact a caller has to infer from array position.
+
+### Error handling
+
+- Classification failure, unresolvable types, and budget exhaustion all degrade to `NameScan`
+  — never an error, never a dropped-without-cause result.
+- Only a *proven* `Unrelated` agreement drops a candidate. Every other outcome keeps it.
+
+### Testing
+
+- House decoy, extended: `User.save()` / `File.save()`, find-references on `User.save` must
+  exclude every `File.save()` call site (the actual precision proof) while an inherited
+  reference through a `DerivedUser : User` subtype instance must still appear (`Inherited`
+  proof).
+- Budget decoy: construct a request where the IO cap is hit before all candidates are
+  verified; assert the un-verified tail is present as `NameScan`, never dropped.
+- Retrofit decoy: a generic-typed receiver (`items: List<String>`, calling a workspace
+  extension function on it) resolves `CstResolved` via go-to-definition after the
+  normalization retrofit, where it previously fell back to `NameScan`.
+- Existing `references.rs` test suite is the recall-parity floor — every existing test's
+  candidate SET must be unchanged; only intra-set labeling/filtering changes.
+- Live probe on the real project before merge: find-references on a same-named member across
+  two unrelated classes, and on an inherited member accessed through a subtype instance.

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -56,9 +56,9 @@ impl Backend {
             &ctx.word,
             ctx.qualifier.as_deref(),
             uri,
-            position.line,
+            position,
             params.context.include_declaration,
-            &*self.indexer,
+            &self.indexer,
         )
         .await;
 

--- a/src/features/definition.rs
+++ b/src/features/definition.rs
@@ -136,11 +136,7 @@ fn try_cst_resolved_definition(
     uri: &Url,
     position: Position,
 ) -> Option<GotoDefinitionResponse> {
-    let cursor = crate::types::CursorPos {
-        line: position.line as usize,
-        utf16_col: position.character as usize,
-    };
-    let sym = crate::indexer::classify_symbol_at(indexer, uri, cursor)?;
+    let sym = crate::indexer::classify_cursor(indexer, uri, position)?;
     match crate::indexer::resolve_identity(&sym, indexer, uri) {
         crate::indexer::NavigationSource::CstResolved(defs) if !defs.is_empty() => {
             locs_to_opt_response(defs.0)

--- a/src/features/implementation.rs
+++ b/src/features/implementation.rs
@@ -15,9 +15,9 @@ use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, SymbolKin
 
 use crate::features::definition::locs_to_opt_response;
 use crate::features::traits::{DocumentAccess, SearchAccess, SymbolIndex};
-use crate::indexer::{classify_symbol_at, Indexer, SymbolRole};
+use crate::indexer::{classify_cursor, Indexer, SymbolRole};
 use crate::rg;
-use crate::types::{CursorPos, FileData};
+use crate::types::FileData;
 
 /// Find implementations for the symbol at `position` — CST-resolved first
 /// (works from a CALL SITE via the receiver's type, not just the declaration
@@ -32,11 +32,7 @@ pub(crate) async fn find_implementation_at(
     uri: &Url,
     position: Position,
 ) -> Option<GotoDefinitionResponse> {
-    let cursor = CursorPos {
-        line: position.line as usize,
-        utf16_col: position.character as usize,
-    };
-    if let Some(sym) = classify_symbol_at(indexer, uri, cursor) {
+    if let Some(sym) = classify_cursor(indexer, uri, position) {
         if let SymbolRole::Reference {
             receiver_type: Some(receiver_type),
             is_call: true,

--- a/src/features/implementation.rs
+++ b/src/features/implementation.rs
@@ -38,11 +38,13 @@ pub(crate) async fn find_implementation_at(
     };
     if let Some(sym) = classify_symbol_at(indexer, uri, cursor) {
         if let SymbolRole::Reference {
-            receiver_type: Some(ty),
+            receiver_type: Some(receiver_type),
             is_call: true,
         } = &sym.role
         {
-            if let Some(response) = find_method_implementations(&sym.name, ty, indexer, uri).await {
+            if let Some(response) =
+                find_method_implementations(&sym.name, receiver_type, indexer, uri).await
+            {
                 return Some(response);
             }
         }

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod implementation;
 pub(crate) mod nullable_call_diagnostics;
 pub(crate) mod on_type_formatting;
 pub(crate) mod references;
+pub(crate) mod references_verify;
 pub(crate) mod rename;
 pub(crate) mod signature_help;
 pub(crate) mod symbols;

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -8,6 +8,7 @@ use tower_lsp::lsp_types::{Location, Position, Range, SymbolKind, Url};
 
 use super::text_utils::{utf16_column, word_byte_offsets};
 use crate::features::traits::{DocumentAccess, ScopeQuery, SearchAccess, SymbolIndex};
+use crate::indexer::{classify_cursor, Indexer, NavigationSource, SymbolRole};
 use crate::rg::RgSearchRequest;
 use crate::StrExt;
 
@@ -31,10 +32,11 @@ pub(crate) async fn find_references_with_qualifier(
     name: &str,
     qualifier: Option<&str>,
     uri: &Url,
-    line: u32,
+    position: Position,
     include_decl: bool,
-    index: &(impl SymbolIndex + DocumentAccess + ScopeQuery + SearchAccess + Send + Sync),
+    index: &Indexer,
 ) -> Vec<Location> {
+    let line = position.line;
     let (parent_class, declared_pkg) =
         resolve_scope_with_qualifier(index, uri, line, name, qualifier);
 
@@ -107,7 +109,33 @@ pub(crate) async fn find_references_with_qualifier(
         );
     }
 
-    locations
+    let query_declaring_type = match classify_cursor(index, uri, position) {
+        Some(symbol) => match &symbol.role {
+            SymbolRole::Declaration { .. } => index.enclosing_class_at(uri, line),
+            SymbolRole::Reference {
+                receiver_type: Some(receiver_type),
+                ..
+            } => Some(receiver_type.clone()),
+            _ => None,
+        },
+        None => None,
+    };
+
+    let verified = crate::features::references_verify::verify_candidates(
+        index,
+        query_declaring_type.as_deref(),
+        locations,
+    );
+    let mut resolved_first: Vec<Location> = Vec::with_capacity(verified.kept.len());
+    let mut name_scanned: Vec<Location> = Vec::new();
+    for source in verified.kept {
+        match source {
+            NavigationSource::CstResolved(location) => resolved_first.push(location),
+            NavigationSource::NameScan(location) => name_scanned.push(location),
+        }
+    }
+    resolved_first.append(&mut name_scanned);
+    resolved_first
 }
 
 // ─── Scope resolution ─────────────────────────────────────────────────────────

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use tower_lsp::lsp_types::Url;
+use tower_lsp::lsp_types::{Position, Url};
 
 use crate::features::references::find_references_with_qualifier;
 use crate::indexer::Indexer;
@@ -96,7 +96,9 @@ async fn find_references_cross_file_with_workspace_root() {
     idx.workspace_root.set(root.to_path_buf());
     idx.index_content(&foo_uri, foo_src);
 
-    let locs = find_references_with_qualifier("MyClass", None, &foo_uri, 1, true, &*idx).await;
+    let locs =
+        find_references_with_qualifier("MyClass", None, &foo_uri, Position::new(1, 0), true, &idx)
+            .await;
     let files = hit_files(&locs);
 
     assert!(
@@ -131,7 +133,9 @@ async fn find_references_cross_file_without_workspace_root() {
     let idx = Arc::new(Indexer::new());
     idx.index_content(&foo_uri, foo_src);
 
-    let locs = find_references_with_qualifier("MyClass", None, &foo_uri, 1, true, &*idx).await;
+    let locs =
+        find_references_with_qualifier("MyClass", None, &foo_uri, Position::new(1, 0), true, &idx)
+            .await;
     let files = hit_files(&locs);
 
     assert!(
@@ -176,7 +180,9 @@ async fn find_references_package_scoped_cross_file() {
 
     // line=1: declaration of MyClass → resolve_scope returns (None, Some("com.example"))
     // → package_scoped_reference_locations is used
-    let locs = find_references_with_qualifier("MyClass", None, &foo_uri, 1, true, &*idx).await;
+    let locs =
+        find_references_with_qualifier("MyClass", None, &foo_uri, Position::new(1, 0), true, &idx)
+            .await;
     let files = hit_files(&locs);
 
     assert!(
@@ -240,7 +246,15 @@ async fn actor_scan_then_find_references_cross_file() {
         .expect("workspace scan must complete within 10s")
         .unwrap();
 
-    let locs = find_references_with_qualifier("MyClass", None, &foo_uri, 1, true, &*indexer).await;
+    let locs = find_references_with_qualifier(
+        "MyClass",
+        None,
+        &foo_uri,
+        Position::new(1, 0),
+        true,
+        &indexer,
+    )
+    .await;
     let files = hit_files(&locs);
 
     assert!(
@@ -277,7 +291,9 @@ async fn find_references_stale_workspace_root_does_not_suppress_results() {
     idx.workspace_root.set(other_project.path().to_path_buf());
     idx.index_content(&foo_uri, foo_src);
 
-    let locs = find_references_with_qualifier("MyClass", None, &foo_uri, 1, true, &*idx).await;
+    let locs =
+        find_references_with_qualifier("MyClass", None, &foo_uri, Position::new(1, 0), true, &idx)
+            .await;
     let files = hit_files(&locs);
 
     assert!(
@@ -372,7 +388,9 @@ class OtherCaller(val f: ReducerB.Factory)
     // Cursor on `Factory` in `    interface Factory {` — line 3 (0-based) in ReducerA.kt
     // (line 2 is `@SomeAnnotation`).  No dot-qualifier → qualifier=None, on_decl=true.
     // enclosing_class_at must return "ReducerA", not "Factory".
-    let locs = find_references_with_qualifier("Factory", None, &ra_uri, 3, false, &*idx).await;
+    let locs =
+        find_references_with_qualifier("Factory", None, &ra_uri, Position::new(3, 0), false, &idx)
+            .await;
 
     let files = hit_files(&locs);
 
@@ -474,8 +492,15 @@ class OtherCaller(val f: ReducerB.Factory)
     // Cursor is on `Factory` in `private val reducerAFactory: ReducerA.Factory`
     // (line 4, after the dot — qualifier = "ReducerA").
     // Line 4 (0-based) = `    private val reducerAFactory: ReducerA.Factory,`
-    let locs =
-        find_references_with_qualifier("Factory", Some("ReducerA"), &vm_uri, 4, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "Factory",
+        Some("ReducerA"),
+        &vm_uri,
+        Position::new(4, 0),
+        false,
+        &idx,
+    )
+    .await;
 
     let files = hit_files(&locs);
 
@@ -562,8 +587,15 @@ class ViewModel(
 
     // Search refs of ReducerA.Factory (qualifier = "ReducerA").
     // Line 5 = `    private val reducerAFactory: ReducerA.Factory,` (0-based)
-    let locs =
-        find_references_with_qualifier("Factory", Some("ReducerA"), &vm_uri, 5, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "Factory",
+        Some("ReducerA"),
+        &vm_uri,
+        Position::new(5, 0),
+        false,
+        &idx,
+    )
+    .await;
 
     let lines: Vec<u32> = locs
         .iter()
@@ -636,7 +668,9 @@ fun buildReducer(f: ReducerA.Factory): ReducerA = f.create()
     idx.index_content(&caller_uri, caller);
 
     // Cursor on `create` in `fun create(): ReducerA` — line 3 (0-based).
-    let locs = find_references_with_qualifier("create", None, &ra_uri, 3, false, &*idx).await;
+    let locs =
+        find_references_with_qualifier("create", None, &ra_uri, Position::new(3, 0), false, &idx)
+            .await;
 
     let files = hit_files(&locs);
 
@@ -721,9 +755,9 @@ class Caller(val f: Outer.Inner.Factory)
         "Factory",
         Some("Outer.Inner"),
         &caller_uri,
-        1, // line 1 (0-based): `class Caller(val f: Outer.Inner.Factory)`
+        Position::new(1, 0), // line 1 (0-based): `class Caller(val f: Outer.Inner.Factory)`
         false,
-        &*idx,
+        &idx,
     )
     .await;
 
@@ -821,7 +855,9 @@ class ReducerC {
     idx.index_content(&rc_uri, reducer_c);
 
     // Cursor on `create` in `fun create(): ReducerA` — line 3 (0-based).
-    let locs = find_references_with_qualifier("create", None, &ra_uri, 3, false, &*idx).await;
+    let locs =
+        find_references_with_qualifier("create", None, &ra_uri, Position::new(3, 0), false, &idx)
+            .await;
 
     let files = hit_files(&locs);
 
@@ -845,7 +881,9 @@ class ReducerC {
     );
 
     // Same assertions must hold when include_decl=true (LSP default).
-    let locs_incl = find_references_with_qualifier("create", None, &ra_uri, 3, true, &*idx).await;
+    let locs_incl =
+        find_references_with_qualifier("create", None, &ra_uri, Position::new(3, 0), true, &idx)
+            .await;
     let files_incl = hit_files(&locs_incl);
     assert!(
         files_incl.iter().any(|f| f == "ReducerA.kt"),
@@ -911,7 +949,9 @@ data class Unrelated(val id: String)
     idx.index_content(&unrelated_uri, unrelated_src);
 
     // Cursor on `id` in `data class Account(val id: String)` — line 1 (0-based).
-    let locs = find_references_with_qualifier("id", None, &account_uri, 1, false, &*idx).await;
+    let locs =
+        find_references_with_qualifier("id", None, &account_uri, Position::new(1, 0), false, &idx)
+            .await;
     let files = hit_files(&locs);
 
     assert!(
@@ -991,7 +1031,15 @@ class LoginPresenter {
     idx.index_content(&login_presenter_uri, login_presenter_src);
 
     // Cursor on `Effect` at its declaration inside IntroContract.kt (line 2, 0-based).
-    let locs = find_references_with_qualifier("Effect", None, &intro_uri, 2, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "Effect",
+        None,
+        &intro_uri,
+        Position::new(2, 0),
+        false,
+        &idx,
+    )
+    .await;
     let files = hit_files(&locs);
 
     assert!(
@@ -1077,8 +1125,15 @@ class IntroHandler {
     // Cursor on `Effect` at a USAGE site inside IntroHandler.kt (off-declaration path).
     // Line 0: package, line 1: import, line 2: class IntroHandler {, line 3: fun process(e: Effect)
     // on_decl=false → resolve_scope falls to declared_package_of (the buggy path).
-    let locs =
-        find_references_with_qualifier("Effect", None, &intro_handler_uri, 3, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "Effect",
+        None,
+        &intro_handler_uri,
+        Position::new(3, 0),
+        false,
+        &idx,
+    )
+    .await;
     let files = hit_files(&locs);
 
     assert!(
@@ -1148,7 +1203,15 @@ fun process(s: IntroContract.State, e: Event) {}
     idx.index_content(&unrelated_uri, unrelated_src);
 
     // Cursor on `Event` at its declaration inside IntroContract (line 2, 0-based).
-    let locs = find_references_with_qualifier("Event", None, &contract_uri, 2, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "Event",
+        None,
+        &contract_uri,
+        Position::new(2, 0),
+        false,
+        &idx,
+    )
+    .await;
 
     assert_refs_contain(&locs, &["GoodCaller.kt"]);
     assert_refs_exclude(&locs, &["UnrelatedCaller.kt"]);
@@ -1216,8 +1279,15 @@ fun handleB(e: IntroContract.Event) {}
     idx.index_content(&b_vm_uri, pkg_b_viewmodel);
 
     // Cursor on `Event` in com.a.IntroContract (line 2, 0-based).
-    let locs =
-        find_references_with_qualifier("Event", None, &a_contract_uri, 2, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "Event",
+        None,
+        &a_contract_uri,
+        Position::new(2, 0),
+        false,
+        &idx,
+    )
+    .await;
 
     assert_refs_contain(&locs, &["PkgACaller.kt"]);
     assert_refs_exclude(&locs, &["PkgBViewModel.kt"]);
@@ -1269,7 +1339,9 @@ interface IntroContract {
     idx.index_content(&b_uri, pkg_b_contract);
 
     // Cursor on `Event` in com.a.IntroContract, include_decl=false.
-    let locs = find_references_with_qualifier("Event", None, &a_uri, 2, false, &*idx).await;
+    let locs =
+        find_references_with_qualifier("Event", None, &a_uri, Position::new(2, 0), false, &idx)
+            .await;
 
     assert_refs_exclude(&locs, &["PkgBContract.kt"]);
 }
@@ -1355,7 +1427,15 @@ fun show(s: ProductScreens) {
     );
 
     // Cursor on `title` in TextBody.Scenes.BusyLoader (line 4, 0-based).
-    let locs = find_references_with_qualifier("title", None, &text_body_uri, 4, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "title",
+        None,
+        &text_body_uri,
+        Position::new(4, 0),
+        false,
+        &idx,
+    )
+    .await;
 
     assert_refs_contain(&locs, &["GoodCaller.kt"]);
     assert_refs_exclude(&locs, &["OtherBody.kt", "OtherCaller.kt"]);
@@ -1421,7 +1501,15 @@ public class Transaction {
     idx.index_content(&other_uri, other_src);
 
     // Cursor on `mAmount` field declaration in Payment.java (line 2, 0-based).
-    let locs = find_references_with_qualifier("mAmount", None, &payment_uri, 2, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "mAmount",
+        None,
+        &payment_uri,
+        Position::new(2, 0),
+        false,
+        &idx,
+    )
+    .await;
 
     // Transaction.java has its own mAmount — must NOT appear
     assert_refs_exclude(&locs, &["Transaction.java"]);
@@ -1488,8 +1576,15 @@ public class Order {
     idx.index_content(&unrelated_uri, unrelated_src);
 
     // Cursor on `getAmount` declaration in Payment.java (line 3, 0-based).
-    let locs =
-        find_references_with_qualifier("getAmount", None, &payment_uri, 3, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "getAmount",
+        None,
+        &payment_uri,
+        Position::new(3, 0),
+        false,
+        &idx,
+    )
+    .await;
 
     // PaymentView calls payment.getAmount() — must be included.
     assert_refs_contain(&locs, &["PaymentView.java"]);
@@ -1549,7 +1644,15 @@ public class Order {
     idx.index_content(&other_uri, other_src);
 
     // Cursor on `mAmount` declaration in Payment.java (line 2, 0-based).
-    let locs = find_references_with_qualifier("mAmount", None, &payment_uri, 2, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "mAmount",
+        None,
+        &payment_uri,
+        Position::new(2, 0),
+        false,
+        &idx,
+    )
+    .await;
 
     // Order.java's own `mAmount` declaration must not appear.
     let order_decl_hits: Vec<_> = locs
@@ -1602,14 +1705,28 @@ public class PaymentView {
 
     // Cursor on `getAmount` in Payment.java (declaration site, line 2, 0-based).
     // includeDeclaration=true: Payment.java itself must appear.
-    let locs_with_decl =
-        find_references_with_qualifier("getAmount", None, &payment_uri, 2, true, &*idx).await;
+    let locs_with_decl = find_references_with_qualifier(
+        "getAmount",
+        None,
+        &payment_uri,
+        Position::new(2, 0),
+        true,
+        &idx,
+    )
+    .await;
     assert_refs_contain(&locs_with_decl, &["Payment.java"]);
     assert_refs_contain(&locs_with_decl, &["PaymentView.java"]);
 
     // From CALL SITE in different package: caller must appear.
-    let locs_from_caller =
-        find_references_with_qualifier("getAmount", None, &caller_uri, 3, false, &*idx).await;
+    let locs_from_caller = find_references_with_qualifier(
+        "getAmount",
+        None,
+        &caller_uri,
+        Position::new(3, 0),
+        false,
+        &idx,
+    )
+    .await;
     assert_refs_contain(&locs_from_caller, &["PaymentView.java"]);
 }
 
@@ -1657,7 +1774,15 @@ public class Caller {
     idx.index_content(&other_uri, other_src);
     idx.index_content(&caller_uri, caller_src);
 
-    let locs = find_references_with_qualifier("process", None, &owner_uri, 2, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "process",
+        None,
+        &owner_uri,
+        Position::new(2, 0),
+        false,
+        &idx,
+    )
+    .await;
 
     assert_refs_contain(&locs, &["Caller.java"]);
     assert_refs_exclude(&locs, &["Other.java"]);
@@ -1712,7 +1837,15 @@ async fn find_references_on_jar_symbol_usage_scopes_to_importers() {
     idx.index_content(&caller_uri, caller_src);
 
     // Cursor on the `remember()` call usage in Caller.kt (line 2, 0-indexed).
-    let locs = find_references_with_qualifier("remember", None, &caller_uri, 2, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "remember",
+        None,
+        &caller_uri,
+        Position::new(2, 0),
+        false,
+        &idx,
+    )
+    .await;
 
     assert_refs_contain(&locs, &["Caller.kt"]);
     assert_refs_exclude(&locs, &["Unrelated.kt"]);
@@ -1774,7 +1907,15 @@ async fn find_references_on_jar_symbol_disambiguates_competing_jars() {
     idx.index_content(&other_uri, other_src);
 
     // Cursor on the `remember()` call usage in Caller.kt (line 2, 0-indexed).
-    let locs = find_references_with_qualifier("remember", None, &caller_uri, 2, false, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "remember",
+        None,
+        &caller_uri,
+        Position::new(2, 0),
+        false,
+        &idx,
+    )
+    .await;
 
     assert_refs_contain(&locs, &["Caller.kt"]);
     assert_refs_exclude(&locs, &["Other.kt"]);
@@ -1850,7 +1991,15 @@ async fn find_references_from_jar_definition_site_returns_workspace_callers() {
     idx.record_extracted_jar_source(&extracted, &jar_src);
 
     // Cursor on the `remember` declaration (line 2) in the extracted file; include_decl.
-    let locs = find_references_with_qualifier("remember", None, &extracted, 2, true, &*idx).await;
+    let locs = find_references_with_qualifier(
+        "remember",
+        None,
+        &extracted,
+        Position::new(2, 0),
+        true,
+        &idx,
+    )
+    .await;
 
     assert_refs_contain(&locs, &["ComposeCaller.kt"]);
     assert_refs_exclude(&locs, &["OtherCaller.kt", "Composables.kt"]);

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -2035,7 +2035,7 @@ async fn find_references_excludes_unrelated_same_named_member() {
     assert!(
         locations
             .iter()
-            .all(|location| location.uri != file_uri || location.range.start.line != 2),
+            .all(|location| location.uri != caller_uri || location.range.start.line != 2),
         "File.save() call site must not appear; got: {:?}",
         locations
     );

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -2004,3 +2004,39 @@ async fn find_references_from_jar_definition_site_returns_workspace_callers() {
     assert_refs_contain(&locs, &["ComposeCaller.kt"]);
     assert_refs_exclude(&locs, &["OtherCaller.kt", "Composables.kt"]);
 }
+
+/// End-to-end house decoy: find-references on `User.save` (invoked from a
+/// call site) must exclude `File.save()`'s call site entirely from the
+/// returned Vec<Location> — the actual precision proof at the public API
+/// boundary, not just verify_candidates' internal VerifiedReferences.
+#[tokio::test]
+async fn find_references_excludes_unrelated_same_named_member() {
+    let idx = Indexer::new();
+    let user_uri = Url::parse("file:///t/User.kt").unwrap();
+    let file_uri = Url::parse("file:///t/File.kt").unwrap();
+    let caller_uri = Url::parse("file:///t/Caller.kt").unwrap();
+    idx.index_content(&user_uri, "class User { fun save() {} }\n");
+    idx.index_content(&file_uri, "class File { fun save() {} }\n");
+    let caller_src = "fun f(user: User, file: File) {\n    user.save()\n    file.save()\n}\n";
+    idx.index_content(&caller_uri, caller_src);
+    idx.store_live_tree(&caller_uri, caller_src);
+    let col = caller_src.lines().nth(1).unwrap().find("save").unwrap() as u32;
+
+    let locations = find_references_with_qualifier(
+        "save",
+        None,
+        &caller_uri,
+        Position::new(1, col),
+        false,
+        &idx,
+    )
+    .await;
+
+    assert!(
+        locations
+            .iter()
+            .all(|location| location.uri != file_uri || location.range.start.line != 2),
+        "File.save() call site must not appear; got: {:?}",
+        locations
+    );
+}

--- a/src/features/references_verify.rs
+++ b/src/features/references_verify.rs
@@ -202,21 +202,62 @@ mod tests {
     /// Budget decoy: once the IO budget is exhausted, remaining candidates
     /// stay in `kept` as `NameScan` — never moved to `rejected`, even when
     /// they WOULD have been proven unrelated with more budget.
+    ///
+    /// To actually exercise budgeting (not merely look like it does), every
+    /// candidate here must genuinely cost IO and genuinely resolve to
+    /// `ReceiverTypeAgreement::Unrelated` if fully verified:
+    /// - One shared, indexed file declares both `User` and `File` (each with
+    ///   a `save()` member) so `has_type_definition` resolves globally.
+    /// - Each candidate lives in its OWN real file on disk that is never
+    ///   indexed or opened, so `classify_symbol_at` must fall back to disk
+    ///   (`live_doc_or_parse`'s cold-start path) — the disk-read budget
+    ///   charge genuinely fires for every one.
+    /// - Each candidate file is a `File`-typed receiver calling `save()`
+    ///   (`fun f(file: File) { file.save() }`), which — once agreement is
+    ///   checked — is provably `Unrelated` to the `User` query type.
+    ///
+    /// With `MAX_VERIFICATION_IO_OPERATIONS = 48` and every fully-verified
+    /// candidate costing exactly 2 units (1 disk-read charge + 1 agreement
+    /// charge — see `verify_candidates`), exactly the first
+    /// `MAX_VERIFICATION_IO_OPERATIONS / 2` candidates can be verified and
+    /// rejected before the budget hits zero; every candidate after that must
+    /// fall back to `NameScan` purely because the budget ran out, not
+    /// because classification failed (their receiver type resolves fine).
     #[test]
     fn budget_exhaustion_never_rejects_only_skips_verification() {
-        let src = "class User { fun save() {} }\nclass File { fun save() {} }\n";
-        let u = uri("/D.kt");
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let decls_src = "class User { fun save() {} }\nclass File { fun save() {} }\n";
+        std::fs::write(root.join("Decls.kt"), decls_src).unwrap();
+        let decls_uri = Url::from_file_path(root.join("Decls.kt")).unwrap();
         let idx = Indexer::new();
-        idx.index_content(&u, src);
-        idx.store_live_tree(&u, src);
-        // Many candidates on unindexed files so every one costs a disk-read
-        // budget unit; with MAX_VERIFICATION_IO_OPERATIONS candidates all
-        // needing 2 units each (disk read + agreement check), the tail
-        // exhausts the budget.
-        let candidates: Vec<Location> = (0..(MAX_VERIFICATION_IO_OPERATIONS as u32 + 5))
-            .map(|line| location(&u, line, 0, 4))
+        idx.index_content(&decls_uri, decls_src);
+
+        let n = MAX_VERIFICATION_IO_OPERATIONS + 10;
+        let candidate_src = "fun f(file: File) { file.save() }\n";
+        let col = candidate_src.find("save").unwrap() as u32;
+        let candidates: Vec<Location> = (0..n)
+            .map(|i| {
+                let name = format!("C{i}.kt");
+                std::fs::write(root.join(&name), candidate_src).unwrap();
+                let candidate_uri = Url::from_file_path(root.join(&name)).unwrap();
+                location(&candidate_uri, 0, col, col + 4)
+            })
             .collect();
+
         let result = verify_candidates(&idx, Some("User"), candidates.clone());
+
+        let max_verifiable = MAX_VERIFICATION_IO_OPERATIONS / 2;
+        assert_eq!(
+            result.rejected.len(),
+            max_verifiable,
+            "exactly the candidates the budget could afford must be proven Unrelated and rejected"
+        );
+        assert!(
+            !result.rejected.is_empty(),
+            "verification must have genuinely run and excluded some candidates"
+        );
         assert!(
             result.rejected.len() < candidates.len(),
             "budget exhaustion must leave some candidates unverified, not reject them all"
@@ -225,6 +266,13 @@ mod tests {
             result.kept.len() + result.rejected.len(),
             candidates.len(),
             "no candidate may vanish — every one is either kept or rejected"
+        );
+        assert!(
+            result
+                .kept
+                .iter()
+                .all(|k| matches!(k, NavigationSource::NameScan(_))),
+            "budget-exhausted candidates must stay NameScan, never silently become CstResolved"
         );
     }
 }

--- a/src/features/references_verify.rs
+++ b/src/features/references_verify.rs
@@ -1,0 +1,230 @@
+//! Per-candidate CST verification for find-references — see
+//! `docs/superpowers/specs/2026-07-20-cst-find-references-design.md`.
+
+use tower_lsp::lsp_types::Location;
+
+use crate::indexer::{Indexer, NavigationSource};
+use crate::resolver::{receiver_type_agreement, ReceiverType, ReceiverTypeAgreement};
+
+/// Per-request cap on IO-costed verification steps (a candidate's file
+/// needing a fresh disk read, or a supertype walk that may spend blocking
+/// JAR-sidecar IPC). Once exhausted, remaining candidates stay `NameScan`
+/// unverified — never dropped, never rejected on budget grounds alone.
+// Wired into `find_references_with_qualifier` in a later task of this slice
+// (slice 6b) — not yet referenced outside this module's own tests.
+#[allow(dead_code)]
+const MAX_VERIFICATION_IO_OPERATIONS: usize = 48;
+
+#[allow(dead_code)]
+pub(crate) struct VerifiedReferences {
+    pub kept: Vec<NavigationSource<Location>>,
+    pub rejected: Vec<Location>,
+}
+
+// Wired into `find_references_with_qualifier` in a later task of this slice
+// (slice 6b) — not yet referenced outside this module's own tests.
+#[allow(dead_code)]
+pub(crate) fn verify_candidates(
+    indexer: &Indexer,
+    query_declaring_type: Option<&str>,
+    candidates: Vec<Location>,
+) -> VerifiedReferences {
+    let Some(query_declaring_type) = query_declaring_type else {
+        // No query identity — every candidate is exactly today's behavior.
+        return VerifiedReferences {
+            kept: candidates
+                .into_iter()
+                .map(NavigationSource::NameScan)
+                .collect(),
+            rejected: Vec::new(),
+        };
+    };
+    let query_declaring_type = ReceiverType::from_raw(query_declaring_type.to_owned()).leaf;
+
+    let mut kept = Vec::new();
+    let mut rejected = Vec::new();
+    let mut io_budget = MAX_VERIFICATION_IO_OPERATIONS;
+
+    for candidate in candidates {
+        if io_budget == 0 {
+            kept.push(NavigationSource::NameScan(candidate));
+            continue;
+        }
+        let file_already_indexed = indexer.files.contains_key(candidate.uri.as_str())
+            || indexer.live_lines.contains_key(candidate.uri.as_str());
+        if !file_already_indexed {
+            io_budget -= 1;
+        }
+        let Some(symbol) = crate::indexer::classify_symbol_at(
+            indexer,
+            &candidate.uri,
+            crate::types::CursorPos {
+                line: candidate.range.start.line as usize,
+                utf16_col: candidate.range.start.character as usize,
+            },
+        ) else {
+            kept.push(NavigationSource::NameScan(candidate));
+            continue;
+        };
+        match &symbol.role {
+            crate::indexer::SymbolRole::Reference {
+                receiver_type: Some(receiver_type),
+                ..
+            } => {
+                let candidate_type = ReceiverType::from_raw(receiver_type.clone()).leaf;
+                // The supertype walk (Inherited case) may spend sidecar IPC —
+                // charge it against the same budget before running it.
+                if io_budget == 0 {
+                    kept.push(NavigationSource::NameScan(candidate));
+                    continue;
+                }
+                io_budget -= 1;
+                match receiver_type_agreement(
+                    indexer,
+                    &candidate_type,
+                    candidate.uri.as_str(),
+                    &query_declaring_type,
+                ) {
+                    ReceiverTypeAgreement::Exact | ReceiverTypeAgreement::Inherited => {
+                        kept.push(NavigationSource::CstResolved(candidate));
+                    }
+                    ReceiverTypeAgreement::Unrelated => rejected.push(candidate),
+                    ReceiverTypeAgreement::Unresolvable => {
+                        kept.push(NavigationSource::NameScan(candidate));
+                    }
+                }
+            }
+            crate::indexer::SymbolRole::Declaration { .. } => {
+                // Verified by exact (name, enclosing class) match. A mismatch
+                // is a *weaker* signal than a proven type mismatch — two
+                // same-named unrelated declarations aren't the "wrong
+                // receiver type" case `ReceiverTypeAgreement` models — so
+                // err toward keeping (`NameScan`), never reject here.
+                let enclosing_class =
+                    indexer.enclosing_class_at(&candidate.uri, candidate.range.start.line);
+                let matches_query = enclosing_class
+                    .as_deref()
+                    .map(|class_name| ReceiverType::from_raw(class_name.to_owned()).leaf)
+                    == Some(query_declaring_type.clone());
+                if matches_query {
+                    kept.push(NavigationSource::CstResolved(candidate));
+                } else {
+                    kept.push(NavigationSource::NameScan(candidate));
+                }
+            }
+            _ => kept.push(NavigationSource::NameScan(candidate)),
+        }
+    }
+
+    VerifiedReferences { kept, rejected }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_lsp::lsp_types::{Position, Range, Url};
+
+    use super::*;
+
+    fn uri(path: &str) -> Url {
+        Url::parse(&format!("file:///t{path}")).unwrap()
+    }
+
+    fn location(uri: &Url, line: u32, col_start: u32, col_end: u32) -> Location {
+        Location {
+            uri: uri.clone(),
+            range: Range::new(Position::new(line, col_start), Position::new(line, col_end)),
+        }
+    }
+
+    /// House decoy: a candidate on `File.save()` must be REJECTED (present
+    /// in `rejected`, absent from `kept`) when the query's declaring type
+    /// is `User`.
+    #[test]
+    fn unrelated_candidate_is_rejected_not_dropped_silently() {
+        let src = "class User { fun save() {} }\n\
+                   class File { fun save() {} }\n\
+                   fun f(file: File) { file.save() }\n";
+        let u = uri("/D.kt");
+        let idx = Indexer::new();
+        idx.index_content(&u, src);
+        idx.store_live_tree(&u, src);
+        let col = src.lines().nth(2).unwrap().find("save").unwrap() as u32;
+        let candidate = location(&u, 2, col, col + 4);
+
+        let result = verify_candidates(&idx, Some("User"), vec![candidate.clone()]);
+        assert!(
+            result.kept.is_empty(),
+            "must not be kept, got {:?}",
+            result.kept.len()
+        );
+        assert_eq!(
+            result.rejected,
+            vec![candidate],
+            "must be in rejected, not silently absent"
+        );
+    }
+
+    /// House decoy, positive: an inherited-member reference through a
+    /// subtype instance must be kept as `CstResolved`.
+    #[test]
+    fn inherited_candidate_is_kept_as_cst_resolved() {
+        let src = "open class User { fun save() {} }\n\
+                   class DerivedUser : User()\n\
+                   fun f(derived: DerivedUser) { derived.save() }\n";
+        let u = uri("/D.kt");
+        let idx = Indexer::new();
+        idx.index_content(&u, src);
+        idx.store_live_tree(&u, src);
+        let col = src.lines().nth(2).unwrap().find("save").unwrap() as u32;
+        let candidate = location(&u, 2, col, col + 4);
+
+        let result = verify_candidates(&idx, Some("User"), vec![candidate.clone()]);
+        assert!(result.rejected.is_empty());
+        assert!(matches!(
+            result.kept.as_slice(),
+            [NavigationSource::CstResolved(loc)] if *loc == candidate
+        ));
+    }
+
+    #[test]
+    fn no_query_identity_passes_every_candidate_through_as_name_scan() {
+        let u = uri("/D.kt");
+        let idx = Indexer::new();
+        let candidate = location(&u, 0, 0, 4);
+        let result = verify_candidates(&idx, None, vec![candidate.clone()]);
+        assert!(result.rejected.is_empty());
+        assert!(matches!(
+            result.kept.as_slice(),
+            [NavigationSource::NameScan(loc)] if *loc == candidate
+        ));
+    }
+
+    /// Budget decoy: once the IO budget is exhausted, remaining candidates
+    /// stay in `kept` as `NameScan` — never moved to `rejected`, even when
+    /// they WOULD have been proven unrelated with more budget.
+    #[test]
+    fn budget_exhaustion_never_rejects_only_skips_verification() {
+        let src = "class User { fun save() {} }\nclass File { fun save() {} }\n";
+        let u = uri("/D.kt");
+        let idx = Indexer::new();
+        idx.index_content(&u, src);
+        idx.store_live_tree(&u, src);
+        // Many candidates on unindexed files so every one costs a disk-read
+        // budget unit; with MAX_VERIFICATION_IO_OPERATIONS candidates all
+        // needing 2 units each (disk read + agreement check), the tail
+        // exhausts the budget.
+        let candidates: Vec<Location> = (0..(MAX_VERIFICATION_IO_OPERATIONS as u32 + 5))
+            .map(|line| location(&u, line, 0, 4))
+            .collect();
+        let result = verify_candidates(&idx, Some("User"), candidates.clone());
+        assert!(
+            result.rejected.len() < candidates.len(),
+            "budget exhaustion must leave some candidates unverified, not reject them all"
+        );
+        assert_eq!(
+            result.kept.len() + result.rejected.len(),
+            candidates.len(),
+            "no candidate may vanish — every one is either kept or rejected"
+        );
+    }
+}

--- a/src/features/references_verify.rs
+++ b/src/features/references_verify.rs
@@ -10,20 +10,18 @@ use crate::resolver::{receiver_type_agreement, ReceiverType, ReceiverTypeAgreeme
 /// needing a fresh disk read, or a supertype walk that may spend blocking
 /// JAR-sidecar IPC). Once exhausted, remaining candidates stay `NameScan`
 /// unverified — never dropped, never rejected on budget grounds alone.
-// Wired into `find_references_with_qualifier` in a later task of this slice
-// (slice 6b) — not yet referenced outside this module's own tests.
-#[allow(dead_code)]
 const MAX_VERIFICATION_IO_OPERATIONS: usize = 48;
 
-#[allow(dead_code)]
 pub(crate) struct VerifiedReferences {
     pub kept: Vec<NavigationSource<Location>>,
+    // Intentionally excluded from `find_references_with_qualifier`'s output —
+    // dropping proven-unrelated candidates is the whole point of this pass.
+    // Read only by this module's own tests, which assert rejection actually
+    // happens rather than candidates silently vanishing from `kept`.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub rejected: Vec<Location>,
 }
 
-// Wired into `find_references_with_qualifier` in a later task of this slice
-// (slice 6b) — not yet referenced outside this module's own tests.
-#[allow(dead_code)]
 pub(crate) fn verify_candidates(
     indexer: &Indexer,
     query_declaring_type: Option<&str>,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -37,8 +37,9 @@ pub(crate) use self::infer::{
     cst_cursor::{cst_call_info, cst_cursor_is_local_var, cst_outer_call_info, CallInfo},
     cst_lambda::{cursor_node_at, LambdaScopeInfo},
     cst_symbol::{
-        classify_symbol_at, is_call_callee, is_declaration_site, navigation_member_ident,
-        navigation_receiver_node, resolve_identity, NavigationSource, SymbolAtCursor, SymbolRole,
+        classify_cursor, classify_symbol_at, is_call_callee, is_declaration_site,
+        navigation_member_ident, navigation_receiver_node, resolve_identity, NavigationSource,
+        SymbolAtCursor, SymbolRole,
     },
     deps::{CallableInfo, InferDeps, OuterScopedParams},
     expr_type::infer_expr_type,

--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -18,7 +18,7 @@ use crate::queries::{
 };
 use crate::resolver::api::Definitions;
 use crate::types::CursorPos;
-use tower_lsp::lsp_types::Url;
+use tower_lsp::lsp_types::{Position, Url};
 
 use super::deps::InferDeps as _;
 use super::speculative::ResolutionDoc;
@@ -132,6 +132,24 @@ pub(crate) enum SymbolRole {
         is_call: bool,
     },
     ImportSegment,
+}
+
+/// `classify_symbol_at`, but taking an LSP `Position` directly — the
+/// `Position → CursorPos` conversion every navigation-feature call site
+/// otherwise repeats.
+pub(crate) fn classify_cursor(
+    indexer: &Indexer,
+    uri: &Url,
+    position: Position,
+) -> Option<SymbolAtCursor> {
+    classify_symbol_at(
+        indexer,
+        uri,
+        CursorPos {
+            line: position.line as usize,
+            utf16_col: position.character as usize,
+        },
+    )
 }
 
 /// Classify the identifier under `pos`: declaration, member reference (with

--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -107,14 +107,12 @@ pub(crate) fn is_call_callee(node: Node<'_>) -> bool {
 }
 
 /// The classified identifier under the cursor, produced by [`classify_symbol_at`].
-#[allow(dead_code)] // wiring seam for later navigation-feature tasks (slice 6a, tasks 3-6)
 #[derive(Debug, Clone)]
 pub(crate) struct SymbolAtCursor {
     pub name: String,
     pub role: SymbolRole,
 }
 
-#[allow(dead_code)] // wiring seam for later navigation-feature tasks (slice 6a, tasks 3-6)
 #[derive(Debug, Clone)]
 pub(crate) enum SymbolRole {
     /// `indexed` is `true` when this declaration's name is captured by
@@ -153,7 +151,6 @@ pub(crate) enum SymbolRole {
 /// authoritative here: fall back to the unrepaired live/parsed tree so an
 /// unrelated error elsewhere in the file doesn't blind classification at the
 /// cursor.
-#[allow(dead_code)] // wiring seam for later navigation-feature tasks (slice 6a, tasks 3-6)
 pub(crate) fn classify_symbol_at(
     indexer: &Indexer,
     uri: &Url,
@@ -248,7 +245,6 @@ pub(crate) fn classify_symbol_at(
 
 /// A definitions lookup result, tagged by how much confidence its identity
 /// carries.
-#[allow(dead_code)] // wiring seam for later navigation-feature tasks (slice 6a, tasks 4-6)
 #[derive(Debug)]
 pub(crate) enum NavigationSource<T> {
     /// Identity established from the CST + index: precise, ranked first.
@@ -265,7 +261,6 @@ pub(crate) enum NavigationSource<T> {
 /// couldn't narrow — an untyped receiver, or a bare reference resolved by
 /// today's name-based `find_definition_qualified(name, None, uri)` (which
 /// can span multiple same-named workspace symbols).
-#[allow(dead_code)] // wiring seam for later navigation-feature tasks (slice 6a, tasks 4-6)
 pub(crate) fn resolve_identity(
     sym: &SymbolAtCursor,
     indexer: &Indexer,
@@ -286,10 +281,10 @@ pub(crate) fn resolve_identity(
             }
         }
         SymbolRole::Reference {
-            receiver_type: Some(ty),
+            receiver_type: Some(receiver_type),
             ..
         } => {
-            let locs = indexer.find_definition_qualified(&sym.name, Some(ty), uri);
+            let locs = indexer.find_definition_qualified(&sym.name, Some(receiver_type), uri);
             if locs.is_empty() {
                 NavigationSource::NameScan(Definitions(locs))
             } else {

--- a/src/resolver/hierarchy.rs
+++ b/src/resolver/hierarchy.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use crate::indexer::Indexer;
+use crate::indexer::{Indexer, InferDeps};
 use crate::types::{CallerContext, FileData};
 
 /// Per-WALK cap on blocking sidecar-IPC promotion attempts for ancestor
@@ -151,3 +151,81 @@ fn super_names_for_class(file_data: &FileData, class_name: &str) -> Vec<String> 
             .collect(),
     }
 }
+
+/// How a candidate receiver's type relates to a target (query) declaring
+/// type. `Exact`/`Inherited` are the two ways a candidate is *proven* to
+/// belong; `Unrelated` is a proven exclusion; `Unresolvable` means the
+/// index doesn't have enough data to prove anything either way (the
+/// candidate type itself isn't indexed) — never treat this as `Unrelated`.
+// Consumed by find-references candidate verification, wired in a later task
+// of this slice (slice 6b) — not yet referenced outside `hierarchy_tests.rs`.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReceiverTypeAgreement {
+    Exact,
+    Inherited,
+    Unrelated,
+    Unresolvable,
+}
+
+/// Ascending walk from `candidate_type`: does `target_type` appear among
+/// its supertypes? Same mechanism `resolve_from_class_hierarchy` already
+/// uses for the string engine's inherited-member lookups, applied in
+/// reverse — not "find the member," but "does this ancestor chain contain
+/// that type."
+// Consumed by find-references candidate verification, wired in a later task
+// of this slice (slice 6b) — not yet referenced outside `hierarchy_tests.rs`.
+#[allow(dead_code)]
+pub(crate) fn supertype_chain_contains(
+    indexer: &Indexer,
+    candidate_type: &str,
+    candidate_uri: &str,
+    target_type: &str,
+) -> bool {
+    walk_hierarchy(
+        indexer,
+        candidate_type,
+        candidate_uri,
+        CallerContext::default(),
+        12,
+        |_, super_name, _, _| {
+            if super_name == target_type {
+                vec![()]
+            } else {
+                vec![]
+            }
+        },
+    )
+    .into_iter()
+    .next()
+    .is_some()
+}
+
+/// The full receiver-type-agreement decision: exact match (cheap, no walk),
+/// else — only if `candidate_type` is genuinely indexed, so a negative
+/// result is trustworthy — an ascending supertype walk.
+// Consumed by find-references candidate verification, wired in a later task
+// of this slice (slice 6b) — not yet referenced outside `hierarchy_tests.rs`.
+#[allow(dead_code)]
+pub(crate) fn receiver_type_agreement(
+    indexer: &Indexer,
+    candidate_type: &str,
+    candidate_uri: &str,
+    target_type: &str,
+) -> ReceiverTypeAgreement {
+    if candidate_type == target_type {
+        return ReceiverTypeAgreement::Exact;
+    }
+    if !indexer.has_type_definition(candidate_type) {
+        return ReceiverTypeAgreement::Unresolvable;
+    }
+    if supertype_chain_contains(indexer, candidate_type, candidate_uri, target_type) {
+        ReceiverTypeAgreement::Inherited
+    } else {
+        ReceiverTypeAgreement::Unrelated
+    }
+}
+
+#[cfg(test)]
+#[path = "hierarchy_tests.rs"]
+mod tests;

--- a/src/resolver/hierarchy.rs
+++ b/src/resolver/hierarchy.rs
@@ -157,9 +157,6 @@ fn super_names_for_class(file_data: &FileData, class_name: &str) -> Vec<String> 
 /// belong; `Unrelated` is a proven exclusion; `Unresolvable` means the
 /// index doesn't have enough data to prove anything either way (the
 /// candidate type itself isn't indexed) — never treat this as `Unrelated`.
-// Consumed by find-references candidate verification, wired in a later task
-// of this slice (slice 6b) — not yet referenced outside `hierarchy_tests.rs`.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ReceiverTypeAgreement {
     Exact,
@@ -173,9 +170,6 @@ pub(crate) enum ReceiverTypeAgreement {
 /// uses for the string engine's inherited-member lookups, applied in
 /// reverse — not "find the member," but "does this ancestor chain contain
 /// that type."
-// Consumed by find-references candidate verification, wired in a later task
-// of this slice (slice 6b) — not yet referenced outside `hierarchy_tests.rs`.
-#[allow(dead_code)]
 pub(crate) fn supertype_chain_contains(
     indexer: &Indexer,
     candidate_type: &str,
@@ -204,9 +198,6 @@ pub(crate) fn supertype_chain_contains(
 /// The full receiver-type-agreement decision: exact match (cheap, no walk),
 /// else — only if `candidate_type` is genuinely indexed, so a negative
 /// result is trustworthy — an ascending supertype walk.
-// Consumed by find-references candidate verification, wired in a later task
-// of this slice (slice 6b) — not yet referenced outside `hierarchy_tests.rs`.
-#[allow(dead_code)]
 pub(crate) fn receiver_type_agreement(
     indexer: &Indexer,
     candidate_type: &str,

--- a/src/resolver/hierarchy_tests.rs
+++ b/src/resolver/hierarchy_tests.rs
@@ -1,0 +1,73 @@
+use super::{receiver_type_agreement, supertype_chain_contains, ReceiverTypeAgreement};
+use crate::indexer::Indexer;
+use tower_lsp::lsp_types::Url;
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file:///t{path}")).unwrap()
+}
+
+fn indexed(path: &str, src: &str) -> (Url, Indexer) {
+    let u = uri(path);
+    let idx = Indexer::new();
+    idx.index_content(&u, src);
+    (u, idx)
+}
+
+#[test]
+fn exact_type_match_is_exact() {
+    let (u, idx) = indexed("/D.kt", "class User\n");
+    assert_eq!(
+        receiver_type_agreement(&idx, "User", u.as_str(), "User"),
+        ReceiverTypeAgreement::Exact
+    );
+}
+
+#[test]
+fn subtype_of_target_is_inherited() {
+    let (u, idx) = indexed("/D.kt", "open class User\nclass DerivedUser : User()\n");
+    assert!(supertype_chain_contains(
+        &idx,
+        "DerivedUser",
+        u.as_str(),
+        "User"
+    ));
+    assert_eq!(
+        receiver_type_agreement(&idx, "DerivedUser", u.as_str(), "User"),
+        ReceiverTypeAgreement::Inherited
+    );
+}
+
+#[test]
+fn unrelated_indexed_type_is_unrelated() {
+    let (u, idx) = indexed("/D.kt", "class User\nclass File\n");
+    assert!(!supertype_chain_contains(&idx, "File", u.as_str(), "User"));
+    assert_eq!(
+        receiver_type_agreement(&idx, "File", u.as_str(), "User"),
+        ReceiverTypeAgreement::Unrelated
+    );
+}
+
+#[test]
+fn unindexed_type_is_unresolvable_not_unrelated() {
+    let (u, idx) = indexed("/D.kt", "class User\n");
+    // "Ghost" is never declared anywhere — has_type_definition fails, so we
+    // must NOT claim to have proven it's unrelated to User.
+    assert_eq!(
+        receiver_type_agreement(&idx, "Ghost", u.as_str(), "User"),
+        ReceiverTypeAgreement::Unresolvable
+    );
+}
+
+/// House decoy: a two-level hierarchy — the target is a grandparent, not the
+/// immediate supertype.
+#[test]
+fn transitive_supertype_is_inherited() {
+    let (u, idx) = indexed(
+        "/D.kt",
+        "open class Base\nopen class Middle : Base()\nclass Leaf : Middle()\n",
+    );
+    assert_eq!(
+        receiver_type_agreement(&idx, "Leaf", u.as_str(), "Base"),
+        ReceiverTypeAgreement::Inherited
+    );
+}

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use api::{Resolver, ReturnType};
 pub(crate) use complete::symbols_from_uri_as_completions_pub;
 #[cfg(test)]
 pub(crate) use complete::{complete_symbol, complete_symbol_with_context, is_annotation_context};
-pub(crate) use hierarchy::walk_hierarchy;
+pub(crate) use hierarchy::{receiver_type_agreement, walk_hierarchy, ReceiverTypeAgreement};
 pub(crate) use import_edit::{already_imported, import_insertion_line, make_import_edit};
 pub(crate) use infer::{
     infer_receiver_type, infer_receiver_type_at, infer_variable_type_raw, InferenceChain,


### PR DESCRIPTION
## What

Slice 6b of the CST resolution unification (spec: `docs/superpowers/specs/2026-07-20-cst-find-references-design.md`, independently critiqued and amended before implementation — see spec's "Critique findings applied" section; plan: `docs/superpowers/plans/2026-07-20-cst-find-references-6b.md`).

Adds a CST-based verification pass on top of find-references' existing rg+index recall (completely unchanged): each candidate is now checked against the query's declaring type, and candidates *proven* to belong to an unrelated type are excluded — the precision gap that let `User.save()` and `File.save()` both surface in one `save` query.

## How

- **`classify_cursor`** (`indexer/infer/cst_symbol.rs`) — extracted the `Position → CursorPos → classify_symbol_at` prologue that `definition.rs` and `implementation.rs` (slice 6a) had each independently hand-rolled; both migrated onto it. Caught during the pre-implementation critique, not left as a third copy.
- **`ReceiverTypeAgreement`** (`resolver/hierarchy.rs`) — `Exact` / `Inherited` / `Unrelated` / `Unresolvable`. The `Unresolvable` case is load-bearing: an unindexed candidate type is *not* evidence it's unrelated, only that the index can't prove anything — verified by a dedicated test and a mutation-style trace in review.
- **`VerifiedReferences { kept, rejected }`** (`features/references_verify.rs`) — per-candidate verification under one request-scoped IO budget (covers both a candidate's disk-read fallback and supertype-walk sidecar IPC, per the explicit "avoid an agent bulk query spawning thousands of IO ops" requirement). Budget exhaustion never rejects — only proven-`Unrelated` candidates move to `rejected`, which is a typed, directly-assertable field, never a silent absence from the result.
- Wired into `find_references_with_qualifier`: recall is untouched, verification is a strict post-pass, `CstResolved` results ordered first.

## Review process (subagent-driven, task-scoped gates)

All 5 implementation tasks went through implement → review → fix → re-review where needed. Three tasks needed a fix round, each a real, reviewer-verified issue:
- **Task 3** (`verify_candidates`): production logic was correct by static trace, but its own regression test for the most safety-critical property (budget exhaustion never rejects) was empirically vacuous — the fixture never actually drove the budget to zero. Rewrote with a fixture proven (via temporary instrumentation) to genuinely exhaust it.
- **Task 5** (end-to-end decoy): the assertion — copied from the plan's own test sketch — checked the wrong URI (the declaration file instead of the file containing the actual decoy call site), making it vacuously true regardless of what the function returned. Fixed and proven genuinely load-bearing with real bypass-wiring RED / restored-wiring GREEN output.
- (Task 2's `ReceiverTypeAgreement` gate ordering was reviewed and confirmed correct on the first pass, no fix needed — included here only to note the review actually exercised it via a mutation-style trace, not just presence-checking.)

## Verification

- 1561 unit tests, clippy dev+release `-D warnings`, e2e smoke.
- Live probe on the real project (Moneta): find-references on a real single-implementor member (`ICacheManager.clearAllCaches`) returned exactly the declaration, the implementation, and all 3 real call sites — nothing spurious; a second probe on a widely-implemented member (`IAppSettings.putString`, 278 references) completed cleanly against the fully-scanned workspace, exercising the verification/budget path at real scale.

## Pre-implementation critique (spec stage)

Independent adversarial critique of the design (before any code) found and corrected three issues: a "retrofit" goal targeting an unreachable scenario (traced two independent layers already preventing it — dropped), a third hand-rolled copy of the classify-cursor prologue (now extracted, see above), and rejected candidates silently vanishing from the result instead of being a typed, assertable fact (now `VerifiedReferences.rejected`).

## Next

Slice 6c (rename) is next, explicitly gated on its own live-probe measurement of cross-file refusal rate before the strict "refuse unless CstResolved" policy locks in, per the parent slice-6 spec's flagged (not yet resolved) policy question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)