### PR TITLE
fix: Flow<T> generic receiver-type inference (follow-up to PR #229 live-probe)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-flow-generic-receiver-inference.md
+++ b/docs/superpowers/plans/2026-07-22-flow-generic-receiver-inference.md
@@ -1,0 +1,512 @@
+# Flow&lt;T&gt; Generic Receiver-Type Inference — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three independently-necessary gaps in receiver-type inference so a value derived from a JAR-defined generic type (`Flow<T>`, via `.first()` or `.map { it -> }`) resolves to its concrete type argument instead of `None` — the root cause of a live-probed rename failure ("identity is ambiguous") on real Kotlin/Android code.
+
+**Architecture:** Three self-contained patches, each mirroring an existing working pattern already in the same file it modifies. No shared code between the three fixes; each has its own task, its own test, and can be reviewed independently. A final task re-runs a live LSP probe against the real project the bug was found in.
+
+**Tech Stack:** Rust, tree-sitter-backed CST inference (`src/indexer/infer/`), the `InferDeps` trait (`src/indexer/infer/deps.rs`) implemented by `Indexer` (`src/indexer.rs`).
+
+## Global Constraints
+
+- Design source of truth: `docs/superpowers/specs/2026-07-22-flow-generic-receiver-inference-design.md`. Do not re-derive reasoning already settled there — the design went through an independent critique that corrected a genuinely unsafe first draft; follow the corrected version exactly.
+- **Do NOT modify `forward_resolve_segments` or `resolve_segments_type`** (`src/indexer/infer/chain.rs`) — their existing "resolve every segment I'm handed" contract is used by other callers and is directly tested by `unresolved_final_suffix_fails_the_strict_walk` (`src/indexer/infer/mod_tests.rs:133-162`), which must keep passing unchanged.
+- No abbreviated identifiers (AGENTS.md project rule).
+- Every existing test must keep passing. Run the FULL suite (`cargo test`) at the end of every task, not just the module you touched — these are shared inference primitives with callers across `resolver/`, `indexer/infer/`, and the feature layer.
+- Each fix is independently reviewable; commit each task separately.
+
+---
+
+### Task 1: `find_var_type` gets a CST fallback for chained receivers
+
+**Files:**
+- Modify: `src/resolver/infer.rs` (`infer_variable_type_from_cst`'s visibility)
+- Modify: `src/indexer.rs` (`InferDeps::find_var_type`, around line 407-409)
+- Test: `src/indexer_tests.rs`
+
+**Interfaces:**
+- Consumes: `infer_variable_type_from_cst(indexer: &Indexer, name: &str, uri: &Url) -> Option<String>` (already exists in `src/resolver/infer.rs`, currently module-private).
+- Produces: no new public interface — `InferDeps::find_var_type` gains a fallback; its signature is unchanged (`fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String>`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/indexer_tests.rs` (append near the other `find_var_type`/`infer_variable_type_raw`-adjacent tests, e.g. after the test at line ~2269 shown in the file today):
+
+```rust
+#[test]
+fn find_var_type_resolves_a_chained_call_initializer_via_cst_fallback() {
+    // `val userData = repository.userData.first()` -- a chained (nav_expr)
+    // receiver that the line-based heuristics in infer_variable_type_raw
+    // explicitly reject (parser.rs's call_expr_receiver_method rejects
+    // multi-level chaining; the resolver/infer.rs line-scan fallback skips
+    // any receiver containing '.'). Only the CST-aware fallback
+    // (infer_variable_type_from_cst) can type this.
+    let idx = Indexer::new();
+    let repo_uri = uri("/Repository.kt");
+    idx.index_content(
+        &repo_uri,
+        concat!(
+            "package com.example\n",
+            "data class UserData(val shouldHideOnboarding: Boolean)\n",
+            "class Repository {\n",
+            "    val userData: UserData = TODO()\n",
+            "    fun use() {\n",
+            "        val local = this.userData\n",
+            "        val hasOnboarded = local.shouldHideOnboarding\n",
+            "    }\n",
+            "}\n",
+        ),
+    );
+    idx.store_live_tree(
+        &repo_uri,
+        concat!(
+            "package com.example\n",
+            "data class UserData(val shouldHideOnboarding: Boolean)\n",
+            "class Repository {\n",
+            "    val userData: UserData = TODO()\n",
+            "    fun use() {\n",
+            "        val local = this.userData\n",
+            "        val hasOnboarded = local.shouldHideOnboarding\n",
+            "    }\n",
+            "}\n",
+        ),
+    );
+
+    let var_type = idx.find_var_type("local", &repo_uri);
+    assert_eq!(
+        var_type.as_deref(),
+        Some("UserData"),
+        "find_var_type must resolve a chained (this.userData-style) initializer \
+         via the CST fallback when the line heuristic can't -- got {var_type:?}"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test find_var_type_resolves_a_chained_call_initializer_via_cst_fallback -- --nocapture`
+Expected: FAIL — `find_var_type` returns `None` today (both line heuristics reject the chained `this.userData` receiver).
+
+*(If this exact fixture doesn't reproduce the failure — e.g. if `this.userData` isn't treated as a chained receiver the same way `niaPreferencesDataSource.userData.first()` was in the original bug report — adjust the fixture to a `val local = someObject.someProperty` shape where `someObject` is itself a property access, not a bare identifier; the essential property needed is a receiver whose CST node is a `navigation_expression`, not a bare `simple_identifier`. Verify by reading `parser.rs`'s `call_expr_receiver_method` guard yourself against whatever fixture you land on, rather than assuming the first attempt is right.)*
+
+- [ ] **Step 3: Make `infer_variable_type_from_cst` crate-visible**
+
+In `src/resolver/infer.rs`, find the function signature (around line 431):
+```rust
+fn infer_variable_type_from_cst(indexer: &Indexer, name: &str, uri: &Url) -> Option<String> {
+```
+Change to:
+```rust
+pub(crate) fn infer_variable_type_from_cst(indexer: &Indexer, name: &str, uri: &Url) -> Option<String> {
+```
+
+- [ ] **Step 4: Add the fallback to `find_var_type`**
+
+In `src/indexer.rs`, find:
+```rust
+    fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String> {
+        infer_variable_type_raw(self, var_name, uri)
+    }
+```
+Replace with:
+```rust
+    fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String> {
+        infer_variable_type_raw(self, var_name, uri)
+            .or_else(|| crate::resolver::infer::infer_variable_type_from_cst(self, var_name, uri))
+    }
+```
+(Use the fully-qualified path if `infer_variable_type_from_cst` isn't already imported at the top of `indexer.rs` — check the existing `use crate::resolver::infer::{...}` block first and add it there instead if that's the established style in this file, rather than inlining the full path.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test find_var_type_resolves_a_chained_call_initializer_via_cst_fallback -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 6: Check for a hot-path performance regression**
+
+`find_var_type` is called from several hot paths (grep confirms: `resolve_root_node_type`, and other call sites in `chain.rs`/`cst_lambda.rs`/`type_subst.rs` shown in the design doc). The new fallback triggers `live_doc_or_parse` (a tree-sitter re-parse) on every miss for a file that's indexed but not currently open. This project has a documented history of similar per-call scans causing hover/inlay latency stalls.
+
+Run a quick sanity check: `cargo build --release` then time a hover-heavy operation on a large real file (e.g. via the CLI's `hover` subcommand if one exists — check `src/cli/run.rs` — or via a quick LSP probe script against a real project) before and after this change, on a FILE THAT IS INDEXED BUT NOT OPEN (the miss path this fallback adds cost to). This is a sanity check, not a rigorous benchmark — if it's clearly fine (no perceptible difference), note that in your report and move on. If it looks meaningfully slower, report `DONE_WITH_CONCERNS` with the numbers rather than silently shipping it — do not attempt to fix a perf regression yourself without checking with the controller first, since the right mitigation (caching, gating the fallback further) is a design decision, not a mechanical follow-up.
+
+- [ ] **Step 7: Run the full test suite**
+
+Run: `cargo test 2>&1 | grep -E "^test result:|FAILED"`
+Expected: all pass, same or greater total count than before this task (one new test added, zero removed).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/resolver/infer.rs src/indexer.rs src/indexer_tests.rs
+git commit -m "fix(indexer): find_var_type falls back to CST inference for chained receivers
+
+infer_variable_type_raw's two line-based heuristics both explicitly reject
+a chained (navigation_expression) receiver -- e.g. val x = a.b.c()  --
+so find_var_type returned None for exactly this shape, even though the
+sibling infer_receiver_type (used by hover and others) already has this
+fallback via infer_variable_type_from_cst. This is the first of three
+independently-necessary fixes for a live-probed rename failure on
+Flow<T>-derived receivers (val x = someFlow.first())."
+```
+
+---
+
+### Task 2: `resolve_callee_chain` pre-slices its segment list
+
+**Files:**
+- Modify: `src/indexer/infer/chain.rs` (`resolve_callee_chain`'s `KIND_NAV_EXPR` arm, around line 241-247)
+- Test: `src/indexer/infer/mod_tests.rs`
+
+**Interfaces:**
+- Consumes: `resolve_segments_type(segments: &[NavSegment<'_>], bytes: &[u8], deps: &impl InferDeps, uri: &Url, strictness: SuffixStrictness) -> Option<String>` (already exists, `chain.rs:546-566` — unchanged by this task).
+- Produces: no signature change — `resolve_callee_chain(callee: tree_sitter::Node<'_>, bytes: &[u8], deps: &impl InferDeps, uri: &Url) -> Option<(String, String)>`'s return VALUE changes for a chained callee ending in a method-with-trailing-lambda (now the type *before* that method, not the method's own corrupted return type); its signature and every other input shape are unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/indexer/infer/mod_tests.rs` (this file already imports `super::chain::{...}` for the sibling test `unresolved_final_suffix_fails_the_strict_walk` at line ~133 — follow that same import style):
+
+```rust
+#[test]
+fn resolve_callee_chain_reports_receiver_type_before_the_final_method_not_its_return_type() {
+    use super::chain::resolve_callee_chain;
+
+    // `container.items.map` -- a nav_expr callee for `container.items.map { ... }`.
+    // resolve_callee_chain must report the type of `container.items` (Box<Thing>)
+    // as the receiver, and "map" as the method name -- NOT "map"'s own (here,
+    // deliberately wrong/unresolvable) return type folded into current_type.
+    let uri = test_url("/Chain.kt");
+    let deps = super::deps::TestDeps::new()
+        .with_var(uri.as_str(), "container", "Container")
+        .with_field("Container", "items", "Box<Thing>");
+    let doc = live_doc_for("fun f() { container.items.map { it } }\n");
+    let nav = find_first_node_of_kind(doc.tree.root_node(), "navigation_expression")
+        .expect("nav node");
+
+    let result = resolve_callee_chain(nav, &doc.bytes, &deps, &uri);
+    assert_eq!(
+        result,
+        Some(("Box<Thing>".to_owned(), "map".to_owned())),
+        "receiver type must be Box<Thing> (the type before .map), with \"map\" \
+         as the separately-reported method name -- got {result:?}"
+    );
+}
+```
+
+`TestDeps::with_field(class_name: &str, field_name: &str, type_name: &str) -> Self` is confirmed
+to exist exactly with this signature (`src/indexer/infer/deps.rs:264-275`) — the test above is
+verified against the real builder, not a guess.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test resolve_callee_chain_reports_receiver_type_before_the_final_method_not_its_return_type -- --nocapture`
+Expected: FAIL — today's `resolve_callee_chain` resolves "map" via `resolve_member_type_on(cur, "map", deps, uri)` inside `forward_resolve_segments`'s `Suffix` arm, which (since `TestDeps` has no method/field named "map" on `Box<Thing>`) returns `None` from `resolve_member_type_on`, hits the `strictness == SuffixStrictness::Fail` check (this call site uses `SuffixStrictness::LeakReceiver`, so it does NOT return `None` outright) — trace the actual current behavior yourself by running the test and reading the actual returned value, since the precise wrong-answer shape depends on `SCOPE_FUNCTIONS`/strictness interaction; don't assume `None` is what you'll see pre-fix, the assertion mismatch itself is what proves the bug.
+
+- [ ] **Step 3: Implement the fix**
+
+In `src/indexer/infer/chain.rs`, find `resolve_callee_chain`'s `KIND_NAV_EXPR` arm:
+```rust
+        k if k == KIND_NAV_EXPR => {
+            let segments = collect_nav_segments(callee, bytes);
+            if segments.is_empty() {
+                return None;
+            }
+            forward_resolve_segments(&segments, bytes, deps, uri, SuffixStrictness::LeakReceiver)
+        }
+```
+Replace with:
+```rust
+        k if k == KIND_NAV_EXPR => {
+            let segments = collect_nav_segments(callee, bytes);
+            if segments.len() < 2 {
+                return None;
+            }
+            // Mirror resolve_call_expr_type's external pre-slice (this same
+            // file, ~line 436-449): the LAST segment is the method being
+            // called with the trailing lambda (e.g. "map"), not itself a
+            // member access to fold into the receiver's type. Do NOT push
+            // this exclusion into forward_resolve_segments/resolve_segments_type
+            // themselves -- their "resolve every segment I'm handed" contract
+            // is relied on elsewhere (see mod_tests.rs's
+            // unresolved_final_suffix_fails_the_strict_walk) and by
+            // resolve_call_expr_type's own already-correct pre-sliced call.
+            let method_name = match segments.last()? {
+                NavSegment::Suffix { name, .. } => name.clone(),
+                _ => return None,
+            };
+            let receiver_type = resolve_segments_type(
+                &segments[..segments.len() - 1],
+                bytes,
+                deps,
+                uri,
+                SuffixStrictness::LeakReceiver,
+            )?;
+            Some((receiver_type, method_name))
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test resolve_callee_chain_reports_receiver_type_before_the_final_method_not_its_return_type -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: Run the existing regression test that guards against breaking this exact class of change**
+
+Run: `cargo test unresolved_final_suffix_fails_the_strict_walk -- --nocapture`
+Expected: PASS, unchanged — this test calls `resolve_segments_type` directly (not through `resolve_callee_chain`), so it must be completely unaffected by this task's change, which only touches `resolve_callee_chain`'s own call site.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `cargo test 2>&1 | grep -E "^test result:|FAILED"`
+Expected: all pass. Pay particular attention to any test involving `.let`/`.also`/`.run`/scope functions or multi-segment chains ending in a trailing lambda — this is the shape this task's fix specifically changes behavior for.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/indexer/infer/chain.rs src/indexer/infer/mod_tests.rs
+git commit -m "fix(chain): resolve_callee_chain excludes the final segment from receiver-type resolution
+
+The KIND_NAV_EXPR arm handed forward_resolve_segments the FULL segment
+list, so for a callee like \`container.items.map\` (the callee of
+\`container.items.map { lambda }\`), \"map\" was resolved as a plain member
+access into current_type -- corrupting the receiver type with map's own
+(often still-generic) return type instead of stopping at the type right
+before the call, which is what every caller of resolve_callee_chain
+expects per its own doc comment. Fixed by pre-slicing at the call site,
+mirroring resolve_call_expr_type's already-correct pattern in this same
+file -- forward_resolve_segments/resolve_segments_type themselves are
+untouched (an earlier draft of this fix modified them directly and was
+caught by review: it would have double-truncated resolve_call_expr_type's
+existing correct usage and broken unresolved_final_suffix_fails_the_strict_walk).
+Second of three independently-necessary fixes for a live-probed rename
+failure on Flow<T>-derived receivers (someFlow.map { it -> ... })."
+```
+
+---
+
+### Task 3: `find_class_type_params` gets a JAR fallback
+
+**Files:**
+- Modify: `src/indexer.rs` (`InferDeps::find_class_type_params`, around line 423-442)
+- Test: `src/indexer_tests.rs`
+
+**Interfaces:**
+- Consumes: `Indexer.jar_definitions: DashMap<String, Vec<Location>>`, `Indexer.jar_files: DashMap<String, Arc<FileData>>`, `crate::indexer::jar::ensure_jar_definitions_for` (all already exist and are already used by the sibling `find_fun_callable_info`, same file).
+- Produces: no signature change — `InferDeps::find_class_type_params(&self, class_name: &str) -> Vec<String>` now returns real type params for a JAR-defined generic class instead of always `Vec::new()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/indexer_tests.rs`. This follows the SAME direct-`SymbolEntry`-construction pattern the existing `jar_symbol_resolved_via_import` test (same file, constructs a `SymbolKind::CLASS` entry) already uses — NOT the function-only `insert_fake_jar_symbol` helper in `it_this_tests.rs` (that helper hardcodes `kind: SymbolKind::FUNCTION`, so it cannot construct a class symbol as-is):
+
+```rust
+#[test]
+fn find_class_type_params_falls_back_to_jar_indexed_classes() {
+    // Simulates a JAR-provided generic class (e.g. kotlinx.coroutines.flow.Flow<T>)
+    // whose own type parameter is needed for generic substitution elsewhere
+    // (build_type_arg_subst). Before this fix, find_class_type_params only
+    // ever read workspace-indexed classes and always returned an empty Vec
+    // for any JAR-defined one.
+    use crate::types::{FileData, SourceSet, SymbolEntry, Visibility};
+    use std::sync::Arc;
+    use tower_lsp::lsp_types::{Location, Position, Range, Url};
+
+    let jar_uri = Url::parse("jar:file:///lib/fake-flow.jar!/").unwrap();
+    let idx = Indexer::new();
+
+    let range = Range {
+        start: Position { line: 0, character: 0 },
+        end: Position { line: 0, character: 4 },
+    };
+    let flow_symbol = SymbolEntry {
+        name: "Flow".into(),
+        kind: SymbolKind::CLASS,
+        visibility: Visibility::Public,
+        range,
+        selection_range: range,
+        detail: "interface kotlinx.coroutines.flow.Flow<out T>".into(),
+        container: None,
+        params: String::new(),
+        param_counts: (0, 0),
+        cold: crate::types::pack_cold_fields(
+            vec!["T".to_owned()],
+            String::new(),
+            String::new(),
+            "A cold asynchronous data stream".into(),
+        ),
+        trailing_lambda: false,
+        deprecated: false,
+    };
+
+    idx.jar_definitions
+        .entry("Flow".into())
+        .or_default()
+        .push(Location {
+            uri: jar_uri.clone(),
+            range,
+        });
+    idx.jar_files.insert(
+        jar_uri.to_string(),
+        Arc::new(FileData {
+            symbols: vec![flow_symbol],
+            source_set: SourceSet::Library,
+            lines: Arc::new(vec![]),
+            ..Default::default()
+        }),
+    );
+
+    let type_params = idx.find_class_type_params("Flow");
+    assert_eq!(
+        type_params,
+        vec!["T".to_owned()],
+        "must find Flow's own type parameter via the JAR fallback -- got {type_params:?}"
+    );
+
+    // Decoy: a genuinely unknown class (neither workspace nor JAR-indexed)
+    // must still return an empty Vec, not panic or find something spurious.
+    assert!(
+        idx.find_class_type_params("TotallyUnknownClass").is_empty(),
+        "an unindexed class name must return an empty Vec, not panic"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test find_class_type_params_falls_back_to_jar_indexed_classes -- --nocapture`
+Expected: FAIL — `find_class_type_params("Flow")` returns `Vec::new()` today (only ever checks `self.definitions`/`self.files`, never `self.jar_definitions`/`self.jar_files`).
+
+- [ ] **Step 3: Implement the fix**
+
+In `src/indexer.rs`, find `find_class_type_params`:
+```rust
+    fn find_class_type_params(&self, class_name: &str) -> Vec<String> {
+        let Some(locations) = self.definitions.get(class_name) else {
+            return Vec::new();
+        };
+        for loc in locations.iter() {
+            let Some(url) = self.file_table.url(loc.file) else {
+                continue;
+            };
+            if let Some(file_data) = self.files.get(url.as_str()) {
+                if let Some(sym) = file_data
+                    .symbols
+                    .iter()
+                    .find(|s| s.name == class_name && !s.type_params().is_empty())
+                {
+                    return sym.type_params().to_vec();
+                }
+            }
+        }
+        Vec::new()
+    }
+```
+Replace with:
+```rust
+    fn find_class_type_params(&self, class_name: &str) -> Vec<String> {
+        if let Some(locations) = self.definitions.get(class_name) {
+            for loc in locations.iter() {
+                let Some(url) = self.file_table.url(loc.file) else {
+                    continue;
+                };
+                if let Some(file_data) = self.files.get(url.as_str()) {
+                    if let Some(sym) = file_data
+                        .symbols
+                        .iter()
+                        .find(|s| s.name == class_name && !s.type_params().is_empty())
+                    {
+                        return sym.type_params().to_vec();
+                    }
+                }
+            }
+        }
+        // Fallback: JAR-indexed classes. Same synthetic-line-as-index
+        // addressing find_fun_callable_info (this same file) already uses
+        // for JAR symbols -- a JAR symbol's "line" is really an index into
+        // its file's own `symbols` Vec, not a real line number.
+        let mut cache_backed_only = 0usize;
+        crate::indexer::jar::ensure_jar_definitions_for(self, class_name, &mut cache_backed_only);
+        if let Some(jar_locs) = self.jar_definitions.get(class_name) {
+            for loc in jar_locs.iter().take(MAX_BY_NAME_DEFS) {
+                if let Some(file_data) = self.jar_files.get(loc.uri.as_str()) {
+                    if let Some(sym) = file_data
+                        .symbols
+                        .get(loc.range.start.line as usize)
+                        .filter(|s| s.name == class_name && !s.type_params().is_empty())
+                    {
+                        return sym.type_params().to_vec();
+                    }
+                }
+            }
+        }
+        Vec::new()
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test find_class_type_params_falls_back_to_jar_indexed_classes -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `cargo test 2>&1 | grep -E "^test result:|FAILED"`
+Expected: all pass, same or greater total count. This change is purely additive (a new fallback branch reached only when the workspace loop finds nothing) — no existing class's type-param resolution should change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/indexer.rs src/indexer_tests.rs
+git commit -m "fix(indexer): find_class_type_params falls back to JAR-indexed classes
+
+Only ever read self.definitions/self.files (workspace-indexed classes),
+so any JAR-defined generic class (e.g. kotlinx.coroutines.flow.Flow<T>)
+always got an empty Vec -- meaning build_type_arg_subst could never build
+a real substitution map for it, no matter how the call to it was reached.
+The sibling find_fun_callable_info already has this exact JAR fallback for
+functions' type parameters; this gives find_class_type_params the same
+two-tier shape. Third of three independently-necessary fixes for a
+live-probed rename failure -- this one specifically backs the
+val x = someFlow.first() case (resolve_call_expr_type's class-level
+substitution path), not the someFlow.map { it } case (which resolves
+through a separate mechanism fixed in Task 2)."
+```
+
+---
+
+### Task 4: Live-probe verification against the real project
+
+**Files:** None — this is a manual verification step, not a code change.
+
+**Interfaces:** None.
+
+- [ ] **Step 1: Install the fixed binary**
+
+```bash
+cargo install --path . --force
+```
+
+- [ ] **Step 2: Re-run the exact live probe that found this bug**
+
+Write (or reuse, if still present in the scratchpad from the original investigation) a small Python script driving `~/.cargo/bin/kmp-lsp` via stdio JSON-RPC against `/home/ocel/Work/samples/nowinandroid`, waiting for the `$/progress` "kmp-lsp/indexing" end notification before querying (an unindexed workspace gives misleadingly pessimistic results — this project's standing lesson from prior live-probe work), then sending `textDocument/rename` at the exact two positions that originally failed:
+
+1. `core/data/src/main/kotlin/com/google/samples/apps/nowinandroid/core/data/repository/OfflineFirstNewsRepository.kt`, the `userData.shouldHideOnboarding` reference inside `modelUpdater = { changedIds -> val userData = niaPreferencesDataSource.userData.first(); val hasOnboarded = userData.shouldHideOnboarding ...}` (the `.first()` case — verify the exact current line/column against the real file, since other tasks in this plan's own history may have shifted nothing here but line numbers are never safe to assume stale).
+2. `feature/foryou/impl/src/main/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/impl/ForYouViewModel.kt`, the `it.shouldHideOnboarding` reference inside `userDataRepository.userData.map { !it.shouldHideOnboarding }` (the lambda-`it` case).
+
+Only inspect the returned `WorkspaceEdit`/error — do not apply anything to disk. Confirm `git status` in the nowInAndroid checkout is clean before and after.
+
+**Expected:** both renames now SUCCEED (return a real `WorkspaceEdit`, not a refusal) — this is the actual user-facing regression floor for this whole plan. If either still refuses, do not consider this plan done; report back with the exact refusal message and re-open investigation rather than declaring victory on unit tests alone — the live probe is the ground truth this plan exists to satisfy.
+
+- [ ] **Step 3: Report results**
+
+Note the outcome (success/failure, exact edit counts if successful) in the final task report — this becomes part of the PR description's test plan, the same way the original bug's live-probe findings were documented.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:** all three fixes from the design doc have a task (Task 1 = Fix 1, Task 2 = Fix 2, Task 3 = Fix 3); the design's testing section's per-fix/per-goal guidance is followed exactly (Task 2's test does not use `insert_fake_jar_symbol` since Fix 2 never touches `find_class_type_params`; Task 3's test constructs a JAR class symbol directly, following `indexer_tests.rs`'s own established `jar_symbol_resolved_via_import` pattern, not the function-only `insert_fake_jar_symbol` helper); the design's mandated live-probe re-run is Task 4.
+
+**Ordering:** the three fix tasks have no dependency on each other and could be done in any order or in parallel by independent reviewers — sequenced 1/2/3 here only because that's the order the design doc presents them in. Task 4 must run last, after all three are merged into the same build.
+
+**Type consistency:** `find_var_type`'s signature (`fn(&self, var_name: &str, uri: &Url) -> Option<String>`), `resolve_callee_chain`'s signature (`fn(callee: tree_sitter::Node<'_>, bytes: &[u8], deps: &impl InferDeps, uri: &Url) -> Option<(String, String)>`), and `find_class_type_params`'s signature (`fn(&self, class_name: &str) -> Vec<String>`) are all unchanged by their respective tasks — every fix is a body-only change, confirmed against the design doc's own "no signature change" framing for Fixes 1 and 3, and Fix 2's explicit "return contract unchanged, only which value" framing.
+
+**Known open item carried into Task 1:** the plan flags (Step 6) that `find_var_type`'s new fallback could add a per-miss re-parse cost on a hot path, and explicitly tells the implementer to check and report rather than silently ship or silently fix — this is a real, not-yet-measured risk the design doc raised and this plan does not resolve in advance, by design (measuring requires the actual implementation to exist first).

--- a/docs/superpowers/specs/2026-07-22-flow-generic-receiver-inference-design.md
+++ b/docs/superpowers/specs/2026-07-22-flow-generic-receiver-inference-design.md
@@ -120,13 +120,66 @@ let receiver_type = if callee.kind() == KIND_NAV_EXPR {
 } else { resolve_root_node_type(callee, bytes, deps, uri) };
 ```
 
-**Fix:** `forward_resolve_segments` must not resolve the *last* suffix into `current_type` when
-that suffix is itself the method being called with a trailing lambda — mirror
-`resolve_call_expr_type`'s exclusion. (Confirmed this is necessary independent of Bug 3: even with
-Bug 3 fixed, `map`'s own raw return type uses `map`'s *function-level* type parameter — commonly
-named `R` in the library source, distinct from `Flow`'s *class-level* `T` — so resolving "map" as
-a plain member access would still produce an unresolved placeholder even with class-level
-substitution working. The two bugs are independently necessary, not alternatives.)
+**Fix — corrected after independent critique found the first draft unsafe.** The first draft of
+this doc proposed changing `forward_resolve_segments`'s own core loop to skip its last segment.
+That is wrong and would have shipped a regression: `resolve_segments_type` (`chain.rs:546-566`,
+contract: "the final type after all segments") is a **thin wrapper that calls
+`forward_resolve_segments` on the exact list it's given, with no truncation of its own**.
+`resolve_call_expr_type` already calls `resolve_segments_type(&segments[..len-1], ...)` —
+pre-sliced *at the call site*. If `forward_resolve_segments` ALSO excluded its own last segment
+internally, `resolve_call_expr_type`'s already-correct call would double-truncate (resolving one
+segment short of where it should stop), and the existing test
+`unresolved_final_suffix_fails_the_strict_walk` (`src/indexer/infer/mod_tests.rs:133-162`, which
+calls `resolve_segments_type` directly and asserts the **last** segment IS attempted) would start
+failing. `forward_resolve_segments`/`resolve_segments_type`'s "resolve every segment I'm handed"
+contract must stay exactly as-is.
+
+The truncation belongs at the caller that currently lacks it: `resolve_callee_chain`'s
+`KIND_NAV_EXPR` arm (`chain.rs:241-247`), which today hands `forward_resolve_segments` the *full*
+segment list and is the one place actually trying to answer "receiver type right before this
+callee's own trailing call" — exactly the question `resolve_call_expr_type` already answers
+correctly for full call expressions, just not yet mirrored here for the bare-callee case:
+
+```rust
+k if k == KIND_NAV_EXPR => {
+    let segments = collect_nav_segments(callee, bytes);
+    if segments.len() < 2 {
+        return None; // no receiver to report for a bare/rootless callee
+    }
+    // Mirror resolve_call_expr_type's external pre-slice (chain.rs:436-449):
+    // the LAST segment is the method being called (`map`), not itself a
+    // member access to fold into the receiver's type.
+    let method_name = match segments.last()? {
+        NavSegment::Suffix { name, .. } => name.clone(),
+        _ => return None,
+    };
+    let receiver_type = resolve_segments_type(
+        &segments[..segments.len() - 1],
+        bytes,
+        deps,
+        uri,
+        SuffixStrictness::LeakReceiver,
+    )?;
+    Some((receiver_type, method_name))
+}
+```
+This keeps `forward_resolve_segments`/`resolve_segments_type` untouched and their existing test
+(`mod_tests.rs:133-162`) passing unchanged, while giving `resolve_callee_chain` the correct
+"receiver before the call" value for `userDataRepository.userData.map` (`Flow<UserData>`, not
+`map`'s own corrupted return type).
+
+**Which goal this actually fixes — corrected.** The first draft implied Bug 3 backs both Goal 1
+and Goal 2. It doesn't: Goal 1 (`.first()`) resolves through `resolve_call_expr_type`'s
+class-level path (`find_method_return_type_for_type` + `build_type_arg_subst`, which calls
+`find_class_type_params` — this is what Bug 3 fixes). Goal 2 (`.map { it }`) resolves through a
+**separate, independent mechanism** — `build_ext_fn_type_subst` (`type_subst.rs:108-150`), which
+derives its substitution purely from the extension function's own declared receiver-type text
+(`"Flow<T>"`) and its own `type_params` (`["T","R"]`), both already supplied by
+`find_fun_callable_info`'s existing, working JAR fallback — **it never calls
+`find_class_type_params` at all**. So Goal 2 needs only this fix (Bug 2); Bug 3 is what Goal 1
+needs. Both fixes are still required (this doc's "three independently-necessary" framing holds),
+but the internal wiring is per-goal, not shared — get this right when writing the plan so tests
+target the actual mechanism each goal depends on.
 
 ### Bug 3 — `find_class_type_params` never reads JAR-indexed classes
 
@@ -185,26 +238,59 @@ fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String> {
         .or_else(|| infer_variable_type_from_cst(self, var_name, uri))
 }
 ```
-`infer_variable_type_from_cst` already exists (used by `infer_receiver_type`) and is
-`pub(crate)`/reachable from `indexer.rs` today (confirm the exact visibility/import path when
-implementing — `infer_receiver_type` calls it directly in the same crate). This is a
-behavior-additive change: every existing caller of `find_var_type` that already succeeded via
-`infer_variable_type_raw` sees no change; only the previously-`None` chained-receiver case gains
-a real answer.
+**Verified visibility gap (caught by independent critique — not "confirm when implementing," a
+required action item):** `infer_variable_type_from_cst` (`src/resolver/infer.rs:431`) is
+module-private to `resolver::infer` — no `pub` at all. `infer_receiver_type` can call it because
+it lives in the same module; `find_var_type` (`src/indexer.rs`, a different module) cannot,
+as-is. **Fix 1 must also add `pub(crate)` to `infer_variable_type_from_cst`'s declaration** or it
+will not compile. This is small and mechanical but is a real, required part of the patch, not an
+implementation detail to sort out later.
 
-### Fix 2 — `src/indexer/infer/chain.rs`, `forward_resolve_segments`
+This is a behavior-additive change: every existing caller of `find_var_type` that already
+succeeded via `infer_variable_type_raw` sees no change; only the previously-`None`
+chained-receiver case gains a real answer. **Perf note, flagged by critique, not yet
+benchmarked:** `find_var_type` is called from several hot paths (`resolve_root_node_type`,
+`receiver_aware_params`, `cst_with_receiver_ctx`, `classify_this_lambda_context`); the new
+fallback triggers a tree-sitter re-parse (`live_doc_or_parse`) on every miss for indexed-but-closed
+files. Given this project's prior history of similar per-call scans causing hover/inlay stalls
+(see `[[perf-by-name-scan-cherry-pick]]` memory), the implementer should sanity-check this isn't a
+regression (e.g. time a hover-heavy operation on a large real file before/after) rather than
+assume it's free — flag DONE_WITH_CONCERNS if it looks costly rather than silently shipping it.
 
-Split the final segment out of the walk, mirroring `resolve_call_expr_type`'s
-`&segments[..segments.len() - 1]` exclusion, then resolve the excluded final segment's *own*
-return type as a separate, later step using the same `find_method_return_type_for_type` +
-`build_type_arg_subst`/`apply_type_subst` combination `resolve_call_expr_type` already uses
-(lines 461-465) — do not invent a new substitution mechanism, reuse the existing one. The
-function's return contract (`Option<(String, String)>` = `(receiver_type, method_name)`) is
-unchanged; only *which* value ends up as `receiver_type` when the last segment is itself a
-call-with-trailing-lambda changes (it becomes "the type before that call," not "that call's
-return type" — which is what every caller of `resolve_callee_chain`/`forward_resolve_segments`
-already expects per its own doc comment: "returning the type of the expression before the final
-method call").
+### Fix 2 — `src/indexer/infer/chain.rs`, `resolve_callee_chain`'s `KIND_NAV_EXPR` arm
+
+**Do NOT modify `forward_resolve_segments` or `resolve_segments_type` themselves** — their
+existing "resolve every segment I'm handed" contract is correct and load-bearing (see the
+"Fix — corrected" note above; the first draft of this section proposed changing the shared core
+loop and an independent critique found it would double-truncate `resolve_call_expr_type`'s
+already-correct usage and break `mod_tests.rs:133-162`). The fix lives entirely in
+`resolve_callee_chain`'s `KIND_NAV_EXPR` arm (`chain.rs:241-247`), pre-slicing the segments
+exactly like `resolve_call_expr_type` already does before calling `resolve_call_expr_type`'s own
+sibling helper `resolve_segments_type`:
+
+```rust
+k if k == KIND_NAV_EXPR => {
+    let segments = collect_nav_segments(callee, bytes);
+    if segments.len() < 2 {
+        return None;
+    }
+    let method_name = match segments.last()? {
+        NavSegment::Suffix { name, .. } => name.clone(),
+        _ => return None,
+    };
+    let receiver_type = resolve_segments_type(
+        &segments[..segments.len() - 1],
+        bytes,
+        deps,
+        uri,
+        SuffixStrictness::LeakReceiver,
+    )?;
+    Some((receiver_type, method_name))
+}
+```
+The function's return contract (`Option<(String, String)>` = `(receiver_type, method_name)`) is
+unchanged. `forward_resolve_segments`/`resolve_segments_type` never see a truncated-then-re-truncated
+list; every other caller of either is completely unaffected.
 
 ### Fix 3 — `src/indexer.rs`, `InferDeps::find_class_type_params`
 
@@ -246,21 +332,46 @@ JAR-defined generic classes, which previously always got an empty `Vec`.
 
 ## Testing
 
-Each fix needs its own unit test at the level it changes (the existing `InferDeps`/`TestDeps` fake
-in `src/indexer/infer/deps.rs` is the established pattern for testing these in isolation — see
-`it_this_tests.rs`'s `.with_class_params(...)` usage), PLUS one end-to-end house-decoy proving the
-combination works: a live-probe-equivalent test (or, if the existing test harness can construct
-an in-memory JAR-symbol fixture cheaply, an integration test) asserting `classify_cursor` on a
-`someFlow.first()`-derived reference and a `someFlow.map { it -> }` lambda `it` reference both
-produce `receiver_type: Some("UserData")` (or an equivalent concrete type), not `None` — this is
-the actual user-facing symptom and the regression floor for this fix.
+**`TestDeps` (`src/indexer/infer/deps.rs`) cannot test Fix 3 — verified by independent critique.**
+`TestDeps` is a from-scratch mock of the `InferDeps` trait; its `find_class_type_params` just
+reads a `HashMap` populated by `.with_class_params(...)` and never touches
+`Indexer::definitions`/`jar_definitions`/`jar_files` at all. A `TestDeps`-based test can prove
+downstream substitution logic behaves correctly *given* a non-empty type-params list — it cannot
+exercise or catch a regression in `Indexer::find_class_type_params`'s own
+workspace-then-JAR-fallback branching, which is the actual code Fix 3 adds. Using `TestDeps` here
+would be false confidence.
 
-Since `Flow` itself lives in a real JAR the unit-test harness doesn't materialize, the end-to-end
-test should use a workspace-defined stand-in generic type with the identical shape (a `class
-Box<T>` or similar declared directly in the test fixture, deliberately indexed the same way a JAR
-symbol would be via `TestDeps`) to prove the mechanism, PLUS a live-probe re-run against the real
-nowInAndroid project (same two cursor positions this bug was found at) before merge, to prove the
-real JAR case specifically.
+The codebase already has the right tool: `insert_fake_jar_symbol`
+(`src/indexer/infer/it_this_tests.rs:2047-2107`) builds a **real** `Indexer` and inserts a
+synthetic symbol directly into `idx.jar_files`/`idx.jar_definitions` — exactly what's needed to
+exercise Fix 3's real fallback branch. Several existing regression tests already use it for
+`find_fun_callable_info`'s JAR path, including `Flow<T>`-shaped cases
+(`regression_jar_collect_on_flow_t_container_generic_not_leak`,
+`regression_productflow_param_collect_result_not_t`); Fix 3's own test should follow the same
+pattern with a `SymbolKind::CLASS` entry instead of a function entry.
+
+Per-fix and per-goal testing (**do not conflate which fix backs which goal** — see the corrected
+Bug 2/3 analysis above):
+- **Fix 1** (`find_var_type`'s CST fallback): a unit test on `Indexer::find_var_type` directly —
+  a `val x = a.b.c()`-shaped chained initializer that the line heuristic can't type, asserting the
+  CST fallback now returns the right answer where it previously returned `None`.
+- **Fix 2** (`resolve_callee_chain`'s pre-slice): a unit test on `resolve_callee_chain` directly
+  (or `cst_it_element_type`/whatever calls it for the lambda-`it` path) proving a
+  `receiver.member.method { lambda }`-shaped callee now returns `(type-of-receiver.member,
+  "method")` instead of `method`'s own corrupted return type — this is Goal 2's actual regression
+  floor, and does NOT need `insert_fake_jar_symbol` since it never touches
+  `find_class_type_params`; a workspace-defined stand-in generic (e.g. a test-fixture `class
+  Box<T>`) is sufficient and appropriate here.
+- **Fix 3** (`find_class_type_params`'s JAR fallback): a unit test using
+  `insert_fake_jar_symbol` to insert a synthetic JAR-defined generic class, asserting
+  `find_class_type_params` now returns its real type params instead of an empty `Vec` — this is
+  Goal 1's actual regression floor.
+- **End-to-end, both goals combined:** a live-probe re-run against the real nowInAndroid project
+  (the exact two cursor positions this bug was found at — `OfflineFirstNewsRepository.kt`'s
+  `.first()`-derived `userData` and `ForYouViewModel.kt`'s lambda `it`) before merge, confirming
+  `classify_cursor`'s `receiver_type` now resolves to `Some("UserData")` at both, and — the
+  original symptom that started this investigation — that rename from those exact reference sites
+  now succeeds instead of refusing.
 
 ## Spec correction
 

--- a/docs/superpowers/specs/2026-07-22-flow-generic-receiver-inference-design.md
+++ b/docs/superpowers/specs/2026-07-22-flow-generic-receiver-inference-design.md
@@ -1,0 +1,276 @@
+# Flow&lt;T&gt; Generic Receiver-Type Inference — Design
+
+Status: **approved design** (investigated via three parallel scout agents, then independently
+re-verified line-by-line against the real code before this doc was written; no open questions
+remain — every claim below cites the exact current code).
+
+## Context (why)
+
+Live-probing the just-shipped CST-verified rename (PR #229) against a real Android project
+(nowInAndroid) found: renaming a data class field from a REFERENCE site fails ("identity is
+ambiguous") whenever the receiver's type is derived by substituting `kotlinx.coroutines.flow.Flow<T>`'s
+generic type argument — both `val x = someFlow.first()` (`T` from a suspend terminal operator's
+return type) and `someFlow.map { it -> ... }` (`T` as the lambda parameter's type). Renaming from
+the field's own declaration works fine; only reference-site rename is affected.
+
+A companion investigation found: this is genuinely the first user-visible break from this gap.
+Go-to-definition silently falls back to an older `CursorContext`-based resolver that still
+produces the right answer; find-references' recall never depended on this classifier in the
+first place (only optional post-hoc verification does, and that verification only *subtracts*
+proven-wrong candidates, never blocks); hover doesn't use this code path at all. Rename is
+unique in requiring the CST engine's `resolve_identity` to succeed with no fallback — by design,
+since a fallback here would reintroduce the exact "silent wrong edit" risk 6c's design was built
+to eliminate. **The fix belongs in the shared inference engine, not in loosening rename's
+identity check.**
+
+A second companion investigation found this partially re-surfaces a conclusion from
+`docs/superpowers/specs/2026-07-20-cst-find-references-design.md:28-35`, which examined the same
+failure shape (a generic-typed receiver never reaching `resolve_identity`'s narrowing logic) and
+concluded it was "unreachable... no bug to retrofit." The live probe now contradicts that —
+`Flow<T>` is a JAR-defined generic, which that analysis didn't distinguish from a workspace-defined
+one. See "Non-goals" for the precise scope of what this doc corrects.
+
+## Goals / non-goals
+
+**Goals**
+1. `val x = someFlow.first()`-shaped local variables (a chained receiver ending in a call) get a
+   correctly-typed CST-aware fallback when the line-based heuristic can't type them.
+2. `someFlow.map { it -> ... }`'s lambda parameter type resolves to the flow's concrete element
+   type, not a leftover generic placeholder.
+3. JAR-defined generic classes' own type parameters (e.g. `Flow<T>`'s `T`) become resolvable at
+   all — today only JAR-defined *functions'* type parameters are (`find_fun_callable_info` already
+   has a JAR fallback; its sibling for classes, `find_class_type_params`, does not).
+4. Correct the `2026-07-20` spec's stale "unreachable" conclusion with a pointer to this doc.
+
+**Non-goals**
+- A general rewrite of the resolution engine's fragmented parallel paths (`parser.rs`'s RHS
+  extraction, `resolver/infer.rs`'s legacy line-scan, `indexer/infer/chain.rs`'s CST walk). That's
+  the long-standing, separately-tracked "unified-resolution" effort; these three fixes are
+  self-contained patches within the existing architecture, not a step toward collapsing it.
+- Making rename accept an unverified fallback path. That would reintroduce exactly the risk 6c
+  was built to eliminate — the correct fix is making the underlying inference actually correct,
+  not loosening what rename requires of it.
+- Any other JAR-defined generic type beyond what these three fixes generally enable — this doc
+  doesn't hunt for every stdlib generic that might still fail; it fixes the three specific,
+  independently-necessary gaps found, which happen to generalize to any JAR-defined generic class.
+
+## The three bugs, each independently necessary
+
+Traced end-to-end from `rename_impl` → `classify_cursor`/`classify_symbol_at` →
+`CstQuery::expr_type()` → `infer_expr_type` → `infer_ident_type` (`src/indexer/infer/expr_type.rs:120`),
+which tries `deps.find_contextual_type` (lambda/`it`) then `deps.find_var_type` (plain variable).
+
+### Bug 1 — `find_var_type` has no CST fallback for chained receivers
+
+`src/indexer.rs:407-409`:
+```rust
+fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String> {
+    infer_variable_type_raw(self, var_name, uri)
+}
+```
+`infer_variable_type_raw` bottoms out in two independent heuristics that both explicitly bail on
+a chained (`nav_expr`) receiver:
+- `parser.rs:2066-2068`'s `call_expr_receiver_method`: `// Reject multi-level chaining... if receiver_node.kind() == KIND_NAV_EXPR { return None; }`
+- `resolver/infer.rs:704`'s line-scan fallback: `if receiver == "this" || receiver == "super" || receiver.contains('.') { continue; }`
+
+So for `val userData = niaPreferencesDataSource.userData.first()`, both heuristics reject the
+chained `niaPreferencesDataSource.userData` receiver and `find_var_type` returns `None` —
+`userData`'s type is never even attempted via the CST-aware path.
+
+The sibling `infer_receiver_type` (`src/resolver/infer.rs:157-181`, used by hover and others, NOT
+by rename's classifier) already has the missing fallback:
+```rust
+ReceiverKind::Variable(name) => match infer_variable_type_raw(indexer, name, uri) {
+    Some(raw) => raw,
+    // CST fallback for initializers the line heuristics miss (e.g. `val x = remember { Foo() }` → `Foo`).
+    None => infer_variable_type_from_cst(indexer, name, uri)?,
+},
+```
+
+**Fix:** give `find_var_type` the same fallback.
+
+### Bug 2 — `forward_resolve_segments` resolves the final segment instead of excluding it
+
+`forward_resolve_segments` (`src/indexer/infer/chain.rs:109-225`) is used (via `resolve_callee_chain`)
+to compute "the receiver type right before the trailing lambda's call" for `someFlow.map { it -> }`.
+Its `NavSegment::Suffix` arm (lines 139-164) applies to *every* suffix uniformly, including the
+last one:
+```rust
+if let Some(resolved) = resolve_member_type_on(cur, name, deps, uri) {
+    current_type = Some(resolved);
+    last_suffix_resolved = true;
+}
+```
+For `userDataRepository.userData.map`, the segments are `Root(userDataRepository)`,
+`Suffix("userData")`, `Suffix("map")` — "map" is *also* a plain `Suffix` here (the call's trailing
+lambda means "map" never becomes a `NavSegment::CallExpr`). So `current_type` gets overwritten
+with `map`'s own (still-generic, function-level-parameterized) return type instead of stopping at
+`Flow<UserData>` — corrupting exactly the value downstream generic substitution needs.
+
+The sibling `resolve_call_expr_type` (`chain.rs:418-495`) already does this correctly — it
+explicitly excludes the final segment before resolving the receiver, then computes the called
+function's own return type as a separate, later step (with its own substitution logic, lines
+453-467):
+```rust
+let receiver_type = if callee.kind() == KIND_NAV_EXPR {
+    let segments = collect_nav_segments(callee, bytes);
+    if segments.len() >= 2 {
+        resolve_segments_type(&segments[..segments.len() - 1], bytes, deps, uri, SuffixStrictness::LeakReceiver)
+    } else { None }
+} else { resolve_root_node_type(callee, bytes, deps, uri) };
+```
+
+**Fix:** `forward_resolve_segments` must not resolve the *last* suffix into `current_type` when
+that suffix is itself the method being called with a trailing lambda — mirror
+`resolve_call_expr_type`'s exclusion. (Confirmed this is necessary independent of Bug 3: even with
+Bug 3 fixed, `map`'s own raw return type uses `map`'s *function-level* type parameter — commonly
+named `R` in the library source, distinct from `Flow`'s *class-level* `T` — so resolving "map" as
+a plain member access would still produce an unresolved placeholder even with class-level
+substitution working. The two bugs are independently necessary, not alternatives.)
+
+### Bug 3 — `find_class_type_params` never reads JAR-indexed classes
+
+`src/indexer.rs:423-442`:
+```rust
+fn find_class_type_params(&self, class_name: &str) -> Vec<String> {
+    let Some(locations) = self.definitions.get(class_name) else { return Vec::new(); };
+    for loc in locations.iter() {
+        ...self.files.get(url.as_str())...
+    }
+    Vec::new()
+}
+```
+Only ever reads `self.definitions`/`self.files` (workspace-indexed symbols). `Flow<T>` is declared
+in the kotlinx-coroutines-core JAR, so this always returns an empty `Vec` for `"Flow"` — meaning
+`build_type_arg_subst` (`indexer/infer/type_subst.rs:21-39`, called from both
+`resolve_member_type_on` and `resolve_call_expr_type`) can never build a `T → UserData`
+substitution for `Flow`, no matter how the call is reached. This is why even a correctly-reached
+`Flow<UserData>.first(): T` still can't resolve to `UserData` — the substitution map is always
+empty for any JAR-defined generic class.
+
+The sibling `find_fun_callable_info` (`src/indexer.rs:467-506`) already has exactly this fallback
+for *functions'* type parameters:
+```rust
+let from_workspace = self.find_in_workspace_defs(fn_name, |loc| { ... });
+if from_workspace.is_some() { return from_workspace; }
+// Fallback: JAR-indexed files (sidecar symbols carry type_params)...
+let mut cache_backed_only = 0usize;
+crate::indexer::jar::ensure_jar_definitions_for(self, fn_name, &mut cache_backed_only);
+let jar_locs = self.jar_definitions.get(fn_name)?;
+for loc in jar_locs.iter().take(MAX_BY_NAME_DEFS) {
+    if let Some(file_data) = self.jar_files.get(loc.uri.as_str()) {
+        if let Some(sym) = file_data.symbols.get(loc.range.start.line as usize)
+            .filter(|s| s.name == fn_name && !s.type_params().is_empty())
+        {
+            return Some(CallableInfo { type_params: sym.type_params().to_vec(), ... });
+        }
+    }
+}
+```
+Note the JAR-symbol addressing convention: `loc.range.start.line as usize` is a synthetic index
+into the JAR file's `symbols` Vec (O(1) direct addressing), not a real line number — this is an
+existing, established convention in this codebase for JAR-indexed symbols, not something this fix
+invents.
+
+**Fix:** give `find_class_type_params` the identical two-tier (workspace-first, JAR-fallback)
+shape, addressing JAR symbols the same synthetic-line-as-index way `find_fun_callable_info` does.
+
+## Design: the three fixes
+
+### Fix 1 — `src/indexer.rs`, `InferDeps::find_var_type`
+
+```rust
+fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String> {
+    infer_variable_type_raw(self, var_name, uri)
+        .or_else(|| infer_variable_type_from_cst(self, var_name, uri))
+}
+```
+`infer_variable_type_from_cst` already exists (used by `infer_receiver_type`) and is
+`pub(crate)`/reachable from `indexer.rs` today (confirm the exact visibility/import path when
+implementing — `infer_receiver_type` calls it directly in the same crate). This is a
+behavior-additive change: every existing caller of `find_var_type` that already succeeded via
+`infer_variable_type_raw` sees no change; only the previously-`None` chained-receiver case gains
+a real answer.
+
+### Fix 2 — `src/indexer/infer/chain.rs`, `forward_resolve_segments`
+
+Split the final segment out of the walk, mirroring `resolve_call_expr_type`'s
+`&segments[..segments.len() - 1]` exclusion, then resolve the excluded final segment's *own*
+return type as a separate, later step using the same `find_method_return_type_for_type` +
+`build_type_arg_subst`/`apply_type_subst` combination `resolve_call_expr_type` already uses
+(lines 461-465) — do not invent a new substitution mechanism, reuse the existing one. The
+function's return contract (`Option<(String, String)>` = `(receiver_type, method_name)`) is
+unchanged; only *which* value ends up as `receiver_type` when the last segment is itself a
+call-with-trailing-lambda changes (it becomes "the type before that call," not "that call's
+return type" — which is what every caller of `resolve_callee_chain`/`forward_resolve_segments`
+already expects per its own doc comment: "returning the type of the expression before the final
+method call").
+
+### Fix 3 — `src/indexer.rs`, `InferDeps::find_class_type_params`
+
+```rust
+fn find_class_type_params(&self, class_name: &str) -> Vec<String> {
+    if let Some(locations) = self.definitions.get(class_name) {
+        for loc in locations.iter() {
+            let Some(url) = self.file_table.url(loc.file) else { continue };
+            if let Some(file_data) = self.files.get(url.as_str()) {
+                if let Some(sym) = file_data.symbols.iter()
+                    .find(|s| s.name == class_name && !s.type_params().is_empty())
+                {
+                    return sym.type_params().to_vec();
+                }
+            }
+        }
+    }
+    // Fallback: JAR-indexed files. Same synthetic-line-as-index addressing
+    // find_fun_callable_info already uses for JAR symbols.
+    let mut cache_backed_only = 0usize;
+    crate::indexer::jar::ensure_jar_definitions_for(self, class_name, &mut cache_backed_only);
+    if let Some(jar_locs) = self.jar_definitions.get(class_name) {
+        for loc in jar_locs.iter().take(MAX_BY_NAME_DEFS) {
+            if let Some(file_data) = self.jar_files.get(loc.uri.as_str()) {
+                if let Some(sym) = file_data.symbols.get(loc.range.start.line as usize)
+                    .filter(|s| s.name == class_name && !s.type_params().is_empty())
+                {
+                    return sym.type_params().to_vec();
+                }
+            }
+        }
+    }
+    Vec::new()
+}
+```
+Behavior-preserving for every class that already resolved via the workspace path (the fallback is
+only reached when the workspace loop finds nothing); newly returns real type params for
+JAR-defined generic classes, which previously always got an empty `Vec`.
+
+## Testing
+
+Each fix needs its own unit test at the level it changes (the existing `InferDeps`/`TestDeps` fake
+in `src/indexer/infer/deps.rs` is the established pattern for testing these in isolation — see
+`it_this_tests.rs`'s `.with_class_params(...)` usage), PLUS one end-to-end house-decoy proving the
+combination works: a live-probe-equivalent test (or, if the existing test harness can construct
+an in-memory JAR-symbol fixture cheaply, an integration test) asserting `classify_cursor` on a
+`someFlow.first()`-derived reference and a `someFlow.map { it -> }` lambda `it` reference both
+produce `receiver_type: Some("UserData")` (or an equivalent concrete type), not `None` — this is
+the actual user-facing symptom and the regression floor for this fix.
+
+Since `Flow` itself lives in a real JAR the unit-test harness doesn't materialize, the end-to-end
+test should use a workspace-defined stand-in generic type with the identical shape (a `class
+Box<T>` or similar declared directly in the test fixture, deliberately indexed the same way a JAR
+symbol would be via `TestDeps`) to prove the mechanism, PLUS a live-probe re-run against the real
+nowInAndroid project (same two cursor positions this bug was found at) before merge, to prove the
+real JAR case specifically.
+
+## Spec correction
+
+`docs/superpowers/specs/2026-07-20-cst-find-references-design.md`'s "Retrofit" analysis (lines
+28-35) concluded a generic-typed receiver reaching `resolve_identity`'s `Reference` arm was
+"unreachable" because `infer_ident_type` strips generics from the type STRING before it's
+produced. That analysis is about a *different* mechanism (string-stripping for an exact-key
+lookup) than this bug (never attempting substitution in the first place for a JAR-defined
+generic's own type parameters) — both are real, but the earlier analysis's "no bug to retrofit"
+conclusion for the broader class of "generic-typed receiver" scenarios doesn't hold now that a
+live probe found a concrete case. Add a short correction note there pointing at this doc, rather
+than rewriting that doc's own (still largely correct, for the specific narrower case it examined)
+analysis.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -119,7 +119,7 @@ mod live_tree_impl;
 // Re-export cache/scan items needed by the inline test module below.
 #[cfg(test)]
 use self::cache::{cache_entry_to_file_result, FileCacheEntry};
-use crate::resolver::infer_variable_type_raw;
+use crate::resolver::{infer_variable_type_from_cst, infer_variable_type_raw};
 #[cfg(test)]
 use crate::rg::regex_escape;
 #[cfg(test)]
@@ -406,6 +406,7 @@ impl InferDeps for Indexer {
     }
     fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String> {
         infer_variable_type_raw(self, var_name, uri)
+            .or_else(|| infer_variable_type_from_cst(self, var_name, uri))
     }
     fn find_field_type(&self, class_name: &str, field_name: &str) -> Option<String> {
         if let Some(type_name) = synthetic_enum_field(self, class_name, field_name) {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -422,20 +422,38 @@ impl InferDeps for Indexer {
         crate::resolver::infer::find_fun_return_type_reachable(self, fn_name, uri)
     }
     fn find_class_type_params(&self, class_name: &str) -> Vec<String> {
-        let Some(locations) = self.definitions.get(class_name) else {
-            return Vec::new();
-        };
-        for loc in locations.iter() {
-            let Some(url) = self.file_table.url(loc.file) else {
-                continue;
-            };
-            if let Some(file_data) = self.files.get(url.as_str()) {
-                if let Some(sym) = file_data
-                    .symbols
-                    .iter()
-                    .find(|s| s.name == class_name && !s.type_params().is_empty())
-                {
-                    return sym.type_params().to_vec();
+        if let Some(locations) = self.definitions.get(class_name) {
+            for loc in locations.iter() {
+                let Some(url) = self.file_table.url(loc.file) else {
+                    continue;
+                };
+                if let Some(file_data) = self.files.get(url.as_str()) {
+                    if let Some(sym) = file_data
+                        .symbols
+                        .iter()
+                        .find(|s| s.name == class_name && !s.type_params().is_empty())
+                    {
+                        return sym.type_params().to_vec();
+                    }
+                }
+            }
+        }
+        // Fallback: JAR-indexed classes. Same synthetic-line-as-index
+        // addressing find_fun_callable_info (this same file) already uses
+        // for JAR symbols -- a JAR symbol's "line" is really an index into
+        // its file's own `symbols` Vec, not a real line number.
+        let mut cache_backed_only = 0usize;
+        crate::indexer::jar::ensure_jar_definitions_for(self, class_name, &mut cache_backed_only);
+        if let Some(jar_locs) = self.jar_definitions.get(class_name) {
+            for loc in jar_locs.iter().take(MAX_BY_NAME_DEFS) {
+                if let Some(file_data) = self.jar_files.get(loc.uri.as_str()) {
+                    if let Some(sym) = file_data
+                        .symbols
+                        .get(loc.range.start.line as usize)
+                        .filter(|s| s.name == class_name && !s.type_params().is_empty())
+                    {
+                        return sym.type_params().to_vec();
+                    }
                 }
             }
         }

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -243,7 +243,56 @@ pub(super) fn resolve_callee_chain(
             if segments.is_empty() {
                 return None;
             }
-            forward_resolve_segments(&segments, bytes, deps, uri, SuffixStrictness::LeakReceiver)
+            // Mirror resolve_call_expr_type's pre-slice (this same file,
+            // ~line 436-449): when the final segment is a plain
+            // (non-scope-function) method name -- e.g. "map" in
+            // `container.items.map { }` -- it is the method being called
+            // with the trailing lambda, not itself a member access to fold
+            // into the receiver's type, so exclude it before resolving.
+            //
+            // Scope functions (let/also/run/apply/takeIf/takeUnless) are
+            // deliberately NOT excluded here, exactly like
+            // resolve_call_expr_type's own SCOPE_FUNCTIONS check gates its
+            // pre-slice: forward_resolve_segments already flows the
+            // receiver type through a scope-function Suffix unchanged, and
+            // that full-list walk also carries side effects tied to
+            // processing that exact segment (e.g. `?.`-driven nullability
+            // stripping) that only fire while it is actually visited.
+            // Slicing it away unconditionally silently drops those side
+            // effects -- caught by running the full suite after the initial
+            // unconditional-slice attempt, which broke
+            // `nullable_let_chain_it_type_resolves`,
+            // `this_type_apply_on_constructor_call_infers_receiver`, and 7
+            // other scope-function-terminated chain tests.
+            //
+            // Do NOT push this exclusion into
+            // forward_resolve_segments/resolve_segments_type themselves --
+            // their "resolve every segment I'm handed" contract is relied on
+            // elsewhere (see mod_tests.rs's
+            // unresolved_final_suffix_fails_the_strict_walk) and by
+            // resolve_call_expr_type's own already-correct pre-sliced call.
+            match segments.last() {
+                Some(NavSegment::Suffix { name, .. })
+                    if !SCOPE_FUNCTIONS.contains(&name.as_str()) =>
+                {
+                    let method_name = name.clone();
+                    let receiver_type = resolve_segments_type(
+                        &segments[..segments.len() - 1],
+                        bytes,
+                        deps,
+                        uri,
+                        SuffixStrictness::LeakReceiver,
+                    )?;
+                    Some((receiver_type, method_name))
+                }
+                _ => forward_resolve_segments(
+                    &segments,
+                    bytes,
+                    deps,
+                    uri,
+                    SuffixStrictness::LeakReceiver,
+                ),
+            }
         }
         k if k == KIND_SIMPLE_IDENT || k == KIND_TYPE_IDENT => {
             let name = callee.utf8_text_owned(bytes)?;

--- a/src/indexer/infer/mod_tests.rs
+++ b/src/indexer/infer/mod_tests.rs
@@ -161,6 +161,68 @@ fn unresolved_final_suffix_fails_the_strict_walk() {
     );
 }
 
+#[test]
+fn resolve_callee_chain_reports_receiver_type_before_the_final_method_not_its_return_type() {
+    use super::chain::resolve_callee_chain;
+
+    // `container.items.map` -- a nav_expr callee for `container.items.map { ... }`.
+    // resolve_callee_chain must report the type of `container.items` (Box<Thing>)
+    // as the receiver, and "map" as the method name -- NOT "map"'s own (here,
+    // deliberately wrong/unresolvable) return type folded into current_type.
+    let uri = test_url("/Chain.kt");
+    let deps = super::deps::TestDeps::new()
+        .with_var(uri.as_str(), "container", "Container")
+        .with_field("Container", "items", "Box<Thing>");
+    let doc = live_doc_for("fun f() { container.items.map { it } }\n");
+    let nav =
+        find_first_node_of_kind(doc.tree.root_node(), "navigation_expression").expect("nav node");
+
+    let result = resolve_callee_chain(nav, &doc.bytes, &deps, &uri);
+    assert_eq!(
+        result,
+        Some(("Box<Thing>".to_owned(), "map".to_owned())),
+        "receiver type must be Box<Thing> (the type before .map), with \"map\" \
+         as the separately-reported method name -- got {result:?}"
+    );
+}
+
+/// Supplementary pin for the same bug as the test above, using a receiver whose
+/// final segment ("map") IS indexed as a real (generic, unresolvable) method --
+/// this is what actually exercises `resolve_member_type_on`'s generic-param
+/// fallback (`first_type_arg_raw`) and corrupts `current_type` pre-fix. The
+/// verbatim brief test above happens to pass even before the fix, because
+/// `TestDeps` there has no "map" method registered at all, so
+/// `resolve_member_type_on` returns `None` cleanly and `LeakReceiver` lets the
+/// type flow through unchanged by coincidence -- it does not exercise the
+/// corruption path. This test does, matching the live-probed Flow<T>.map bug:
+/// pre-fix this resolves to `Some(("Thing", "map"))` (the corrupted, unwrapped
+/// element type); post-fix it must be `Some(("Box<Thing>", "map"))`.
+#[test]
+fn resolve_callee_chain_does_not_corrupt_receiver_when_final_method_is_indexed_and_generic() {
+    use super::chain::resolve_callee_chain;
+
+    let uri = test_url("/ChainIndexedMap.kt");
+    let deps = super::deps::TestDeps::new()
+        .with_var(uri.as_str(), "container", "Container")
+        .with_field("Container", "items", "Box<Thing>")
+        // "map" is indexed on Box, returning its own unresolved generic param "T"
+        // (no `with_class_params` registered for "Box", so the type-arg subst is
+        // empty and "T" stays a generic placeholder -- forcing the
+        // `first_type_arg_raw` fallback in `resolve_member_type_on`).
+        .with_method_return_for_type("Box", "map", "T");
+    let doc = live_doc_for("fun f() { container.items.map { it } }\n");
+    let nav =
+        find_first_node_of_kind(doc.tree.root_node(), "navigation_expression").expect("nav node");
+
+    let result = resolve_callee_chain(nav, &doc.bytes, &deps, &uri);
+    assert_eq!(
+        result,
+        Some(("Box<Thing>".to_owned(), "map".to_owned())),
+        "receiver type must stay Box<Thing> (the type before .map) even though \
+         \"map\" is indexed with a generic return type -- got {result:?}"
+    );
+}
+
 /// Unknown ROOT decoy: `resolve_root_node_type` falls back to `Some(name)`
 /// for an unresolvable root ident; combined with a leaking walk this used to
 /// be able to resolve a nav to the literal root string. The strict nav arm

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -3351,3 +3351,79 @@ fn indexer_has_jar_tier1_fields_initialized_empty() {
     let id = idx.jar_table.intern("/some/path.jar");
     assert_eq!(idx.jar_table.path(id).as_deref(), Some("/some/path.jar"));
 }
+
+#[test]
+fn find_class_type_params_falls_back_to_jar_indexed_classes() {
+    // Simulates a JAR-provided generic class (e.g. kotlinx.coroutines.flow.Flow<T>)
+    // whose own type parameter is needed for generic substitution elsewhere
+    // (build_type_arg_subst). Before this fix, find_class_type_params only
+    // ever read workspace-indexed classes and always returned an empty Vec
+    // for any JAR-defined one.
+    use crate::types::{FileData, SourceSet, SymbolEntry, Visibility};
+    use std::sync::Arc;
+    use tower_lsp::lsp_types::{Location, Position, Range, Url};
+
+    let jar_uri = Url::parse("jar:file:///lib/fake-flow.jar!/").unwrap();
+    let idx = Indexer::new();
+
+    let range = Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 4,
+        },
+    };
+    let flow_symbol = SymbolEntry {
+        name: "Flow".into(),
+        kind: SymbolKind::CLASS,
+        visibility: Visibility::Public,
+        range,
+        selection_range: range,
+        detail: "interface kotlinx.coroutines.flow.Flow<out T>".into(),
+        container: None,
+        params: String::new(),
+        param_counts: (0, 0),
+        cold: crate::types::pack_cold_fields(
+            vec!["T".to_owned()],
+            String::new(),
+            String::new(),
+            "A cold asynchronous data stream".into(),
+        ),
+        trailing_lambda: false,
+        deprecated: false,
+    };
+
+    idx.jar_definitions
+        .entry("Flow".into())
+        .or_default()
+        .push(Location {
+            uri: jar_uri.clone(),
+            range,
+        });
+    idx.jar_files.insert(
+        jar_uri.to_string(),
+        Arc::new(FileData {
+            symbols: vec![flow_symbol],
+            source_set: SourceSet::Library,
+            lines: Arc::new(vec![]),
+            ..Default::default()
+        }),
+    );
+
+    let type_params = idx.find_class_type_params("Flow");
+    assert_eq!(
+        type_params,
+        vec!["T".to_owned()],
+        "must find Flow's own type parameter via the JAR fallback -- got {type_params:?}"
+    );
+
+    // Decoy: a genuinely unknown class (neither workspace nor JAR-indexed)
+    // must still return an empty Vec, not panic or find something spurious.
+    assert!(
+        idx.find_class_type_params("TotallyUnknownClass").is_empty(),
+        "an unindexed class name must return an empty Vec, not panic"
+    );
+}

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -2315,6 +2315,52 @@ fn lambda_param_dotted_nested_class_chain() {
 }
 
 #[test]
+fn find_var_type_resolves_a_chained_call_initializer_via_cst_fallback() {
+    // `val local = this.userData` -- a chained (nav_expr) receiver that the
+    // line-based heuristics in infer_variable_type_raw explicitly reject
+    // (parser.rs's nav_expr_receiver_field rejects `this`/`super` receivers).
+    // Only the CST-aware fallback (infer_variable_type_from_cst) can type this.
+    let idx = Indexer::new();
+    let repo_uri = uri("/Repository.kt");
+    idx.index_content(
+        &repo_uri,
+        concat!(
+            "package com.example\n",
+            "data class UserData(val shouldHideOnboarding: Boolean)\n",
+            "class Repository {\n",
+            "    val userData: UserData = TODO()\n",
+            "    fun use() {\n",
+            "        val local = this.userData\n",
+            "        val hasOnboarded = local.shouldHideOnboarding\n",
+            "    }\n",
+            "}\n",
+        ),
+    );
+    idx.store_live_tree(
+        &repo_uri,
+        concat!(
+            "package com.example\n",
+            "data class UserData(val shouldHideOnboarding: Boolean)\n",
+            "class Repository {\n",
+            "    val userData: UserData = TODO()\n",
+            "    fun use() {\n",
+            "        val local = this.userData\n",
+            "        val hasOnboarded = local.shouldHideOnboarding\n",
+            "    }\n",
+            "}\n",
+        ),
+    );
+
+    let var_type = idx.find_var_type("local", &repo_uri);
+    assert_eq!(
+        var_type.as_deref(),
+        Some("UserData"),
+        "find_var_type must resolve a chained (this.userData-style) initializer \
+         via the CST fallback when the line heuristic can't -- got {var_type:?}"
+    );
+}
+
+#[test]
 fn lambda_param_dotted_nested_class_chain_with_stdlib() {
     // Same as above but with stdlib sources indexed (simulates post-indexing state)
     let idx = Indexer::new();

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -428,7 +428,11 @@ fn infer_var_from_rhs_data(
 /// the live tree and infer the initializer's type via `infer_expr_type`. Catches
 /// cases the line-based heuristics miss — notably lambda-result calls like
 /// Compose `remember { Foo() }` (→ `Foo`) and constructor calls.
-fn infer_variable_type_from_cst(indexer: &Indexer, var_name: &str, uri: &Url) -> Option<String> {
+pub(crate) fn infer_variable_type_from_cst(
+    indexer: &Indexer,
+    var_name: &str,
+    uri: &Url,
+) -> Option<String> {
     let doc = indexer.live_doc_or_parse(uri)?;
     let bytes = doc.bytes.as_slice();
     let init = find_prop_initializer(doc.tree.root_node(), bytes, var_name)?;

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -23,8 +23,8 @@ pub(crate) use complete::{complete_symbol, complete_symbol_with_context, is_anno
 pub(crate) use hierarchy::{receiver_type_agreement, walk_hierarchy, ReceiverTypeAgreement};
 pub(crate) use import_edit::{already_imported, import_insertion_line, make_import_edit};
 pub(crate) use infer::{
-    infer_receiver_type, infer_receiver_type_at, infer_variable_type_raw, InferenceChain,
-    ReceiverKind, ReceiverType,
+    infer_receiver_type, infer_receiver_type_at, infer_variable_type_from_cst,
+    infer_variable_type_raw, InferenceChain, ReceiverKind, ReceiverType,
 };
 pub(crate) use infer_lines::extract_collection_element_type;
 pub(crate) use resolve::{ensure_file_data, fqns_for_name, resolve_symbol_no_rg};


### PR DESCRIPTION
## Summary

Live-probe testing of PR #229's rename feature against nowInAndroid (see that PR's comment thread) found reference-site rename failing for any receiver whose type is derived by substituting `kotlinx.coroutines.flow.Flow<T>`'s generic argument — e.g. `someFlow.first()` and `someFlow.map { it -> }`. Investigation (3 parallel scouts) found this is **3 independently pre-existing, narrow inference gaps**, not an architectural issue — go-to-def/find-references/hover all tolerate the gap by design; only rename's stricter identity requirement exposed it.

- `InferDeps::find_var_type` (`src/indexer.rs`) had no CST-aware fallback for chained receivers — added, mirroring the sibling `infer_receiver_type`'s existing `infer_variable_type_from_cst` fallback.
- `resolve_callee_chain`'s `KIND_NAV_EXPR` arm (`src/indexer/infer/chain.rs`) resolved its full segment list instead of excluding the final segment before resolving the receiver type — fixed by pre-slicing at the call site (mirroring `resolve_call_expr_type`'s existing pattern), gated on `!SCOPE_FUNCTIONS.contains(fn_name)` since scope functions (`let`/`also`/`run`/`apply`/etc.) take a different, already-correct path.
- `InferDeps::find_class_type_params` (`src/indexer.rs`) never read JAR-indexed classes, only workspace-defined ones — added a JAR fallback mirroring the sibling `find_fun_callable_info`'s existing pattern.

Design and plan docs: `docs/superpowers/specs/2026-07-22-flow-generic-receiver-inference-design.md`, `docs/superpowers/plans/2026-07-22-flow-generic-receiver-inference.md`.

## Test plan

- [x] `cargo test`: 1565 passed / 0 failed / 3 ignored (main suite), 0 failures across all test binaries
- [x] `cargo clippy --all-targets -- -D warnings`: clean
- [x] Per-task unit tests for each of the 3 fixes (CST fallback, chain pre-slice, JAR fallback), each verified RED pre-fix / GREEN post-fix
- [x] Whole-branch review (opus): READY TO MERGE AS-IS, zero Critical/Important findings
- [x] Live-probe re-verification against the real nowInAndroid project at the exact two cursor positions that originally failed: both now succeed (16 files / 33 edits each), consistent ~50ms latency — resolves the perf concern raised during Task 1 for the real-world scenario (a `this`-receiver-shaped synthetic microbenchmark found a ~77x slower miss path, but the real bug's bare-identifier-receiver shape does not enter that path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)