### PR TITLE
fix(diagnostics): missing-import diagnostics on edit + import quick-fix

### DIFF
--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -74,6 +74,13 @@ impl Backend {
             {
                 actions.push(action);
             }
+            actions.extend(
+                features::missing_import_diagnostics::missing_import_actions(
+                    self.indexer.as_ref(),
+                    uri,
+                    &params.context.diagnostics,
+                ),
+            );
         }
 
         let lang = crate::Language::from_path(uri.path());

--- a/src/features/missing_import_diagnostics.rs
+++ b/src/features/missing_import_diagnostics.rs
@@ -15,7 +15,8 @@
 //! [`collect_missing_import_flags`] over an entire workspace to measure
 //! precision — see that module for the aggregate false-positive methodology.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use tower_lsp::lsp_types::*;
 use tree_sitter::Node;
@@ -28,6 +29,7 @@ use crate::queries::{
 };
 use crate::resolver::{fqns_for_name, receiver_provides_member, resolve_in_scope_strict};
 use crate::types::CursorPos;
+use crate::LinesExt;
 
 /// A flagged reference: the bare name and where it occurs.
 pub(crate) struct MissingImportFlag {
@@ -301,6 +303,73 @@ pub(crate) fn missing_import_diagnostics(
             ..Default::default()
         })
         .collect()
+}
+
+/// Quick-fix code actions for this module's own diagnostics: "Import 'Fqn'"
+/// for each known FQN of the flagged name, one candidate per action when a
+/// bare name is ambiguous across the workspace.
+///
+/// Reads the flagged name directly back out of the diagnostic message rather
+/// than re-walking the CST: the client already told us which of our own
+/// diagnostics apply at this position via `CodeActionContext::diagnostics`,
+/// and the message format is ours to parse (`missing_import_diagnostics`,
+/// above, is the only producer).
+pub(crate) fn missing_import_actions(
+    indexer: &Indexer,
+    uri: &Url,
+    diagnostics: &[Diagnostic],
+) -> Vec<CodeActionOrCommand> {
+    let Some(lines) = indexer.mem_lines_for(uri.as_str()) else {
+        return Vec::new();
+    };
+    let needs_semicolon = crate::Language::from_path(uri.path()) == crate::Language::Java;
+
+    diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.source.as_deref() == Some("kmp-lsp"))
+        .filter_map(|diagnostic| {
+            let name = flagged_name_from_message(&diagnostic.message)?;
+            Some((diagnostic, name))
+        })
+        .flat_map(|(diagnostic, name)| {
+            fqns_for_name(indexer, name).into_iter().map({
+                let lines = Arc::clone(&lines);
+                move |fqn| import_action(uri, &lines, diagnostic, fqn, needs_semicolon)
+            })
+        })
+        .collect()
+}
+
+/// Extract `Foo` back out of `"'Foo' is not imported and not in scope"`.
+fn flagged_name_from_message(message: &str) -> Option<&str> {
+    message
+        .strip_prefix('\'')?
+        .split_once('\'')
+        .map(|(name, _)| name)
+}
+
+fn import_action(
+    uri: &Url,
+    lines: &[String],
+    diagnostic: &Diagnostic,
+    fqn: String,
+    needs_semicolon: bool,
+) -> CodeActionOrCommand {
+    let mut changes = HashMap::new();
+    changes.insert(
+        uri.clone(),
+        vec![lines.make_import_edit(&fqn, needs_semicolon)],
+    );
+    CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Import '{fqn}'"),
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diagnostic.clone()]),
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        ..Default::default()
+    })
 }
 
 #[cfg(test)]

--- a/src/features/missing_import_diagnostics_tests.rs
+++ b/src/features/missing_import_diagnostics_tests.rs
@@ -1,9 +1,9 @@
-use tower_lsp::lsp_types::Url;
+use tower_lsp::lsp_types::{CodeActionKind, CodeActionOrCommand, Diagnostic, Url};
 
 use crate::indexer::live_tree::parse_live;
 use crate::indexer::Indexer;
 
-use super::missing_import_diagnostics;
+use super::{missing_import_actions, missing_import_diagnostics};
 
 fn uri(path: &str) -> Url {
     Url::parse(&format!("file:///test{path}")).unwrap()
@@ -105,5 +105,61 @@ fn diagnostics_suppressed_while_jars_loading() {
     assert!(
         !diags.is_empty(),
         "diagnostics must resume once JAR indexing is done"
+    );
+}
+
+#[test]
+fn offers_an_import_quickfix_for_a_flagged_diagnostic() {
+    let (uri, idx, src) = setup(&[
+        ("/lib/Foo.kt", "package com.example.lib\nclass Foo\n"),
+        ("/app/Caller.kt", "package app\nfun use(): Foo = Foo()\n"),
+    ]);
+    let diags = run_diagnostics(&idx, &uri, &src);
+    assert_eq!(diags.len(), 1, "expected one diagnostic: {diags:?}");
+
+    let actions = missing_import_actions(&idx, &uri, &diags);
+    assert_eq!(
+        actions.len(),
+        1,
+        "expected exactly one import candidate: {actions:?}"
+    );
+    let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+        panic!("expected a CodeAction, got {:?}", actions[0]);
+    };
+    assert_eq!(action.title, "Import 'com.example.lib.Foo'");
+    assert_eq!(action.kind, Some(CodeActionKind::QUICKFIX));
+    assert_eq!(
+        action.diagnostics.as_deref(),
+        Some(&diags[..]),
+        "quickfix must be associated back to the diagnostic it fixes"
+    );
+    let file_edits = action
+        .edit
+        .as_ref()
+        .and_then(|edit| edit.changes.as_ref())
+        .and_then(|changes| changes.get(&uri))
+        .expect("edit must target the caller file");
+    assert_eq!(file_edits.len(), 1);
+    assert!(
+        file_edits[0]
+            .new_text
+            .contains("import com.example.lib.Foo"),
+        "expected an import insertion, got {:?}",
+        file_edits[0].new_text
+    );
+}
+
+#[test]
+fn no_import_action_for_an_unrelated_diagnostic() {
+    let (uri, idx, _src) = setup(&[("/app/Caller.kt", "package app\nfun use() {}\n")]);
+    let unrelated = vec![Diagnostic {
+        message: "some other diagnostic".to_owned(),
+        source: Some("kmp-lsp".to_owned()),
+        ..Default::default()
+    }];
+    let actions = missing_import_actions(&idx, &uri, &unrelated);
+    assert!(
+        actions.is_empty(),
+        "must not fire for diagnostics that aren't ours: {actions:?}"
     );
 }

--- a/src/workspace/file_change_handler.rs
+++ b/src/workspace/file_change_handler.rs
@@ -9,6 +9,7 @@ use tower_lsp::Client;
 use crate::backend::helpers::syntax_diagnostics;
 use crate::features::call_arg_diagnostics::call_arg_diagnostics;
 use crate::features::fill_when::when_diagnostics;
+use crate::features::missing_import_diagnostics::missing_import_diagnostics;
 use crate::features::nullable_call_diagnostics::nullable_dot_call_diagnostics;
 use crate::indexer::live_tree::{lang_for_path, parse_live};
 use crate::indexer::Indexer;
@@ -180,6 +181,7 @@ impl FileChangeHandler {
                         );
                         diagnostics.extend(arg_diags);
                         diagnostics.extend(nullable_dot_call_diagnostics(&indexer, &uri, doc));
+                        diagnostics.extend(missing_import_diagnostics(&indexer, &uri, doc));
                     } else {
                         log::debug!(
                             "diag[gen={}]: live_doc is None — no call-arg diagnostics",

--- a/tests/lsp_smoke.rs
+++ b/tests/lsp_smoke.rs
@@ -265,6 +265,60 @@ impl LspClient {
             }),
         );
     }
+
+    /// Send a whole-document `textDocument/didChange` (single full-text change).
+    fn change_file(&mut self, uri: &str, version: i64, text: &str) {
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": {"uri": uri, "version": version},
+                "contentChanges": [{"text": text}],
+            }),
+        );
+    }
+
+    /// Wait until a `textDocument/publishDiagnostics` for `uri` carries a
+    /// diagnostic whose message contains `needle`, or panic after `timeout`.
+    ///
+    /// Diagnostics recompute asynchronously (debounced re-index + possible
+    /// jar-phase settling), so this keeps consuming publishes for the same
+    /// uri rather than asserting on the first one, which may predate the
+    /// edit being reflected.
+    fn wait_for_diagnostic_containing(&mut self, uri: &str, needle: &str, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let msg = self.rx.recv_timeout(remaining).unwrap_or_else(|_| {
+                panic!(
+                    "timeout ({timeout:?}) waiting for a publishDiagnostics on {uri} \
+                     containing {needle:?}"
+                )
+            });
+            if msg.get("method").is_some() && msg.get("id").is_some() {
+                let server_id = msg["id"].clone();
+                self.write_raw(&json!({"jsonrpc": "2.0", "id": server_id, "result": null}));
+                continue;
+            }
+            if msg.get("method") != Some(&json!("textDocument/publishDiagnostics")) {
+                continue;
+            }
+            if msg["params"]["uri"].as_str() != Some(uri) {
+                continue;
+            }
+            let matched = msg["params"]["diagnostics"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .any(|d| {
+                    d["message"]
+                        .as_str()
+                        .is_some_and(|message| message.contains(needle))
+                });
+            if matched {
+                return;
+            }
+        }
+    }
 }
 
 impl Drop for LspClient {
@@ -720,4 +774,59 @@ fn smoke_completion_from_compiled_jar() {
         );
         std::thread::sleep(Duration::from_millis(200));
     }
+}
+
+/// Regression: `missing_import_diagnostics` was wired into the didOpen and
+/// jar-ready-republish paths (`document_handler.rs`) but not into the
+/// debounced `didChange` re-index path (`file_change_handler.rs`) — so a
+/// missing-import diagnostic only ever appeared once, at file-open time, and
+/// never again as the user kept editing (deleting an import via a live edit
+/// silently produced no diagnostic, no matter how long you waited).
+#[test]
+fn smoke_missing_import_diagnostic_on_edit() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    write(root, "workspace.json", r#"{"sourcePaths":[]}"#);
+    write(
+        root,
+        "lib/Target.kt",
+        "package com.example.lib\n\nclass Target\n",
+    );
+
+    let with_import = concat!(
+        "package com.example.app\n",
+        "\n",
+        "import com.example.lib.Target\n",
+        "\n",
+        "fun demo() {\n",
+        "    val x = Target()\n",
+        "}\n",
+    );
+    write(root, "src/Main.kt", with_import);
+
+    let mut client = LspClient::spawn(root);
+    client.initialize(root);
+    client.wait_for_indexing();
+
+    let uri = file_uri(root, "src/Main.kt");
+    client.open_file(&uri, "kotlin", with_import);
+
+    // Delete the import via a live edit (didChange) -- this is the path that
+    // was never wired up. Bump generously past the 300ms debounce and any
+    // jar-phase settling.
+    let without_import = concat!(
+        "package com.example.app\n",
+        "\n",
+        "fun demo() {\n",
+        "    val x = Target()\n",
+        "}\n",
+    );
+    client.change_file(&uri, 2, without_import);
+
+    client.wait_for_diagnostic_containing(
+        &uri,
+        "'Target' is not imported and not in scope",
+        Duration::from_secs(20),
+    );
 }


### PR DESCRIPTION
## Summary

Two closely related fixes/additions to the missing-import diagnostic (#232):

**1. Fix: `missing_import_diagnostics` never re-ran on ongoing edits.**

It was wired into `document_handler.rs`'s `didOpen`/jar-ready-republish paths, but `file_change_handler.rs`'s debounced `didChange` re-index path -- the one that handles every ongoing edit -- has its own separate diagnostic-computation block that was never updated to include it. So the diagnostic only ever computed once, at file-open time (or the delayed jar-ready republish shortly after); any further edit never re-triggered it.

Found live-testing: deleting an import worked once, but deleting the same import a second time (after undoing) never re-triggered the diagnostic. Confirmed via direct protocol probing that `file_change_handler.rs`'s publish path was simply missing the call, not a caching or gating issue.

Regression test: `tests/lsp_smoke.rs::smoke_missing_import_diagnostic_on_edit` spawns the real binary, opens a file with a valid import, deletes it via a live `textDocument/didChange`, and asserts the diagnostic appears -- the only test level that exercises the real `client.publish_diagnostics` call. Verified RED without the fix, GREEN with it.

**2. Feature: quick-fix code action to add the missing import.**

Adds "Import 'Fqn'" as a `QUICKFIX` code action for each of our own missing-import diagnostics in the `CodeActionContext` -- one action per FQN candidate when a bare name is ambiguous across the workspace. Reuses the existing auto-import primitives (`fqns_for_name`, `make_import_edit`) already used by completion's auto-import edits, rather than reimplementing import insertion.

Verified end-to-end over the real LSP protocol: opened a file with a valid import, deleted it via `didChange`, confirmed the diagnostic appears, then requested `textDocument/codeAction` at its range and confirmed the quick-fix is returned with a correct `WorkspaceEdit` inserting the import after the package line.

## Test plan
- [x] Verified RED without the didChange fix (test times out waiting for the diagnostic, 20s)
- [x] Verified GREEN with the fix
- [x] `cargo test` -- full suite (1588 unit + all integration binaries) passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] Live-probed the code action over the real protocol (not just unit tests)