### PR TITLE
release: 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.25.0
+
 ### Features
 
 - **CST-verified go-to-definition, goto-implementation, document-highlight, find-references, and rename** — these five features now classify the cursor's symbol from the actual parse tree (declaration vs. member reference, with the receiver's resolved type) instead of a pure name-based `rg`/index scan, and verify each candidate's identity against that classification before returning it. Two classes with an identically-named member (`User.save()` / `File.save()`) no longer bleed into each other's results; an inherited member accessed through a subtype still resolves correctly via the supertype chain. Every feature keeps its existing recall guarantee — a candidate the CST can't verify (untyped receiver, JAR symbol, etc.) is still returned, just unlabeled, so nothing that worked before regresses. Rename additionally **refuses with a clear reason** (surfaced in the editor, e.g. Helix's status line) rather than guessing, on: an ambiguous/unresolvable identity, a library-defined symbol, or a symbol that participates in an override relationship (either the interface or the concrete side) — cross-type rename-through-inheritance isn't supported yet.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "kmp-lsp"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bincode",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["."]
 
 [package]
 name        = "kmp-lsp"
-version = "0.24.0"
+version = "0.25.0"
 edition     = "2021"
 description = "Fast, low-memory LSP server for Kotlin, Java, and Swift. Instant startup, dot-completion, go-to-definition, hover — no JVM required."
 license     = "MIT"


### PR DESCRIPTION
## Summary

Cuts the `Unreleased` CHANGELOG section into `0.25.0` and bumps `Cargo.toml`'s version to match. Headline changes since 0.24.0:

- CST-verified go-to-definition, goto-implementation, document-highlight, find-references, and rename
- Local variable/parameter rename now understands full Kotlin block scoping (if/for/while/when/try/catch/finally)
- Missing-import diagnostic + its "Import 'Fqn'" quick-fix code action
- Go-to-definition into extracted library source (`*-sources.jar` entries actually open)
- `jarPaths` for indexing compiled jars without a Gradle build
- Accurate per-symbol JAR package resolution
- Several bug fixes (see CHANGELOG.md)

## Test plan
- [x] `cargo build` -- confirms Cargo.lock/Cargo.toml agree on 0.25.0
- [x] `cargo test` -- full suite (1588 unit + all integration binaries) passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean

Once merged, I'll tag `v0.25.0` on `main` to trigger the release workflow (cross-platform binaries, VS Code extension, GitHub Release, crates.io publish).