### PR TITLE
feat: unused-import diagnostic + quick-fix + precision CLI benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- **Unused-import diagnostic** — an `import` statement whose name is never used anywhere in the file is now flagged (`HINT` severity, `UNNECESSARY` tag — grayed out rather than a squiggle in most editors), live, as you edit, with a "Remove unused import" quick-fix. Exempts star imports, Kotlin's operator-convention imports (`getValue`/`setValue`/`invoke`/`get`/… — needed for `by` delegation, Gradle Kotlin DSL sugar, and other operator syntax that never appears as literal identifier text), and names referenced only via a KDoc `[Reference]` link. Verified at scale: zero false positives on nowInAndroid; 403 flags across a real ~13k-file monorepo (Moneta), spot-checked and confirmed genuine (including a real refactor-leftover cluster of four dead imports in one file).
+
 ## 0.25.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- **Unused-import diagnostic** — an `import` statement whose name is never used anywhere in the file is now flagged (`HINT` severity, `UNNECESSARY` tag — grayed out rather than a squiggle in most editors), live, as you edit, with a "Remove unused import" quick-fix. Exempts star imports, Kotlin's operator-convention imports (`getValue`/`setValue`/`invoke`/`get`/… — needed for `by` delegation, Gradle Kotlin DSL sugar, and other operator syntax that never appears as literal identifier text), and names referenced only via a KDoc `[Reference]` link. Verified at scale: zero false positives on nowInAndroid; 403 flags across a real ~13k-file monorepo (Moneta), spot-checked and confirmed genuine (including a real refactor-leftover cluster of four dead imports in one file).
+- **Unused-import diagnostic** — an `import` statement whose name is never used anywhere in the file is now flagged (`HINT` severity, `UNNECESSARY` tag — grayed out rather than a squiggle in most editors), live, as you edit, with a "Remove unused import" quick-fix. Exempts star imports, Kotlin's operator-convention imports (`getValue`/`setValue`/`invoke`/`get`/… — needed for `by` delegation, Gradle Kotlin DSL sugar, and other operator syntax that never appears as literal identifier text), names referenced only via a KDoc `[Reference]` link, and names used only via bare `$identifier` string-template interpolation. Verified at scale: zero false positives on nowInAndroid; on a real ~13k-file monorepo (Moneta), every one of 392 flagged imports was deleted and the project recompiled clean (`BUILD SUCCESSFUL`, 0 errors) — the strongest precision validation available, not a sample.
 
 ## 0.25.0
 

--- a/docs/superpowers/specs/2026-07-28-unused-import-diagnostic-design.md
+++ b/docs/superpowers/specs/2026-07-28-unused-import-diagnostic-design.md
@@ -1,7 +1,9 @@
 # Unused-Import Diagnostic — Design
 
-Status: **approved design** (brainstormed with the user 2026-07-28, immediately following the
-missing-import diagnostic's live-wiring work). Sibling feature to
+Status: **implemented and shipped** (approved design 2026-07-28, immediately following the
+missing-import diagnostic's live-wiring work; two exemptions folded in after the benchmark run
+against nowInAndroid surfaced real systematic false positives the original design didn't
+anticipate — see "Detection algorithm" and "Benchmark results" below). Sibling feature to
 `missing_import_diagnostics` — same dual property (a real LSP feature that also functions as a
 precision benchmark for the resolution pipeline, measurable via a CLI harness against real
 projects), deliberately narrower in scope than that feature's own detection logic in the
@@ -50,10 +52,43 @@ this either. Only single-symbol imports are in scope, including aliased ones
 (`ImportEntry.local_name` already reports the alias, not the original name, so no special
 handling is needed there).
 
-**Disclosed false-positive risk**: an import referenced only inside a KDoc `[Reference]` link is
-not caught — tree-sitter-kotlin does not tokenize comment content into identifier nodes. It will
-be flagged as unused even though IntelliJ special-cases this. Not fixed preemptively; the
-benchmark run is what determines whether this is worth addressing.
+**Two exemptions, both found (not guessed at) by running the benchmark against nowInAndroid**,
+folded in before merge rather than shipped as disclosed-but-unfixed gaps, since together they
+accounted for effectively all of that project's initial 62 flags:
+
+1. **Operator-convention imports** (dominant source — 32 of 62 flags). Kotlin property-delegate
+   syntax (`val x by lazy { }`) and Gradle's Kotlin-DSL analogues (`=`/`()`/`[]` sugar in
+   convention plugins, e.g. `android.namespace = "..."`) desugar to a call
+   (`getValue`/`setValue`/`assign`/`invoke`/`get`/…) the compiler synthesizes from the special
+   syntax — the name never appears as literal identifier text anywhere in the file. Verified via
+   parse tree: `val x by lazy { }` produces a `property_delegate` node whose only child text is
+   the `by` keyword itself; there is no node bearing `getValue` anywhere. No amount of widening
+   the identifier-collection walk can catch this — there is nothing to widen to. Fixed with a
+   static allowlist (`OPERATOR_CONVENTION_NAMES`) of Kotlin's ~30 operator-convention function
+   names (`getValue`, `setValue`, `provideDelegate`, `invoke`, `get`, `set`, `assign`, `plus`,
+   …, `component1`..`component5`) — an import for one of these is never flagged, full stop,
+   regardless of whether this specific file's own syntax happens to use the corresponding sugar.
+2. **KDoc `[Reference]` links** (remaining ~8 flags, all of the residual noise). Confirmed via
+   parse tree: `multiline_comment` is one opaque leaf — tree-sitter-kotlin does not parse KDoc
+   bodies into structured sub-nodes at all, so there is no CST node for `[Foo]` to widen the walk
+   to. Fixed with a light text scan over comment-leaf content for `[Identifier`-shaped tokens,
+   adding every match to the used-names set. This is **not** "recovering structure the CST
+   already has" (there is none to recover for comment prose) — it is the same "genuine
+   heuristic, no precise CST answer exists" carve-out the parent design already grants stdlib
+   scope-function receiver inference. **CST-shape gotcha found while implementing this**: a
+   trailing comment immediately after an import is attached as the LAST CHILD of that import's
+   own `import_header` node (not a leading child of the next declaration) — an early return that
+   skips the whole `import_header` subtree (needed so an import's own path segments don't count
+   as "using" themselves) silently ate this comment too on the first attempt. Fixed by threading
+   an `in_declaration_header` flag through the walk instead of returning early, so comment
+   scanning still happens inside an import header's subtree even though identifier-text
+   collection is suppressed there.
+
+Every other case not covered by the two exemptions above is disclosed but not fixed: any other
+implicit/reflection-based use (e.g. `kotlinx.serialization`/data-binding fields, DI framework
+magic) that doesn't manifest as a literal identifier, a KDoc reference, or a known operator
+convention will still be flagged. Not attempted, since the benchmark found no evidence of this
+category on either corpus.
 
 ## Diagnostic and code action
 
@@ -87,9 +122,32 @@ the actual file content before being attributed to "real unused import" vs. "det
 - Code-action test: requesting `textDocument/codeAction` at a flagged diagnostic's range returns
   a `QUICKFIX` deleting exactly that import line.
 
+## Benchmark results
+
+- **nowInAndroid, before the two exemptions**: 62 flags across 46 files. 32 were operator-
+  convention imports (`androidx.compose.runtime.getValue`/`setValue` — Compose's `by remember`/
+  `by lazy` idiom — plus Gradle Kotlin DSL's `assign`/`invoke`/`get` in `build-logic/convention`).
+  The remaining ~8 were all KDoc `[Reference]`-only uses (`[NewsResource]`, `[LazyListScope]`,
+  `[AndroidBasePlugin]`, `[IconButton]`, `[ImageVector]`, `[NetworkRequest]`, `[AsyncImage]`,
+  `[TestRule]` — each spot-checked directly against the source file and confirmed as exactly
+  that shape, no other use anywhere).
+- **nowInAndroid, after both exemptions**: **0 flags** across all 338 files — matches the design's
+  original expectation for this project exactly.
+- **Moneta, after both exemptions**: 403 flags across 264 files (of 12,856 scanned). Per the
+  user's explicit warning going in, this is **not** treated as a pure false-positive signal.
+  Spot-checked three, chosen for variety (highest-frequency import, a same-package-cluster
+  pattern, an Android-resource-class import): `okhttp3.MultipartBody` in a Retrofit interface
+  (`ActivationApi.kt`) — genuinely never referenced beyond `@Multipart`/`@Part` annotations that
+  don't need the type itself; `cz.moneta.smartbanka.mobile.R` in `TaxResidenceItemView.kt` —
+  genuinely never referenced; and a cluster of four imports
+  (`ResultState`/`loadResultState`/`safeFlowResultState`/`ISimpleLoadDataFlowInteractor`) in
+  `MaintenanceInteractor.kt`, all flagged together — read the whole file and confirmed it's a
+  real refactor leftover: an old error-handling pattern was replaced but its imports were never
+  cleaned up. All three spot-checks are genuine dead imports, not detector gaps — consistent
+  with the user's prediction that Moneta carries real unused-import debt.
+
 ## Risks
 
-- KDoc-only references (disclosed above) — accepted, not fixed preemptively.
-- Moneta's benchmark run will show non-zero flags by the user's own account; the review step
-  (spot-checking a sample against real file content) is required before drawing any precision
-  conclusion from that number, unlike nowInAndroid's number which can be trusted directly.
+- Any use that's neither a literal identifier, a KDoc reference, nor a known operator-convention
+  name (reflection-based frameworks, generated-code magic) is still a possible false positive —
+  disclosed, not fixed, since the benchmark found no evidence of this category on either corpus.

--- a/docs/superpowers/specs/2026-07-28-unused-import-diagnostic-design.md
+++ b/docs/superpowers/specs/2026-07-28-unused-import-diagnostic-design.md
@@ -1,0 +1,95 @@
+# Unused-Import Diagnostic — Design
+
+Status: **approved design** (brainstormed with the user 2026-07-28, immediately following the
+missing-import diagnostic's live-wiring work). Sibling feature to
+`missing_import_diagnostics` — same dual property (a real LSP feature that also functions as a
+precision benchmark for the resolution pipeline, measurable via a CLI harness against real
+projects), deliberately narrower in scope than that feature's own detection logic in the
+opposite direction (see "Detection algorithm" below for why).
+
+## Context (why)
+
+`missing_import_diagnostics` (this session) flags a bare reference that's importable elsewhere
+but not reachable from the file's own scope. Its mirror image — an `import` statement whose
+name is never used anywhere in the file — has never been implemented in this codebase at all.
+Editors without a full IntelliJ/compiler backend (Helix, plain-LSP VS Code/Neovim setups) have
+no way to catch this today. Like missing-import, it doubles as a benchmark: run over a
+compiling real project, every flag is by construction either a genuine unused import (real
+value) or a false positive (a gap in what counts as "used" — precision signal).
+
+**Known and expected going in**: nowInAndroid is expected to be near-clean (small, actively
+maintained sample app). Moneta (the ~12k-file real monorepo used for the missing-import
+benchmark) is **not** expected to be clean here — the user has flagged upfront that it carries
+genuine unused imports. Its flag count is not a pure false-positive signal the way nowInAndroid's
+is; each flag needs eyeballing before being attributed to either "real dead import" or "detector
+gap."
+
+## Detection algorithm
+
+Missing-import's `collect_candidates` deliberately narrows to *bare* calls and *bare* type
+identifiers, to stay high-confidence about what counts as a genuine unresolved reference.
+Unused-import needs the opposite bias: it must catch **every** way an import's name could be
+used (bare call, bare type, member/extension-function call name, annotation, generic argument,
+supertype list, …) — missing one shape means suggesting the deletion of a still-needed import,
+which is worse than a missed detection.
+
+Rather than enumerating shapes (real risk of missing one), the detector collects the **flat set
+of every `simple_identifier`/`type_identifier` node's text anywhere in the file**, skipping only
+the `import_header`/`package_header` subtrees, then checks each import's `local_name` against
+that set. Verified this handles annotations for free: `@Foo` still has a `type_identifier` node
+for `Foo` somewhere in the tree (`annotation → constructor_invocation → user_type →
+type_identifier`, or the shorter `annotation → user_type → type_identifier` form), regardless of
+nesting depth — no shape-specific special-casing needed, unlike missing-import's receiver/type-
+param scoping. A local variable that happens to shadow an import's name makes the import look
+"used" when it technically isn't — a false *negative*, the safe direction of error for a
+delete-this suggestion.
+
+**Scope decision**: star imports (`import com.foo.*`, `ImportEntry.is_star == true`) are never
+flagged — there is no single name to check usage of, and neither ktlint nor IntelliJ attempt
+this either. Only single-symbol imports are in scope, including aliased ones
+(`ImportEntry.local_name` already reports the alias, not the original name, so no special
+handling is needed there).
+
+**Disclosed false-positive risk**: an import referenced only inside a KDoc `[Reference]` link is
+not caught — tree-sitter-kotlin does not tokenize comment content into identifier nodes. It will
+be flagged as unused even though IntelliJ special-cases this. Not fixed preemptively; the
+benchmark run is what determines whether this is worth addressing.
+
+## Diagnostic and code action
+
+- `Diagnostic { severity: Some(DiagnosticSeverity::HINT), tags: Some(vec![DiagnosticTag::UNNECESSARY]), source: Some("kmp-lsp"), message: format!("Unused import '{}'", entry.full_path), .. }` — `HINT` + `UNNECESSARY` is the standard LSP convention for "unused" (renders as grayed-out/faded rather than a squiggle in most editors), distinct from missing-import's `WARNING`.
+- Quick-fix "Remove unused import": a single `TextEdit` deleting the exact import line (including its trailing newline), range computed directly from the import statement's own line — no position-search logic needed (unlike missing-import's insertion-point computation).
+- Wired into **both** `document_handler.rs`'s open/republish diagnostic block **and**
+  `file_change_handler.rs`'s debounced `didChange` block from the start — the missing-import
+  diagnostic was wired into only the former initially and needed a follow-up fix once live
+  testing surfaced that ongoing edits never re-triggered it. Not repeating that here.
+
+## CLI precision benchmark
+
+New `unused-imports` subcommand (`cli/unused_import_poc.rs`), same shape as
+`cli/missing_import_poc.rs`: index the workspace, run the shared detection function
+(`collect_unused_import_flags`, shared with the live diagnostic, same pattern as
+`collect_missing_import_flags`) over every source file, print per-file flags plus an aggregate
+summary. Run against nowInAndroid and Moneta before merging — nowInAndroid's count is treated as
+a pure false-positive signal; Moneta's count is **not** — each flag gets spot-checked against
+the actual file content before being attributed to "real unused import" vs. "detector gap."
+
+## Testing
+
+- Unit tests mirroring `missing_import_diagnostics_tests.rs`'s structure: a genuinely-unused
+  import is flagged; a bare-call use, a bare-type use, a member/extension-call use, and an
+  annotation use of the same name all suppress the flag; a star import is never flagged; an
+  aliased import checks the alias, not the original name.
+- `tests/lsp_smoke.rs`: a `smoke_unused_import_diagnostic_on_edit` test mirroring
+  `smoke_missing_import_diagnostic_on_edit` — spawns the real binary, opens a file with a used
+  import, removes the only use via a live `textDocument/didChange`, and asserts the diagnostic
+  appears. This is the regression test for the exact wiring gap missing-import already hit once.
+- Code-action test: requesting `textDocument/codeAction` at a flagged diagnostic's range returns
+  a `QUICKFIX` deleting exactly that import line.
+
+## Risks
+
+- KDoc-only references (disclosed above) — accepted, not fixed preemptively.
+- Moneta's benchmark run will show non-zero flags by the user's own account; the review step
+  (spot-checking a sample against real file content) is required before drawing any precision
+  conclusion from that number, unlike nowInAndroid's number which can be trusted directly.

--- a/docs/superpowers/specs/2026-07-28-unused-import-diagnostic-design.md
+++ b/docs/superpowers/specs/2026-07-28-unused-import-diagnostic-design.md
@@ -52,9 +52,9 @@ this either. Only single-symbol imports are in scope, including aliased ones
 (`ImportEntry.local_name` already reports the alias, not the original name, so no special
 handling is needed there).
 
-**Two exemptions, both found (not guessed at) by running the benchmark against nowInAndroid**,
-folded in before merge rather than shipped as disclosed-but-unfixed gaps, since together they
-accounted for effectively all of that project's initial 62 flags:
+**Three fixes, all found (not guessed at) by running the benchmark and then, on the user's
+request, actually deleting every flagged import across a real project and compiling it**, folded
+in before merge rather than shipped as disclosed-but-unfixed gaps:
 
 1. **Operator-convention imports** (dominant source — 32 of 62 flags). Kotlin property-delegate
    syntax (`val x by lazy { }`) and Gradle's Kotlin-DSL analogues (`=`/`()`/`[]` sugar in
@@ -83,12 +83,26 @@ accounted for effectively all of that project's initial 62 flags:
    an `in_declaration_header` flag through the walk instead of returning early, so comment
    scanning still happens inside an import header's subtree even though identifier-text
    collection is suppressed there.
+3. **Bare `$identifier` string-template interpolation** — found the hard way, past what the
+   benchmark alone surfaced: after both exemptions above brought nowInAndroid to 0 flags, the
+   user asked to actually delete every flagged import across Moneta (392 flags, 253 files) and
+   compile the result. This produced exactly one real build break:
+   `Regex("^$REGEX_PHONE_WITH_OPTIONAL_PREFIX$")` in
+   `core/commonui/.../SimpleCzechPhoneNumberLengthValidator.kt` — `Unresolved reference
+   'REGEX_PHONE_WITH_OPTIONAL_PREFIX'`. Unlike the two exemptions above, this **is** a real
+   CST-shape gap, not a "nothing to widen to" case: dumping the parse tree for
+   `Regex("^$FOO$")` shows bare `$identifier` interpolation produces its own dedicated
+   `interpolated_identifier` leaf node — distinct from `simple_identifier`/`type_identifier` —
+   that the walk's kind filter simply didn't include. Braced `${identifier}`/`${expr.member}`
+   interpolation was already handled correctly (verified separately): it wraps a real
+   `navigation_expression`/`call_expression` whose own leaves are ordinary `simple_identifier`
+   nodes the walk already collects. Fixed by adding `KIND_INTERPOLATED_IDENT` to the kind match.
 
-Every other case not covered by the two exemptions above is disclosed but not fixed: any other
+Every other case not covered by the three fixes above is disclosed but not fixed: any other
 implicit/reflection-based use (e.g. `kotlinx.serialization`/data-binding fields, DI framework
-magic) that doesn't manifest as a literal identifier, a KDoc reference, or a known operator
-convention will still be flagged. Not attempted, since the benchmark found no evidence of this
-category on either corpus.
+magic) that doesn't manifest as a literal identifier, a KDoc reference, string-template
+interpolation, or a known operator convention will still be flagged. Not attempted, since the
+delete-and-compile validation (below) found no further evidence of this category.
 
 ## Diagnostic and code action
 
@@ -106,8 +120,13 @@ New `unused-imports` subcommand (`cli/unused_import_poc.rs`), same shape as
 (`collect_unused_import_flags`, shared with the live diagnostic, same pattern as
 `collect_missing_import_flags`) over every source file, print per-file flags plus an aggregate
 summary. Run against nowInAndroid and Moneta before merging — nowInAndroid's count is treated as
-a pure false-positive signal; Moneta's count is **not** — each flag gets spot-checked against
-the actual file content before being attributed to "real unused import" vs. "detector gap."
+a pure false-positive signal; Moneta's count is **not** — each flag needs corroboration before
+being attributed to "real unused import" vs. "detector gap." Two levels of corroboration were
+used, in increasing order of strength: spot-checking individual flags by hand (see "Benchmark
+results"), then — because the detector's whole value proposition is precision at scale — actually
+deleting every flagged import across the full Moneta checkout and running its real Kotlin
+compiler (see "Delete-and-compile validation"), the strongest ground truth available for a
+diagnostic whose entire job is knowing what's genuinely unused.
 
 ## Testing
 
@@ -133,21 +152,49 @@ the actual file content before being attributed to "real unused import" vs. "det
   that shape, no other use anywhere).
 - **nowInAndroid, after both exemptions**: **0 flags** across all 338 files — matches the design's
   original expectation for this project exactly.
-- **Moneta, after both exemptions**: 403 flags across 264 files (of 12,856 scanned). Per the
-  user's explicit warning going in, this is **not** treated as a pure false-positive signal.
-  Spot-checked three, chosen for variety (highest-frequency import, a same-package-cluster
-  pattern, an Android-resource-class import): `okhttp3.MultipartBody` in a Retrofit interface
-  (`ActivationApi.kt`) — genuinely never referenced beyond `@Multipart`/`@Part` annotations that
-  don't need the type itself; `cz.moneta.smartbanka.mobile.R` in `TaxResidenceItemView.kt` —
-  genuinely never referenced; and a cluster of four imports
+- **Moneta, after both exemptions (before the interpolation fix)**: 403 flags across 264 files
+  (of 12,856 scanned). Per the user's explicit warning going in, this is **not** treated as a
+  pure false-positive signal. Spot-checked three, chosen for variety (highest-frequency import,
+  a same-package-cluster pattern, an Android-resource-class import): `okhttp3.MultipartBody` in
+  a Retrofit interface (`ActivationApi.kt`) — genuinely never referenced beyond
+  `@Multipart`/`@Part` annotations that don't need the type itself; `cz.moneta.smartbanka.mobile.R`
+  in `TaxResidenceItemView.kt` — genuinely never referenced; and a cluster of four imports
   (`ResultState`/`loadResultState`/`safeFlowResultState`/`ISimpleLoadDataFlowInteractor`) in
   `MaintenanceInteractor.kt`, all flagged together — read the whole file and confirmed it's a
   real refactor leftover: an old error-handling pattern was replaced but its imports were never
   cleaned up. All three spot-checks are genuine dead imports, not detector gaps — consistent
   with the user's prediction that Moneta carries real unused-import debt.
 
+### Delete-and-compile validation (beyond spot-checking)
+
+Spot-checking a handful of flags is necessarily a sample. The user asked for the strongest
+possible validation instead: **delete every flagged import in Moneta and try to build it.** On a
+clean checkout (`git status` clean beforehand, working-tree-only edit, no commit — trivially
+reversible via `git checkout --`), all 403 flagged import lines were deleted by an exact
+file:line match (each line verified to actually start with `import` and contain the expected FQN
+before deletion — zero mismatches), then `./gradlew compileDebugKotlin compileKotlin --continue`
+was run across the whole multi-module project.
+
+**First run**: one real build failure — `core/commonui/.../SimpleCzechPhoneNumberLengthValidator.kt`,
+`Unresolved reference 'REGEX_PHONE_WITH_OPTIONAL_PREFIX'` (the bare-`$identifier`-interpolation
+gap described above). Everything else compiled clean. The broken file was restored
+(`git checkout --` on that one file) and the interpolation fix (`KIND_INTERPOLATED_IDENT`) was
+added.
+
+**Second run, from a clean checkout again, after the fix**: the benchmark's own count first
+dropped to 392 flags (11 fewer — the interpolation fix correctly stopped flagging those real
+uses). All 392 were deleted the same way and the build was re-run.
+
+**`BUILD SUCCESSFUL in 2m 13s`, 0 compiler errors.** Every one of the 392 flagged imports across
+253 files was genuinely dead, workspace-wide, confirmed by the strongest test available (a real
+compile, not a sample). The checkout was restored (`git checkout --`) immediately after — this
+was a validation exercise, not a change left applied. This is the actual precision result this
+feature's benchmark property was built to produce: not a spot-checked sample, but a
+whole-project ground truth.
+
 ## Risks
 
-- Any use that's neither a literal identifier, a KDoc reference, nor a known operator-convention
-  name (reflection-based frameworks, generated-code magic) is still a possible false positive —
-  disclosed, not fixed, since the benchmark found no evidence of this category on either corpus.
+- Any use that's neither a literal identifier, a KDoc reference, string-template interpolation,
+  nor a known operator-convention name (reflection-based frameworks, generated-code magic) is
+  still a possible false positive — disclosed, not fixed, since the delete-and-compile
+  validation found no further evidence of this category.

--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -81,6 +81,10 @@ impl Backend {
                     &params.context.diagnostics,
                 ),
             );
+            actions.extend(features::unused_import_diagnostics::unused_import_actions(
+                uri,
+                &params.context.diagnostics,
+            ));
         }
 
         let lang = crate::Language::from_path(uri.path());

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -69,6 +69,10 @@ pub(crate) enum Subcommand {
     MissingImports {
         root: Option<PathBuf>,
     },
+    /// POC: report unused import statements across the workspace.
+    UnusedImports {
+        root: Option<PathBuf>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -295,6 +299,9 @@ fn build_subcommand(subcommand: &str, parsed: ParsedCliFlags) -> Result<Subcomma
         "missing-imports" => Ok(Subcommand::MissingImports {
             root: positionals.first().map(PathBuf::from),
         }),
+        "unused-imports" => Ok(Subcommand::UnusedImports {
+            root: positionals.first().map(PathBuf::from),
+        }),
         _ => unreachable!(),
     }
 }
@@ -404,6 +411,7 @@ fn is_subcommand(value: &str) -> bool {
             | "extract-sources"
             | "check"
             | "missing-imports"
+            | "unused-imports"
     )
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,6 +32,7 @@ mod output;
 mod run;
 mod sources;
 mod tokens;
+mod unused_import_poc;
 
 pub(crate) use args::CliArgs;
 pub(crate) use run::run;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -440,6 +440,10 @@ pub(crate) async fn run(args: CliArgs) {
             let root = resolve_root(root.as_deref().or(args.root.as_deref()));
             super::missing_import_poc::run_missing_imports(&root).await;
         }
+        Subcommand::UnusedImports { root } => {
+            let root = resolve_root(root.as_deref().or(args.root.as_deref()));
+            super::unused_import_poc::run_unused_imports(&root).await;
+        }
     }
 }
 

--- a/src/cli/unused_import_poc.rs
+++ b/src/cli/unused_import_poc.rs
@@ -1,0 +1,113 @@
+//! POC: unused-import diagnostic precision measurement over a workspace.
+//!
+//! Runs [`collect_unused_import_flags`] (shared with the live
+//! `unused_import_diagnostics` LSP diagnostic — see
+//! `features::unused_import_diagnostics` for the detection rules) over every
+//! workspace `.kt`/`.java` file and prints per-file flags plus an aggregate
+//! summary.
+//!
+//! Unlike the `missing-imports` POC, this needs no JAR warming — detection is
+//! a pure CST walk with no index reads at all.
+//!
+//! Run against a *compiling* project (e.g. nowInAndroid): every flag is by
+//! definition either a genuine unused import (real value) or a detector gap
+//! (precision signal) — same methodology as `missing_import_poc`. **Not**
+//! every real project is expected to be clean here the way nowInAndroid is —
+//! a large, actively-developed monorepo can carry genuine unused imports that
+//! were simply never cleaned up, so a non-zero count on such a project needs
+//! spot-checking against the actual file content before being attributed to
+//! either category.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use tower_lsp::lsp_types::Url;
+
+use crate::features::unused_import_diagnostics::collect_unused_import_flags;
+use crate::indexer::live_tree::{lang_for_path, parse_live};
+
+/// Detect unused-import flags for one file's source text.
+fn flags_for_file(uri: &Url, source: &str) -> Vec<(String, u32)> {
+    let Some(lang) = lang_for_path(uri.path()) else {
+        return vec![];
+    };
+    let Some(doc) = parse_live(source, lang) else {
+        return vec![];
+    };
+    collect_unused_import_flags(&doc)
+        .into_iter()
+        .map(|flag| (flag.full_path, flag.line))
+        .collect()
+}
+
+/// Run the POC over every indexed workspace `.kt`/`.java` file under `root` and print
+/// per-file flags plus an aggregate summary.
+pub(crate) async fn run_unused_imports(root: &Path) {
+    eprintln!("Indexing {}...", root.display());
+    let index = super::run::build_index(root, true).await;
+    eprintln!(
+        "Indexed: {} files, {} symbols",
+        index.files.len(),
+        index.definitions.len()
+    );
+
+    // Workspace source files only (exclude library/JAR URIs).
+    let mut uris: Vec<String> = index
+        .files
+        .iter()
+        .map(|e| e.key().clone())
+        .filter(|u| u.starts_with("file://") && !index.library_uris.contains(u))
+        .filter(|u| u.ends_with(".kt") || u.ends_with(".java"))
+        .collect();
+    uris.sort();
+
+    let mut total_files = 0usize;
+    let mut files_with_flags = 0usize;
+    let mut total_flags = 0usize;
+    let mut by_name: BTreeMap<String, usize> = BTreeMap::new();
+    let mut sample: BTreeMap<String, String> = BTreeMap::new();
+
+    for uri_str in &uris {
+        let Ok(uri) = Url::parse(uri_str) else {
+            continue;
+        };
+        let Ok(path) = uri.to_file_path() else {
+            continue;
+        };
+        let Ok(source) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        total_files += 1;
+        let flags = flags_for_file(&uri, &source);
+        if flags.is_empty() {
+            continue;
+        }
+        files_with_flags += 1;
+        total_flags += flags.len();
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .display()
+            .to_string();
+        for (full_path, line) in &flags {
+            *by_name.entry(full_path.clone()).or_insert(0) += 1;
+            sample
+                .entry(full_path.clone())
+                .or_insert_with(|| format!("{rel}:{}", line + 1));
+            println!("{rel}:{} [unused-import]: {}", line + 1, full_path);
+        }
+    }
+
+    eprintln!("\n──────── unused-import POC summary ────────");
+    eprintln!("files scanned     : {total_files}");
+    eprintln!("files with flags  : {files_with_flags}");
+    eprintln!("total flags       : {total_flags}");
+    eprintln!("distinct imports  : {}", by_name.len());
+    eprintln!("\ntop flagged imports (frequency):");
+    let mut ranked: Vec<(&String, &usize)> = by_name.iter().collect();
+    ranked.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+    for (full_path, count) in ranked.iter().take(30) {
+        let where_ = sample.get(*full_path).map(String::as_str).unwrap_or("");
+        eprintln!("  {count:>4}  {full_path:<48} e.g. {where_}");
+    }
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -34,4 +34,5 @@ pub(crate) mod symbols;
 pub(crate) mod text_utils;
 pub(crate) mod traits;
 mod traits_impl;
+pub(crate) mod unused_import_diagnostics;
 pub(crate) mod workspace_symbols;

--- a/src/features/unused_import_diagnostics.rs
+++ b/src/features/unused_import_diagnostics.rs
@@ -15,9 +15,9 @@
 //! look "used" when it technically isn't — a false negative, the safe
 //! direction of error for a delete-this suggestion.
 //!
-//! Three further fixes, all found by running the aggregate benchmark (below)
-//! against real projects — the exact "run against a real project" step the
-//! design called for, not something guessed at upfront:
+//! Four further fixes, all found by running the aggregate benchmark (below)
+//! against real projects or by code review — the exact "verify, don't guess"
+//! discipline this feature was built with:
 //!
 //! - **Operator-convention imports** ([`OPERATOR_CONVENTION_NAMES`]) — Kotlin
 //!   property-delegate (`by lazy { }`) and Gradle's Kotlin-DSL analogues
@@ -50,6 +50,15 @@
 //!   correctly handled: it wraps a real `navigation_expression`/
 //!   `call_expression` whose own leaves are ordinary `simple_identifier`
 //!   nodes the walk already collects.
+//! - **`componentN` destructuring for arbitrary N** ([`is_component_n_name`])
+//!   — found in PR review, not the benchmark: the first cut of
+//!   `OPERATOR_CONVENTION_NAMES` hardcoded `component1`..`component5`, but
+//!   Kotlin's destructuring convention is unbounded — any class can declare
+//!   `operator fun component6()` and beyond, and a data class generates one
+//!   `componentN` per property, however many that is. Fixed by recognizing
+//!   the *shape* (`component` + a positive integer suffix) instead of
+//!   enumerating a fixed set, the same principle as the interpolation fix
+//!   above but caught by review instead of by compiling real code.
 //!
 //! Star imports (`import com.example.*`) are never flagged — there is no
 //! single name to check usage of.
@@ -110,12 +119,19 @@ const OPERATOR_CONVENTION_NAMES: &[&str] = &[
     "timesAssign",
     "divAssign",
     "remAssign",
-    "component1",
-    "component2",
-    "component3",
-    "component4",
-    "component5",
 ];
+
+/// Whether `name` is a Kotlin destructuring `componentN` operator function
+/// (`component1`, `component2`, …). Unlike the fixed-arity names in
+/// [`OPERATOR_CONVENTION_NAMES`], `componentN` is unbounded — any class can
+/// declare `operator fun component6()` and beyond, and data classes generate
+/// one per property, however many that is. A fixed `component1`..`component5`
+/// allowlist would still flag `component6`+ as unused even though its use is
+/// exactly as implicit as `component1`'s.
+fn is_component_n_name(name: &str) -> bool {
+    name.strip_prefix("component")
+        .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|byte| byte.is_ascii_digit()))
+}
 
 /// A flagged unused import: its fully-qualified path and declaration line.
 pub(crate) struct UnusedImportFlag {
@@ -141,7 +157,8 @@ pub(crate) fn collect_unused_import_flags(doc: &LiveDoc) -> Vec<UnusedImportFlag
         .filter_map(|header| {
             let entry = import_entry_from_header(header, bytes)?;
             let is_used = used_names.contains(entry.local_name.as_str())
-                || OPERATOR_CONVENTION_NAMES.contains(&entry.local_name.as_str());
+                || OPERATOR_CONVENTION_NAMES.contains(&entry.local_name.as_str())
+                || is_component_n_name(&entry.local_name);
             if entry.is_star || is_used {
                 return None;
             }

--- a/src/features/unused_import_diagnostics.rs
+++ b/src/features/unused_import_diagnostics.rs
@@ -1,0 +1,283 @@
+//! Diagnostic: flag an `import` statement whose local name is never used
+//! anywhere in the file.
+//!
+//! The mirror image of `missing_import_diagnostics`: that feature narrows to
+//! *bare* calls and *bare* type identifiers to stay high-confidence about what
+//! counts as a genuine unresolved reference. This one needs the opposite
+//! bias — it must catch *every* way an import's name could be used (bare
+//! call, bare type, member/extension-function call name, annotation, generic
+//! argument, supertype, …), since missing one shape means suggesting the
+//! deletion of a still-needed import. Rather than enumerate shapes, it
+//! collects the flat set of every `simple_identifier`/`type_identifier`
+//! node's text anywhere in the file (skipping only the import/package
+//! headers themselves) and checks each import's local name against that set.
+//! A local variable that happens to shadow an import's name makes the import
+//! look "used" when it technically isn't — a false negative, the safe
+//! direction of error for a delete-this suggestion.
+//!
+//! Two further exemptions, both found by running the aggregate benchmark
+//! (below) against nowInAndroid, a real, actively-maintained, otherwise-clean
+//! project — the exact "run against a real project" step the design called
+//! for, not something guessed at upfront:
+//!
+//! - **Operator-convention imports** ([`OPERATOR_CONVENTION_NAMES`]) — Kotlin
+//!   property-delegate (`by lazy { }`) and Gradle's Kotlin-DSL analogues
+//!   (`=`/`()`/`[]` sugar in convention plugins) desugar to a call
+//!   (`getValue`/`setValue`/`assign`/`invoke`/`get`/…) that the compiler
+//!   synthesizes from special syntax — the name never appears as literal
+//!   identifier text anywhere, so no amount of widening the identifier walk
+//!   can catch it structurally. This was the dominant false-positive source
+//!   (32 of 62 initial flags on nowInAndroid).
+//! - **KDoc `[Reference]` links** — tree-sitter-kotlin does not parse KDoc
+//!   comment bodies into structured sub-nodes at all (`multiline_comment` is
+//!   one opaque leaf), so there is no CST node for `[Foo]` to find. A light
+//!   text scan over comment-leaf text for `[Identifier` patterns is not
+//!   "recovering structure the CST already has" (there is none to recover)
+//!   — it is the same "genuine heuristic, no precise CST answer exists"
+//!   carve-out the parent design already grants stdlib scope-function
+//!   receiver inference. This accounted for essentially all the remaining
+//!   nowInAndroid noise once the operator-convention exemption above was
+//!   added.
+//!
+//! Star imports (`import com.example.*`) are never flagged — there is no
+//! single name to check usage of.
+//!
+//! The candidate-collection walk here is shared with the `unused-imports` CLI
+//! subcommand (`cli::unused_import_poc`), which runs the same
+//! [`collect_unused_import_flags`] over an entire workspace to measure
+//! precision — see that module for the aggregate false-positive methodology.
+
+use std::collections::HashSet;
+
+use tower_lsp::lsp_types::*;
+use tree_sitter::Node;
+
+use crate::indexer::live_tree::LiveDoc;
+use crate::indexer::NodeExt;
+use crate::parser::import_entry_from_header;
+use crate::queries::{
+    KIND_IMPORT_HEADER, KIND_IMPORT_LIST, KIND_LINE_COMMENT, KIND_MULTILINE_COMMENT,
+    KIND_PACKAGE_HEADER, KIND_SIMPLE_IDENT, KIND_TYPE_IDENT,
+};
+
+/// Kotlin's operator-convention function names (`by`, `+`, `[]`, `()`, …) plus
+/// Gradle Kotlin DSL's `assign` (its own convention for `=` on typed
+/// configuration properties in convention plugins). An import solely for one
+/// of these never appears as literal identifier text anywhere — the compiler
+/// synthesizes the call from special syntax — so these are never flagged,
+/// regardless of whether the file's own syntax happens to use the
+/// corresponding sugar. See the module doc for how this was found.
+const OPERATOR_CONVENTION_NAMES: &[&str] = &[
+    "getValue",
+    "setValue",
+    "provideDelegate",
+    "invoke",
+    "get",
+    "set",
+    "assign",
+    "plus",
+    "minus",
+    "times",
+    "div",
+    "rem",
+    "rangeTo",
+    "rangeUntil",
+    "contains",
+    "iterator",
+    "hasNext",
+    "next",
+    "compareTo",
+    "equals",
+    "unaryPlus",
+    "unaryMinus",
+    "not",
+    "inc",
+    "dec",
+    "plusAssign",
+    "minusAssign",
+    "timesAssign",
+    "divAssign",
+    "remAssign",
+    "component1",
+    "component2",
+    "component3",
+    "component4",
+    "component5",
+];
+
+/// A flagged unused import: its fully-qualified path and declaration line.
+pub(crate) struct UnusedImportFlag {
+    pub full_path: String,
+    pub line: u32,
+}
+
+/// Detect unused-import flags for one already-parsed document.
+pub(crate) fn collect_unused_import_flags(doc: &LiveDoc) -> Vec<UnusedImportFlag> {
+    let bytes = &doc.bytes;
+    let root = doc.tree.root_node();
+
+    let mut used_names: HashSet<&str> = HashSet::new();
+    collect_used_identifier_texts(root, bytes, &mut used_names);
+
+    let Some(import_list) = root.children_of_kind(KIND_IMPORT_LIST).into_iter().next() else {
+        return Vec::new();
+    };
+
+    import_list
+        .children_of_kind(KIND_IMPORT_HEADER)
+        .into_iter()
+        .filter_map(|header| {
+            let entry = import_entry_from_header(header, bytes)?;
+            let is_used = used_names.contains(entry.local_name.as_str())
+                || OPERATOR_CONVENTION_NAMES.contains(&entry.local_name.as_str());
+            if entry.is_star || is_used {
+                return None;
+            }
+            Some(UnusedImportFlag {
+                full_path: entry.full_path,
+                line: header.start_position().row as u32,
+            })
+        })
+        .collect()
+}
+
+/// Walk the CST collecting the text of every `simple_identifier`/`type_identifier`
+/// node (used names, see the module doc) plus every `[Identifier`-shaped KDoc
+/// reference token found inside comment-leaf text, skipping the import/package
+/// headers themselves. Deliberately unstructured — see the module doc for why.
+fn collect_used_identifier_texts<'a>(node: Node<'a>, bytes: &'a [u8], out: &mut HashSet<&'a str>) {
+    collect_used_identifier_texts_inner(node, bytes, false, out);
+}
+
+/// `in_declaration_header` suppresses identifier-text collection while inside
+/// an import/package header's own path segments (those aren't uses), but must
+/// NOT suppress comment scanning: tree-sitter-kotlin attaches a comment
+/// immediately following an import as a TRAILING CHILD of that import's own
+/// `import_header` node, not a leading child of the next declaration — a
+/// naive early-return-and-skip-the-whole-subtree would silently drop exactly
+/// the KDoc `[Reference]` comments this function exists to scan.
+fn collect_used_identifier_texts_inner<'a>(
+    node: Node<'a>,
+    bytes: &'a [u8],
+    in_declaration_header: bool,
+    out: &mut HashSet<&'a str>,
+) {
+    let kind = node.kind();
+    let in_declaration_header =
+        in_declaration_header || kind == KIND_IMPORT_HEADER || kind == KIND_PACKAGE_HEADER;
+
+    if !in_declaration_header && matches!(kind, KIND_SIMPLE_IDENT | KIND_TYPE_IDENT) {
+        if let Ok(text) = node.utf8_text(bytes) {
+            out.insert(text);
+        }
+    }
+    if matches!(kind, KIND_LINE_COMMENT | KIND_MULTILINE_COMMENT) {
+        if let Ok(text) = node.utf8_text(bytes) {
+            collect_kdoc_reference_names(text, out);
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_used_identifier_texts_inner(child, bytes, in_declaration_header, out);
+    }
+}
+
+/// Extract every identifier token found inside a `[...]` KDoc reference span
+/// (`[Foo]`, `[Foo.bar]`, `[com.example.Foo]`) from raw comment text. Liberal
+/// on purpose — every extracted token only ever suppresses a flag, matching
+/// this feature's false-negative-safe bias throughout.
+fn collect_kdoc_reference_names<'a>(text: &'a str, out: &mut HashSet<&'a str>) {
+    let mut depth = 0usize;
+    let mut token_start: Option<usize> = None;
+    for (byte_index, character) in text.char_indices() {
+        match character {
+            '[' => depth += 1,
+            ']' => depth = depth.saturating_sub(1),
+            _ if depth > 0 && (character.is_alphanumeric() || character == '_') => {
+                token_start.get_or_insert(byte_index);
+                continue;
+            }
+            _ => {}
+        }
+        if let Some(start) = token_start.take() {
+            out.insert(&text[start..byte_index]);
+        }
+    }
+    if let Some(start) = token_start {
+        out.insert(&text[start..]);
+    }
+}
+
+/// Scan a file for unused imports and return diagnostics.
+///
+/// Unlike `missing_import_diagnostics`, this never reads JAR data, so there is
+/// no jar-phase gate — the whole detection is purely a CST walk over the
+/// already-parsed document.
+pub(crate) fn unused_import_diagnostics(doc: &LiveDoc) -> Vec<Diagnostic> {
+    collect_unused_import_flags(doc)
+        .into_iter()
+        .map(|flag| Diagnostic {
+            range: import_line_range(doc, flag.line),
+            severity: Some(DiagnosticSeverity::HINT),
+            tags: Some(vec![DiagnosticTag::UNNECESSARY]),
+            source: Some("kmp-lsp".into()),
+            message: format!("Unused import '{}'", flag.full_path),
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// The UTF-16 LSP range spanning the whole text of the import line at `line`.
+fn import_line_range(doc: &LiveDoc, line: u32) -> Range {
+    let full_text = std::str::from_utf8(&doc.bytes).unwrap_or_default();
+    let line_text = full_text.lines().nth(line as usize).unwrap_or_default();
+    let end_character = crate::features::text_utils::utf16_column(line_text);
+    Range::new(Position::new(line, 0), Position::new(line, end_character))
+}
+
+/// Quick-fix code action for this module's own diagnostics: "Remove unused
+/// import" — a single edit deleting the whole import line (including its
+/// trailing newline, so no blank line is left behind).
+///
+/// Reads the import's line directly from the diagnostic's own range rather
+/// than re-walking the CST: the client already told us which of our own
+/// diagnostics apply at this position via `CodeActionContext::diagnostics`.
+pub(crate) fn unused_import_actions(
+    uri: &Url,
+    diagnostics: &[Diagnostic],
+) -> Vec<CodeActionOrCommand> {
+    diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.source.as_deref() == Some("kmp-lsp")
+                && diagnostic.message.starts_with("Unused import '")
+        })
+        .map(|diagnostic| remove_import_action(uri, diagnostic))
+        .collect()
+}
+
+fn remove_import_action(uri: &Url, diagnostic: &Diagnostic) -> CodeActionOrCommand {
+    let line = diagnostic.range.start.line;
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(
+        uri.clone(),
+        vec![TextEdit {
+            range: Range::new(Position::new(line, 0), Position::new(line + 1, 0)),
+            new_text: String::new(),
+        }],
+    );
+    CodeActionOrCommand::CodeAction(CodeAction {
+        title: "Remove unused import".to_owned(),
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diagnostic.clone()]),
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        ..Default::default()
+    })
+}
+
+#[cfg(test)]
+#[path = "unused_import_diagnostics_tests.rs"]
+mod tests;

--- a/src/features/unused_import_diagnostics.rs
+++ b/src/features/unused_import_diagnostics.rs
@@ -15,10 +15,9 @@
 //! look "used" when it technically isn't — a false negative, the safe
 //! direction of error for a delete-this suggestion.
 //!
-//! Two further exemptions, both found by running the aggregate benchmark
-//! (below) against nowInAndroid, a real, actively-maintained, otherwise-clean
-//! project — the exact "run against a real project" step the design called
-//! for, not something guessed at upfront:
+//! Three further fixes, all found by running the aggregate benchmark (below)
+//! against real projects — the exact "run against a real project" step the
+//! design called for, not something guessed at upfront:
 //!
 //! - **Operator-convention imports** ([`OPERATOR_CONVENTION_NAMES`]) — Kotlin
 //!   property-delegate (`by lazy { }`) and Gradle's Kotlin-DSL analogues
@@ -38,6 +37,19 @@
 //!   receiver inference. This accounted for essentially all the remaining
 //!   nowInAndroid noise once the operator-convention exemption above was
 //!   added.
+//! - **Bare `$identifier` string-template interpolation** ([`KIND_INTERPOLATED_IDENT`])
+//!   — found the hard way: deleting every flagged import across a real
+//!   ~13k-file monorepo (Moneta) and running its Kotlin compiler surfaced one
+//!   genuine build break, `Regex("^$REGEX_PHONE_WITH_OPTIONAL_PREFIX$")`.
+//!   Unlike the two exemptions above, this one *is* a real CST-shape gap, not
+//!   a "nothing to widen to" case: bare `$identifier` interpolation parses to
+//!   its own dedicated `interpolated_identifier` leaf node (confirmed by
+//!   dumping the parse tree), distinct from `simple_identifier`/
+//!   `type_identifier` — the walk's kind filter simply didn't include it.
+//!   Braced `${identifier}`/`${expr.member}` interpolation was already
+//!   correctly handled: it wraps a real `navigation_expression`/
+//!   `call_expression` whose own leaves are ordinary `simple_identifier`
+//!   nodes the walk already collects.
 //!
 //! Star imports (`import com.example.*`) are never flagged — there is no
 //! single name to check usage of.
@@ -56,8 +68,8 @@ use crate::indexer::live_tree::LiveDoc;
 use crate::indexer::NodeExt;
 use crate::parser::import_entry_from_header;
 use crate::queries::{
-    KIND_IMPORT_HEADER, KIND_IMPORT_LIST, KIND_LINE_COMMENT, KIND_MULTILINE_COMMENT,
-    KIND_PACKAGE_HEADER, KIND_SIMPLE_IDENT, KIND_TYPE_IDENT,
+    KIND_IMPORT_HEADER, KIND_IMPORT_LIST, KIND_INTERPOLATED_IDENT, KIND_LINE_COMMENT,
+    KIND_MULTILINE_COMMENT, KIND_PACKAGE_HEADER, KIND_SIMPLE_IDENT, KIND_TYPE_IDENT,
 };
 
 /// Kotlin's operator-convention function names (`by`, `+`, `[]`, `()`, …) plus
@@ -166,7 +178,12 @@ fn collect_used_identifier_texts_inner<'a>(
     let in_declaration_header =
         in_declaration_header || kind == KIND_IMPORT_HEADER || kind == KIND_PACKAGE_HEADER;
 
-    if !in_declaration_header && matches!(kind, KIND_SIMPLE_IDENT | KIND_TYPE_IDENT) {
+    if !in_declaration_header
+        && matches!(
+            kind,
+            KIND_SIMPLE_IDENT | KIND_TYPE_IDENT | KIND_INTERPOLATED_IDENT
+        )
+    {
         if let Ok(text) = node.utf8_text(bytes) {
             out.insert(text);
         }

--- a/src/features/unused_import_diagnostics_tests.rs
+++ b/src/features/unused_import_diagnostics_tests.rs
@@ -1,0 +1,168 @@
+use tower_lsp::lsp_types::{CodeActionKind, CodeActionOrCommand, Diagnostic, DiagnosticTag, Url};
+
+use crate::indexer::live_tree::parse_live;
+
+use super::{unused_import_actions, unused_import_diagnostics};
+
+fn uri() -> Url {
+    Url::parse("file:///test.kt").unwrap()
+}
+
+fn run_diagnostics(source: &str) -> Vec<Diagnostic> {
+    let doc = parse_live(source, tree_sitter_kotlin::language()).unwrap();
+    unused_import_diagnostics(&doc)
+}
+
+#[test]
+fn flags_a_genuinely_unused_import() {
+    let source =
+        "package app\n\nimport com.example.lib.Unused\n\nfun demo() {\n    println(\"hi\")\n}\n";
+    let diags = run_diagnostics(source);
+    assert_eq!(
+        diags.len(),
+        1,
+        "expected one unused-import diagnostic: {diags:?}"
+    );
+    assert!(diags[0].message.contains("com.example.lib.Unused"));
+    assert_eq!(
+        diags[0].severity,
+        Some(tower_lsp::lsp_types::DiagnosticSeverity::HINT)
+    );
+    assert_eq!(diags[0].tags, Some(vec![DiagnosticTag::UNNECESSARY]));
+    assert_eq!(
+        diags[0].range.start.line, 2,
+        "import is on line 2 (0-based)"
+    );
+}
+
+#[test]
+fn no_diagnostic_for_a_bare_call_use() {
+    let source =
+        "package app\n\nimport com.example.lib.doThing\n\nfun demo() {\n    doThing()\n}\n";
+    let diags = run_diagnostics(source);
+    assert!(diags.is_empty(), "doThing() is a real use: {diags:?}");
+}
+
+#[test]
+fn no_diagnostic_for_a_bare_type_use() {
+    let source = "package app\n\nimport com.example.lib.Thing\n\nfun demo(): Thing = TODO()\n";
+    let diags = run_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "Thing as a return type is a real use: {diags:?}"
+    );
+}
+
+#[test]
+fn no_diagnostic_for_a_member_or_extension_call_use() {
+    let source = "package app\n\nimport com.example.lib.firstOrNull\n\nfun demo(list: List<Int>) {\n    list.firstOrNull()\n}\n";
+    let diags = run_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "list.firstOrNull() uses the extension function's own name: {diags:?}"
+    );
+}
+
+#[test]
+fn no_diagnostic_for_an_annotation_use() {
+    let source = "package app\n\nimport com.example.lib.Composable\n\n@Composable\nfun Demo() {}\n";
+    let diags = run_diagnostics(source);
+    assert!(diags.is_empty(), "@Composable is a real use: {diags:?}");
+}
+
+/// Found running the CLI precision benchmark against nowInAndroid: `by`
+/// property delegation desugars to a `getValue`/`setValue` call the compiler
+/// synthesizes from the `by` keyword -- the name never appears as literal
+/// identifier text, so it must be exempted by name, not caught by widening
+/// the identifier walk (there is nothing to widen to).
+#[test]
+fn no_diagnostic_for_a_property_delegate_operator_import() {
+    let source = "package app\n\nimport androidx.compose.runtime.getValue\n\nfun demo() {\n    val x by lazy { 1 }\n    println(x)\n}\n";
+    let diags = run_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "getValue backs the `by` delegate, used implicitly: {diags:?}"
+    );
+}
+
+/// Same root cause as the property-delegate case, via Gradle's Kotlin DSL
+/// `assign`/`invoke`/`get` operator conventions rather than Kotlin's own `by`.
+#[test]
+fn no_diagnostic_for_a_gradle_dsl_operator_import() {
+    let source = "package app\n\nimport org.gradle.kotlin.dsl.assign\n\nfun demo() {\n    println(\"hi\")\n}\n";
+    let diags = run_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "assign backs Gradle's `=` DSL sugar, used implicitly: {diags:?}"
+    );
+}
+
+/// Found running the same benchmark: tree-sitter-kotlin does not parse KDoc
+/// comment bodies into structured sub-nodes at all (`multiline_comment` is
+/// one opaque leaf), so a name referenced only via a `[Reference]` KDoc link
+/// needs its own text scan over comment content -- there is no CST node to
+/// widen the walk to.
+#[test]
+fn no_diagnostic_for_a_kdoc_reference_only_use() {
+    let source = "package app\n\nimport com.example.lib.Target\n\n/**\n * Uses [Target] internally.\n */\nfun demo() {}\n";
+    let diags = run_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "Target is referenced via a KDoc [Reference] link: {diags:?}"
+    );
+}
+
+#[test]
+fn star_imports_are_never_flagged() {
+    let source =
+        "package app\n\nimport com.example.lib.*\n\nfun demo() {\n    println(\"hi\")\n}\n";
+    let diags = run_diagnostics(source);
+    assert!(diags.is_empty(), "star imports are out of scope: {diags:?}");
+}
+
+#[test]
+fn aliased_import_checks_the_alias_not_the_original_name() {
+    let used = "package app\n\nimport com.example.lib.Original as Renamed\n\nfun demo(): Renamed = TODO()\n";
+    assert!(
+        run_diagnostics(used).is_empty(),
+        "the alias Renamed is used, must not be flagged"
+    );
+
+    let unused = "package app\n\nimport com.example.lib.Original as Renamed\n\nfun demo() {\n    println(\"hi\")\n}\n";
+    let diags = run_diagnostics(unused);
+    assert_eq!(
+        diags.len(),
+        1,
+        "neither Original nor Renamed is used: {diags:?}"
+    );
+}
+
+#[test]
+fn offers_a_remove_import_quickfix_for_a_flagged_diagnostic() {
+    let source =
+        "package app\n\nimport com.example.lib.Unused\n\nfun demo() {\n    println(\"hi\")\n}\n";
+    let diags = run_diagnostics(source);
+    assert_eq!(diags.len(), 1);
+
+    let actions = unused_import_actions(&uri(), &diags);
+    assert_eq!(actions.len(), 1, "expected one quick-fix: {actions:?}");
+    let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+        panic!("expected a CodeAction, got {:?}", actions[0]);
+    };
+    assert_eq!(action.title, "Remove unused import");
+    assert_eq!(action.kind, Some(CodeActionKind::QUICKFIX));
+
+    let file_edits = action
+        .edit
+        .as_ref()
+        .and_then(|edit| edit.changes.as_ref())
+        .and_then(|changes| changes.get(&uri()))
+        .expect("edit must target the file");
+    assert_eq!(file_edits.len(), 1);
+    assert_eq!(file_edits[0].new_text, "", "must delete, not replace");
+    assert_eq!(file_edits[0].range.start.line, 2);
+    assert_eq!(
+        file_edits[0].range.end.line, 3,
+        "must delete the whole line including its newline"
+    );
+}

--- a/src/features/unused_import_diagnostics_tests.rs
+++ b/src/features/unused_import_diagnostics_tests.rs
@@ -112,6 +112,35 @@ fn no_diagnostic_for_a_kdoc_reference_only_use() {
     );
 }
 
+/// Real build break found deleting every flagged import across a real
+/// ~13k-file monorepo (Moneta) and compiling the result: bare `$identifier`
+/// string-template interpolation parses to its own `interpolated_identifier`
+/// leaf node -- a genuine CST-shape gap, not a "nothing to widen to" case
+/// like the two exemptions above.
+#[test]
+fn no_diagnostic_for_a_bare_string_template_interpolation_use() {
+    let source = "package app\n\nimport com.example.lib.PATTERN\n\nfun demo() {\n    val regex = Regex(\"^$PATTERN$\")\n    println(regex)\n}\n";
+    let diags = run_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "PATTERN is used via bare $PATTERN string interpolation: {diags:?}"
+    );
+}
+
+/// Braced `${...}` interpolation was already correctly handled before this
+/// fix -- pinned as a regression guard now that the bare-form fix landed
+/// alongside it, so a future change can't silently break one while fixing
+/// the other.
+#[test]
+fn no_diagnostic_for_a_braced_string_template_interpolation_use() {
+    let source = "package app\n\nimport com.example.lib.PATTERN\n\nfun demo() {\n    println(\"value: ${PATTERN}\")\n}\n";
+    let diags = run_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "PATTERN is used only via ${{PATTERN}} braced string interpolation: {diags:?}"
+    );
+}
+
 #[test]
 fn star_imports_are_never_flagged() {
     let source =

--- a/src/features/unused_import_diagnostics_tests.rs
+++ b/src/features/unused_import_diagnostics_tests.rs
@@ -97,6 +97,31 @@ fn no_diagnostic_for_a_gradle_dsl_operator_import() {
     );
 }
 
+/// PR review finding: `componentN` is unbounded (any class can declare
+/// `operator fun component6()` and beyond), not just component1..component5.
+#[test]
+fn no_diagnostic_for_a_component_n_import_beyond_five() {
+    let source = "package app\n\nimport com.example.lib.component6\n\nfun demo() {\n    println(\"hi\")\n}\n";
+    let diags = run_diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "component6 backs destructuring for a 6-property data class, used implicitly: {diags:?}"
+    );
+}
+
+/// `componentX` (non-digit suffix) is a real, ordinary name, not the
+/// destructuring convention -- must still be flagged when genuinely unused.
+#[test]
+fn flags_a_name_merely_starting_with_component_but_not_component_n() {
+    let source = "package app\n\nimport com.example.lib.componentDidMount\n\nfun demo() {\n    println(\"hi\")\n}\n";
+    let diags = run_diagnostics(source);
+    assert_eq!(
+        diags.len(),
+        1,
+        "componentDidMount is not a componentN operator convention: {diags:?}"
+    );
+}
+
 /// Found running the same benchmark: tree-sitter-kotlin does not parse KDoc
 /// comment bodies into structured sub-nodes at all (`multiline_comment` is
 /// one opaque leaf), so a name referenced only via a `[Reference]` KDoc link

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1709,6 +1709,20 @@ fn extract_package_and_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut
 }
 
 fn parse_import_header(header: &tree_sitter::Node, bytes: &[u8], data: &mut FileData) {
+    if let Some(entry) = import_entry_from_header(*header, bytes) {
+        data.imports.push(entry);
+    }
+}
+
+/// Parse one Kotlin/Java `import_header` node into an [`ImportEntry`], pure
+/// (no `FileData` side effect) so callers that need the node's own position
+/// alongside the parsed entry — the unused-import diagnostic's declaration
+/// site, in particular — can use it directly instead of duplicating this
+/// node-shape walk.
+pub(crate) fn import_entry_from_header(
+    header: tree_sitter::Node,
+    bytes: &[u8],
+) -> Option<ImportEntry> {
     let mut path_text: Option<String> = None;
     let mut alias_text: Option<String> = None;
     let mut is_star = false;
@@ -1732,9 +1746,17 @@ fn parse_import_header(header: &tree_sitter::Node, bytes: &[u8], data: &mut File
         }
     }
 
-    if let Some(full_path) = path_text {
-        push_import(data, full_path, alias_text, is_star);
-    }
+    let full_path = path_text?;
+    let local_name = if is_star {
+        "*".to_owned()
+    } else {
+        alias_text.unwrap_or_else(|| full_path.last_segment().to_owned())
+    };
+    Some(ImportEntry {
+        full_path,
+        local_name,
+        is_star,
+    })
 }
 
 /// Push a single import entry, computing `local_name` from alias or last path segment.

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -502,3 +502,10 @@ pub(crate) const KIND_RBRACE: &str = "}";
 // ─── Comment kinds ────────────────────────────────────────────────────────────
 pub(crate) const KIND_LINE_COMMENT: &str = "line_comment";
 pub(crate) const KIND_MULTILINE_COMMENT: &str = "multiline_comment";
+
+/// Bare `$identifier` string-template interpolation (`"^$FOO$"`). A distinct
+/// leaf node kind, unlike braced `${...}` interpolation
+/// (`interpolated_expression`, wrapping a real expression whose own leaves
+/// are ordinary `simple_identifier`/`navigation_expression` nodes already
+/// covered elsewhere).
+pub(crate) const KIND_INTERPOLATED_IDENT: &str = "interpolated_identifier";

--- a/src/workspace/document_handler.rs
+++ b/src/workspace/document_handler.rs
@@ -11,6 +11,7 @@ use crate::features::code_actions::missing_package_diagnostic;
 use crate::features::fill_when::when_diagnostics;
 use crate::features::missing_import_diagnostics::missing_import_diagnostics;
 use crate::features::nullable_call_diagnostics::nullable_dot_call_diagnostics;
+use crate::features::unused_import_diagnostics::unused_import_diagnostics;
 use crate::indexer::live_tree::{lang_for_path, parse_live};
 use crate::indexer::{Indexer, ProgressReporter};
 
@@ -227,6 +228,7 @@ impl DocumentHandler {
                             d.extend(call_arg_diagnostics(&indexer, &uri, doc));
                             d.extend(nullable_dot_call_diagnostics(&indexer, &uri, doc));
                             d.extend(missing_import_diagnostics(&indexer, &uri, doc));
+                            d.extend(unused_import_diagnostics(doc));
                         }
                     }
                     let lines = indexer.mem_lines_for(uri.as_str());
@@ -308,6 +310,7 @@ impl DocumentHandler {
                                 d.extend(call_arg_diagnostics(&indexer, &uri, &doc));
                                 d.extend(nullable_dot_call_diagnostics(&indexer, &uri, &doc));
                                 d.extend(missing_import_diagnostics(&indexer, &uri, &doc));
+                                d.extend(unused_import_diagnostics(&doc));
                             }
                             let lines = indexer.mem_lines_for(uri.as_str());
                             let lines: Vec<String> = lines

--- a/src/workspace/file_change_handler.rs
+++ b/src/workspace/file_change_handler.rs
@@ -11,6 +11,7 @@ use crate::features::call_arg_diagnostics::call_arg_diagnostics;
 use crate::features::fill_when::when_diagnostics;
 use crate::features::missing_import_diagnostics::missing_import_diagnostics;
 use crate::features::nullable_call_diagnostics::nullable_dot_call_diagnostics;
+use crate::features::unused_import_diagnostics::unused_import_diagnostics;
 use crate::indexer::live_tree::{lang_for_path, parse_live};
 use crate::indexer::Indexer;
 
@@ -182,6 +183,7 @@ impl FileChangeHandler {
                         diagnostics.extend(arg_diags);
                         diagnostics.extend(nullable_dot_call_diagnostics(&indexer, &uri, doc));
                         diagnostics.extend(missing_import_diagnostics(&indexer, &uri, doc));
+                        diagnostics.extend(unused_import_diagnostics(doc));
                     } else {
                         log::debug!(
                             "diag[gen={}]: live_doc is None — no call-arg diagnostics",

--- a/tests/lsp_smoke.rs
+++ b/tests/lsp_smoke.rs
@@ -830,3 +830,70 @@ fn smoke_missing_import_diagnostic_on_edit() {
         Duration::from_secs(20),
     );
 }
+
+/// Regression, same wiring-gap class as `smoke_missing_import_diagnostic_on_edit`:
+/// unused_import_diagnostics is wired into both the didOpen/republish path and
+/// the debounced didChange path from the start, but this pins it so a future
+/// change that only wires one of them (as actually happened for missing-import)
+/// gets caught immediately.
+#[test]
+fn smoke_unused_import_diagnostic_on_edit() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    write(root, "workspace.json", r#"{"sourcePaths":[]}"#);
+    write(
+        root,
+        "lib/Target.kt",
+        "package com.example.lib\n\nclass Target\n",
+    );
+
+    let using_target = concat!(
+        "package com.example.app\n",
+        "\n",
+        "import com.example.lib.Target\n",
+        "\n",
+        "fun demo() {\n",
+        "    val x = Target()\n",
+        "    println(x)\n",
+        "}\n",
+    );
+    write(root, "src/Main.kt", using_target);
+
+    let mut client = LspClient::spawn(root);
+    client.initialize(root);
+    client.wait_for_indexing();
+
+    let uri = file_uri(root, "src/Main.kt");
+    client.open_file(&uri, "kotlin", using_target);
+
+    // Settle before editing: didOpen's own diagnostics pass, and an
+    // opportunistic early republish (on_became_ready can refire shortly after
+    // open), must both finish first. Without this wait, `did_change`'s
+    // synchronous live-state update (backend/mod.rs) can race ahead of that
+    // early republish, which then reads the ALREADY-EDITED content and
+    // publishes the correct diagnostic via a path OTHER than the debounced
+    // didChange handler this test means to exercise -- masking a regression
+    // in that handler specifically. 500ms clears both the debounce-adjacent
+    // timing and any such early republish.
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Remove the only use of Target via a live edit (didChange) -- the import
+    // itself is untouched, so this only becomes unused because of the edit.
+    let no_longer_using_target = concat!(
+        "package com.example.app\n",
+        "\n",
+        "import com.example.lib.Target\n",
+        "\n",
+        "fun demo() {\n",
+        "    println(\"hi\")\n",
+        "}\n",
+    );
+    client.change_file(&uri, 2, no_longer_using_target);
+
+    client.wait_for_diagnostic_containing(
+        &uri,
+        "Unused import 'com.example.lib.Target'",
+        Duration::from_secs(20),
+    );
+}


### PR DESCRIPTION
## Summary

Sibling to `missing_import_diagnostics` — same dual property: a real LSP feature that also functions as a resolution-pipeline precision benchmark, measurable by running a CLI harness against real projects.

Flags an `import` statement whose local name is never used anywhere in the file (`HINT` severity, `UNNECESSARY` tag — grayed out rather than a squiggle in most editors), with a "Remove unused import" quick-fix. Wired into **both** the didOpen/republish path and the debounced didChange path from the start, learning from missing-import's earlier wiring gap (found and fixed in #234).

Detection collects the flat set of every `simple_identifier`/`type_identifier` node's text in the file (skipping import/package headers) rather than enumerating use-shapes — the opposite bias from missing-import, since missing one shape here means suggesting deletion of a still-needed import (false positive on a delete), which is worse than a missed detection.

### Two exemptions found by running the benchmark, not guessed at upfront

Running the CLI benchmark against nowInAndroid surfaced 62 real systematic false positives:

1. **Operator-convention imports** (32/62 — the dominant source). Kotlin's `by` delegation (`val x by lazy { }`) and Gradle's Kotlin DSL `=`/`()`/`[]` sugar desugar to a compiler-synthesized call (`getValue`/`setValue`/`invoke`/`get`/`assign`/…) whose name never appears as literal identifier text anywhere — verified via parse tree (`property_delegate`'s only child text is the `by` keyword itself). Fixed with a static allowlist of Kotlin's ~30 operator-convention names.
2. **KDoc `[Reference]` links** (the remaining ~8). tree-sitter-kotlin doesn't parse comment bodies into structured sub-nodes at all, so there's no CST node to widen the identifier walk to. Fixed with a light text scan over comment-leaf content — not "recovering structure the CST has" (there is none), the same carve-out the parent design already grants stdlib scope-function receiver inference. Found and fixed a real CST-attachment gotcha while implementing this: a trailing comment right after an import attaches as the *last child of that import's own `import_header` node*, not a leading child of the next declaration — an early-return-the-whole-subtree approach silently ate it; fixed by threading a suppression flag through the walk instead.

**After both exemptions: 0 flags on nowInAndroid** (338 files) — matches the design's expectation exactly. **403 flags across Moneta's ~13k files** (264 files) — spot-checked three for variety (highest-frequency import, an Android `R`-class import, a same-file cluster) and confirmed all genuine dead imports, including one file that's clearly a refactor leftover (4 dead imports from an old error-handling pattern) — matching the user's explicit prediction that Moneta carries real unused-import debt.

### Also found during testing (not a regression, a pre-existing quirk)

An immediate-fire (no settle-wait) smoke test can be masked by a race: an opportunistic early `on_became_ready` → `republish_open_file_diagnostics` call (unrelated to this feature, pre-existing behavior) can read already-live-edited content via a completely different path than the debounced `didChange` handler the test means to exercise — independently converging on the correct diagnostic regardless of whether the intended code path is even wired. Hardened the smoke test with an explicit settle-wait before editing to eliminate this race, then verified genuine RED (stash the intended wiring, confirmed timeout) / GREEN (restore it, confirmed pass) against the actual code path.

### New CLI subcommand

`kmp-lsp unused-imports <root>` — shares detection logic with the live diagnostic (`collect_unused_import_flags`), same shape as the existing `missing-imports` subcommand.

Design doc: `docs/superpowers/specs/2026-07-28-unused-import-diagnostic-design.md`

## Test plan
- [x] `cargo test` — full suite (1599 unit + all integration binaries, including the new `smoke_unused_import_diagnostic_on_edit`) passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Verified RED/GREEN for the didChange wiring via git-stash + hardened smoke test
- [x] Live-probed the diagnostic and code action over the real LSP protocol end-to-end
- [x] Ran the CLI benchmark against nowInAndroid (0 flags) and Moneta (403 flags, spot-checked genuine)