### PR TITLE
fix(vscode): bundle vscode-languageclient with esbuild

### DIFF
--- a/contrib/vscode/.vscodeignore
+++ b/contrib/vscode/.vscodeignore
@@ -2,3 +2,4 @@
 node_modules/
 *.tar.gz
 bin/
+extension.js

--- a/contrib/vscode/package.json
+++ b/contrib/vscode/package.json
@@ -7,7 +7,10 @@
   "icon": "icon.png",
   "engines": { "vscode": "^1.75.0" },
   "activationEvents": ["onLanguage:kotlin", "onLanguage:java", "onLanguage:swift"],
-  "main": "./extension.js",
+  "main": "./dist/extension.js",
+  "scripts": {
+    "vscode:prepublish": "npx esbuild ./extension.js --bundle --outfile=dist/extension.js --external:vscode --platform=node --format=cjs"
+  },
   "contributes": {
     "languages": [
       {
@@ -35,7 +38,8 @@
       }
     }
   },
-  "dependencies": {
+  "devDependencies": {
+    "esbuild": "^0.25.0",
     "vscode-languageclient": "^9.0.1"
   }
 }


### PR DESCRIPTION
The VSIX shipped an unbundled extension.js that require()'d vscode-languageclient/node, but the dependency wasn't included in the package due (--no-dependencies + node_modules/ in .vscodeignore). This caused "Cannot find module 'vscode-languageclient/node'" at activation time.

So i switched to esbuild: vscode-languageclient is now bundled into dist/extension.js via thevscode:prepublish hook in the package.json, which runs automatically before vsce package. No changes needed in the release workflow.