### PR TITLE
fix(swift): correct param counts and eliminate false-positive arg-count diagnostics

### DIFF
--- a/src/features/call_arg_diagnostics_tests.rs
+++ b/src/features/call_arg_diagnostics_tests.rs
@@ -1368,7 +1368,7 @@ fn call_arg_diagnostics_suppresses_when_unmaterialized_jar_has_same_named_candid
     );
 }
 
-// ── Swift reproduction scratch (temporary, will be replaced by real tests) ──
+// ── Swift call-arg diagnostics ───────────────────────────────────────────────
 
 /// Run diagnostics using a Swift-parsed live tree (mirrors production flow
 /// for `.swift` files, where `run_diagnostics` above hardcodes Kotlin).

--- a/src/features/call_arg_diagnostics_tests.rs
+++ b/src/features/call_arg_diagnostics_tests.rs
@@ -1367,3 +1367,283 @@ fn call_arg_diagnostics_suppresses_when_unmaterialized_jar_has_same_named_candid
          positive; got: {diags:?}"
     );
 }
+
+// ── Swift reproduction scratch (temporary, will be replaced by real tests) ──
+
+/// Run diagnostics using a Swift-parsed live tree (mirrors production flow
+/// for `.swift` files, where `run_diagnostics` above hardcodes Kotlin).
+fn run_swift_diagnostics(
+    idx: &Indexer,
+    uri: &Url,
+    source: &str,
+) -> Vec<tower_lsp::lsp_types::Diagnostic> {
+    let doc = parse_live(source, tree_sitter_swift_bundled::language()).unwrap();
+    call_arg_diagnostics(idx, uri, &doc)
+}
+
+#[test]
+fn swift_func_call_matching_args_ok() {
+    let (uri, idx, src) = setup(&[(
+        "/a.swift",
+        concat!(
+            "func greet(name: String, age: Int) {}\n",
+            "func main() {\n",
+            "    greet(\"Alice\", 30)\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_swift_diagnostics(&idx, &uri, &src);
+    assert!(diags.is_empty(), "expected no diagnostics: {diags:?}");
+}
+
+#[test]
+fn swift_func_call_too_few_args_warns() {
+    let (uri, idx, src) = setup(&[(
+        "/a.swift",
+        concat!(
+            "func greet(name: String, age: Int) {}\n",
+            "func main() {\n",
+            "    greet(\"Alice\")\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_swift_diagnostics(&idx, &uri, &src);
+    assert_eq!(diags.len(), 1, "expected 1 diagnostic: {diags:?}");
+    assert!(
+        diags[0].message.contains("expected 2"),
+        "msg: {}",
+        diags[0].message
+    );
+    assert!(
+        diags[0].message.contains("found 1"),
+        "msg: {}",
+        diags[0].message
+    );
+}
+
+#[test]
+fn swift_struct_memberwise_init_matching_args_ok() {
+    // No explicit `init` — call resolution must fall back to the
+    // synthesized memberwise initializer instead of treating the struct as
+    // a 0-argument callable.
+    let (uri, idx, src) = setup(&[(
+        "/a.swift",
+        concat!(
+            "struct Point {\n",
+            "    let x: Int\n",
+            "    let y: Int\n",
+            "}\n",
+            "func main() {\n",
+            "    let p = Point(x: 1, y: 2)\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_swift_diagnostics(&idx, &uri, &src);
+    assert!(diags.is_empty(), "expected no diagnostics: {diags:?}");
+}
+
+#[test]
+fn swift_struct_memberwise_init_too_few_args_warns() {
+    let (uri, idx, src) = setup(&[(
+        "/a.swift",
+        concat!(
+            "struct Point {\n",
+            "    let x: Int\n",
+            "    let y: Int\n",
+            "}\n",
+            "func main() {\n",
+            "    let p = Point(x: 1)\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_swift_diagnostics(&idx, &uri, &src);
+    assert_eq!(diags.len(), 1, "expected 1 diagnostic: {diags:?}");
+    assert!(
+        diags[0].message.contains("expected 2"),
+        "msg: {}",
+        diags[0].message
+    );
+    assert!(
+        diags[0].message.contains("found 1"),
+        "msg: {}",
+        diags[0].message
+    );
+}
+
+#[test]
+fn swift_struct_memberwise_init_too_many_args_warns() {
+    let (uri, idx, src) = setup(&[(
+        "/a.swift",
+        concat!(
+            "struct Point {\n",
+            "    let x: Int\n",
+            "    let y: Int\n",
+            "}\n",
+            "func main() {\n",
+            "    let p = Point(x: 1, y: 2, z: 3)\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_swift_diagnostics(&idx, &uri, &src);
+    assert_eq!(diags.len(), 1, "expected 1 diagnostic: {diags:?}");
+    assert!(
+        diags[0].message.contains("found 3"),
+        "msg: {}",
+        diags[0].message
+    );
+}
+
+#[test]
+fn swift_struct_memberwise_init_default_value_makes_param_optional() {
+    let (uri, idx, src) = setup(&[(
+        "/a.swift",
+        concat!(
+            "struct Point {\n",
+            "    let x: Int\n",
+            "    var y: Int = 0\n",
+            "}\n",
+            "func main() {\n",
+            "    let p = Point(x: 1)\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_swift_diagnostics(&idx, &uri, &src);
+    assert!(
+        diags.is_empty(),
+        "y has a default value, so omitting it must not warn: {diags:?}"
+    );
+}
+
+#[test]
+fn swift_struct_computed_property_excluded_from_memberwise_init() {
+    let (uri, idx, src) = setup(&[(
+        "/a.swift",
+        concat!(
+            "struct Point {\n",
+            "    let x: Int\n",
+            "    let y: Int\n",
+            "    var sum: Int { return x + y }\n",
+            "}\n",
+            "func main() {\n",
+            "    let p = Point(x: 1, y: 2)\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_swift_diagnostics(&idx, &uri, &src);
+    assert!(
+        diags.is_empty(),
+        "computed property must not count toward memberwise init arity: {diags:?}"
+    );
+}
+
+#[test]
+fn swift_explicit_init_used_for_call_arg_diagnostics() {
+    let (uri, idx, src) = setup(&[(
+        "/a.swift",
+        concat!(
+            "class Foo {\n",
+            "    init(a: Int, b: String) {}\n",
+            "}\n",
+            "func main() {\n",
+            "    let f = Foo(a: 1)\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_swift_diagnostics(&idx, &uri, &src);
+    assert_eq!(diags.len(), 1, "expected 1 diagnostic: {diags:?}");
+    assert!(
+        diags[0].message.contains("expected 2"),
+        "msg: {}",
+        diags[0].message
+    );
+    assert!(
+        diags[0].message.contains("found 1"),
+        "msg: {}",
+        diags[0].message
+    );
+}
+
+#[test]
+fn swift_class_default_init_zero_args_ok() {
+    // No explicit init, every stored property has a default — Swift
+    // synthesizes a zero-arg `init()`.
+    let (uri, idx, src) = setup(&[(
+        "/a.swift",
+        concat!(
+            "class Config {\n",
+            "    var retries: Int = 3\n",
+            "}\n",
+            "func main() {\n",
+            "    let c = Config()\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_swift_diagnostics(&idx, &uri, &src);
+    assert!(diags.is_empty(), "expected no diagnostics: {diags:?}");
+}
+
+#[test]
+fn swift_class_default_init_rejects_args() {
+    let (uri, idx, src) = setup(&[(
+        "/a.swift",
+        concat!(
+            "class Config {\n",
+            "    var retries: Int = 3\n",
+            "}\n",
+            "func main() {\n",
+            "    let c = Config(5)\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_swift_diagnostics(&idx, &uri, &src);
+    assert_eq!(diags.len(), 1, "expected 1 diagnostic: {diags:?}");
+    assert!(
+        diags[0].message.contains("found 1"),
+        "msg: {}",
+        diags[0].message
+    );
+}
+
+#[test]
+fn swift_class_no_usable_init_suppresses_diagnostic() {
+    // No explicit init, and a stored property with no default — Swift has no
+    // valid initializer to call here (a real compiler error), so there is no
+    // signature to validate against; must not guess and false-positive.
+    let (uri, idx, src) = setup(&[(
+        "/a.swift",
+        concat!(
+            "class Config {\n",
+            "    var retries: Int\n",
+            "}\n",
+            "func main() {\n",
+            "    let c = Config(5, 6, 7)\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_swift_diagnostics(&idx, &uri, &src);
+    assert!(
+        diags.is_empty(),
+        "no known signature — must suppress: {diags:?}"
+    );
+}
+
+#[test]
+fn swift_overloaded_explicit_init_suppresses_diagnostic() {
+    let (uri, idx, src) = setup(&[(
+        "/a.swift",
+        concat!(
+            "class Foo {\n",
+            "    init(a: Int) {}\n",
+            "    init(a: Int, b: Int) {}\n",
+            "}\n",
+            "func main() {\n",
+            "    let f = Foo(a: 1, b: 2, c: 3)\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_swift_diagnostics(&idx, &uri, &src);
+    assert!(
+        diags.is_empty(),
+        "ambiguous between two init arities — must suppress: {diags:?}"
+    );
+}

--- a/src/features/signature_help_tests.rs
+++ b/src/features/signature_help_tests.rs
@@ -295,3 +295,68 @@ fn no_sig_help_inside_primary_constructor() {
         "sig help must NOT fire inside primary constructor; got: {result:?}"
     );
 }
+
+// ── Swift: sig help must not fire inside a definition's parameter list ────────
+//
+// tree-sitter-swift has no `function_value_parameters`/`primary_constructor`
+// wrapper node — `(`, `parameter`, `)` are direct children of the
+// declaration node itself (`function_declaration`/`init_declaration`), which
+// also encloses the function/init body. Without special handling, the CST
+// walk never recognizes "cursor is inside a definition" for Swift and falls
+// through to the text-based `(`-scanning fallback, which treats the
+// definition's own parameter list as an unclosed call — firing bogus sig
+// help while simply typing a Swift function signature.
+
+#[test]
+fn swift_no_sig_help_inside_func_declaration_params() {
+    let src = "func greet(ha: String, ba: String) {\n    greet(ha: \"\", ba: \"\")\n}";
+    let (u, idx) = setup_with_live_lines("/Greet.swift", src);
+    // col 17 = inside "String" in the first parameter's type.
+    let pos = Position::new(0, 17);
+    let result = compute_signature_help(&u, pos, &idx);
+    assert!(
+        result.is_none(),
+        "sig help must NOT fire inside a Swift func's own parameter list; got: {result:?}"
+    );
+}
+
+#[test]
+fn swift_no_sig_help_inside_init_declaration_params() {
+    let src = "class Foo {\n    init(x: Int, y: Int) {}\n}\n";
+    let (u, idx) = setup_with_live_lines("/Foo.swift", src);
+    // col 13 = inside "Int" in the first parameter's type.
+    let pos = Position::new(1, 13);
+    let result = compute_signature_help(&u, pos, &idx);
+    assert!(
+        result.is_none(),
+        "sig help must NOT fire inside a Swift init's own parameter list; got: {result:?}"
+    );
+}
+
+#[test]
+fn swift_sig_help_fires_after_open_paren() {
+    let src = "func greet(name: String, age: Int) {}\nfunc main() {\n    greet()\n}";
+    let (u, idx) = setup_with_live_lines("/Greet.swift", src);
+    let pos = Position::new(2, 10);
+    let result = compute_signature_help(&u, pos, &idx);
+    assert!(result.is_some(), "expected sig help after `(`, got None");
+    assert_eq!(result.unwrap().active_parameter, Some(0));
+}
+
+#[test]
+fn swift_sig_help_fires_for_unclosed_call_inside_function_body() {
+    // Regression guard: suppressing sig help inside a Swift function's OWN
+    // parameter list must not also suppress it for an unclosed call inside
+    // a *different* (enclosing) function's body — e.g. live-typing `greet(`
+    // inside `main()`. `main`'s own declaration node encloses this call
+    // site too (Swift has no narrow param-list wrapper to bound it), so this
+    // exercises that the point-in-param-span check is precise.
+    let src = "func greet(name: String) {}\nfunc main() {\n    greet(\n}\n";
+    let (u, idx) = setup_with_live_lines("/Main.swift", src);
+    let pos = Position::new(2, 10);
+    let result = compute_signature_help(&u, pos, &idx);
+    assert!(
+        result.is_some(),
+        "sig help must still fire for an unclosed call inside a function body; got: {result:?}"
+    );
+}

--- a/src/indexer/infer/cst_cursor.rs
+++ b/src/indexer/infer/cst_cursor.rs
@@ -4,7 +4,8 @@ use tree_sitter::Point;
 use crate::indexer::live_tree::utf16_col_to_byte;
 use crate::indexer::{Indexer, NodeExt};
 use crate::queries::{
-    KIND_CALL_EXPR, KIND_FORMAL_PARAMS, KIND_FUN_VALUE_PARAMS, KIND_LAMBDA_LIT, KIND_PRIMARY_CTOR,
+    KIND_CALL_EXPR, KIND_FORMAL_PARAMS, KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS, KIND_INIT_DECL,
+    KIND_LAMBDA_LIT, KIND_LPAREN, KIND_PRIMARY_CTOR, KIND_PROTOCOL_FUNC_DECL, KIND_RPAREN,
     KIND_VALUE_ARG,
 };
 
@@ -73,6 +74,18 @@ fn cst_call_info_skip(pos: Position, indexer: &Indexer, uri: &Url, skip: u32) ->
                 in_definition = true;
                 break None;
             }
+            // Swift has no such wrapper node — `(`, `parameter`, `)` are direct
+            // children of the declaration itself, which also encloses the
+            // function/init body. Only treat this as a definition when the
+            // cursor sits within the declaration's own parameter-list span,
+            // not merely somewhere inside its body (a call there must still
+            // resolve normally, e.g. live-typing an unclosed call).
+            KIND_FUN_DECL | KIND_INIT_DECL | KIND_PROTOCOL_FUNC_DECL
+                if swift_point_in_own_param_list(cur, point) =>
+            {
+                in_definition = true;
+                break None;
+            }
             _ => match cur.parent() {
                 Some(parent) => cur = parent,
                 None => break None,
@@ -113,6 +126,36 @@ fn cst_call_info_skip(pos: Position, indexer: &Indexer, uri: &Url, skip: u32) ->
         return text_based_call_info(full_text, cursor_byte);
     }
     None
+}
+
+/// Returns `true` when `point` falls within `decl`'s own `(...)` parameter
+/// span — as opposed to elsewhere in `decl` (e.g. its function body), which
+/// for Swift's flat `function_declaration`/`init_declaration`/
+/// `protocol_function_declaration` nodes is also part of the same node.
+fn swift_point_in_own_param_list(decl: tree_sitter::Node, point: Point) -> bool {
+    let mut open: Option<tree_sitter::Node> = None;
+    let mut close: Option<tree_sitter::Node> = None;
+    let mut cursor = decl.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            match child.kind() {
+                KIND_LPAREN if open.is_none() => open = Some(child),
+                KIND_RPAREN if open.is_some() && close.is_none() => close = Some(child),
+                _ => {}
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    let (Some(open), Some(close)) = (open, close) else {
+        return false;
+    };
+    let p = (point.row, point.column);
+    let start = open.start_position();
+    let end = close.end_position();
+    p >= (start.row, start.column) && p <= (end.row, end.column)
 }
 
 fn count_active_param(value_arguments: &tree_sitter::Node, cursor_byte: usize) -> u32 {

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -778,6 +778,7 @@ fn collect_params_from_file(
         false
     };
     let is_java = file_uri.ends_with(".java");
+    let is_swift = file_uri.ends_with(".swift");
 
     // Compiled-JAR (sidecar) symbols carry parameter *types* in their signature
     // `detail` but no default-value markers (e.g. `fun WindowInsets(left: Int, …)`
@@ -823,29 +824,55 @@ fn collect_params_from_file(
         .iter()
         .filter(name_matches)
         .filter(receiver_matches)
-        .filter_map(|s| {
-            let params_text = if !s.params.is_empty() {
-                s.params.clone()
-            } else {
-                extract_params_from_detail(&s.detail)
-                    .or_else(|| collect_params_from_line(&data.lines, s.range.start.line as usize))
-                    .or_else(|| {
-                        // 0-arg constructors (e.g. `class Foo`) may lack explicit `()`.
-                        if s.param_counts == (0, 0) {
-                            Some(String::new())
-                        } else {
-                            None
-                        }
-                    })?
+        .flat_map(|s| -> Vec<(String, (u8, u8))> {
+            // Swift structs/classes never carry constructor params on their own
+            // CST node (no Kotlin-style inline primary constructor) — the real
+            // signature lives on a nested `init` (explicit or synthesized at
+            // parse time; see `synthesize_swift_implicit_init`). Resolve through
+            // those instead of the type's own (always-empty) params/counts.
+            // Emitting one candidate per `init` lets the caller's arity-envelope
+            // dedup correctly detect an overloaded initializer as ambiguous.
+            if is_swift && matches!(s.kind, SymbolKind::STRUCT | SymbolKind::CLASS) {
+                return data
+                    .symbols
+                    .iter()
+                    .filter(|c| {
+                        c.kind == SymbolKind::CONSTRUCTOR
+                            && c.container.as_deref() == Some(s.name.as_str())
+                    })
+                    .map(|c| (c.params.clone(), c.param_counts))
+                    .collect();
+            }
+            let params_text = match extract_params_or_fallback(s, &data.lines) {
+                Some(text) => text,
+                None => return vec![],
             };
             let counts = if is_compiled_jar {
                 (0, s.param_counts.1)
             } else {
                 s.param_counts
             };
-            Some((params_text, counts))
+            vec![(params_text, counts)]
         })
         .collect()
+}
+
+/// Extract a symbol's parameter text, falling back to detail/line scanning,
+/// then to an explicit `()` for a genuine 0-arg constructor.
+fn extract_params_or_fallback(s: &SymbolEntry, lines: &[String]) -> Option<String> {
+    if !s.params.is_empty() {
+        return Some(s.params.clone());
+    }
+    extract_params_from_detail(&s.detail)
+        .or_else(|| collect_params_from_line(lines, s.range.start.line as usize))
+        .or_else(|| {
+            // 0-arg constructors (e.g. `class Foo`) may lack explicit `()`.
+            if s.param_counts == (0, 0) {
+                Some(String::new())
+            } else {
+                None
+            }
+        })
 }
 
 /// Number of indexed definitions (workspace + JAR) for a call name.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,18 +8,19 @@ use tree_sitter::{Node, Parser, Query, QueryCursor};
 use crate::indexer::NodeExt;
 use crate::queries::{
     self, KIND_ANNOTATION_TYPE_DECL, KIND_CALLABLE_REF, KIND_CALL_EXPR, KIND_CALL_SUFFIX,
-    KIND_CLASS_BODY, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ, KIND_CTOR_DECL,
-    KIND_DELEGATION_SPEC, KIND_ENUM_CONSTANT, KIND_ENUM_DECL, KIND_EQ, KIND_EXTENDS_INTERFACES,
-    KIND_FIELD_DECL, KIND_FORMAL_PARAM, KIND_FORMAL_PARAMS, KIND_FUN, KIND_FUNCTION_TYPE,
-    KIND_FUN_BODY, KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS, KIND_IDENTIFIER, KIND_IMPORT_ALIAS,
-    KIND_IMPORT_DECL, KIND_IMPORT_HEADER, KIND_IMPORT_LIST, KIND_INFIX_EXPR, KIND_INHERITANCE_SPEC,
-    KIND_INHERITANCE_SPECS, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_METHOD_DECL, KIND_MODIFIERS,
-    KIND_MOD_FINAL, KIND_MOD_STATIC, KIND_NAV_EXPR, KIND_NULLABLE_TYPE, KIND_OBJECT_DECL,
-    KIND_PACKAGE_DECL, KIND_PACKAGE_HEADER, KIND_PARAMETER, KIND_PREFIX_EXPR, KIND_PRIMARY_CTOR,
-    KIND_PROP_DECL, KIND_PROP_DELEGATE, KIND_PROTOCOL_DECL, KIND_RECORD_DECL, KIND_SCOPED_IDENT,
-    KIND_SECONDARY_CTOR, KIND_SIMPLE_IDENT, KIND_SOURCE_FILE, KIND_STATEMENTS, KIND_SUPERCLASS,
-    KIND_SUPER_INTERFACES, KIND_TYPE_IDENT, KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VALUE_ARGS,
-    KIND_VAR_DECL, KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT, KOTLIN_DEFINITIONS,
+    KIND_CLASS_BODY, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ, KIND_COMPUTED_PROPERTY,
+    KIND_CTOR_DECL, KIND_DELEGATION_SPEC, KIND_ENUM_CONSTANT, KIND_ENUM_DECL, KIND_EQ,
+    KIND_EXTENDS_INTERFACES, KIND_FIELD_DECL, KIND_FORMAL_PARAM, KIND_FORMAL_PARAMS, KIND_FUN,
+    KIND_FUNCTION_TYPE, KIND_FUN_BODY, KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS, KIND_IDENTIFIER,
+    KIND_IMPORT_ALIAS, KIND_IMPORT_DECL, KIND_IMPORT_HEADER, KIND_IMPORT_LIST, KIND_INFIX_EXPR,
+    KIND_INHERITANCE_SPEC, KIND_INHERITANCE_SPECS, KIND_INIT_DECL, KIND_INTERFACE_DECL,
+    KIND_LAMBDA_LIT, KIND_LPAREN, KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MOD_FINAL,
+    KIND_MOD_STATIC, KIND_NAV_EXPR, KIND_NULLABLE_TYPE, KIND_OBJECT_DECL, KIND_PACKAGE_DECL,
+    KIND_PACKAGE_HEADER, KIND_PARAMETER, KIND_PREFIX_EXPR, KIND_PRIMARY_CTOR, KIND_PROP_DECL,
+    KIND_PROP_DELEGATE, KIND_PROTOCOL_DECL, KIND_PROTOCOL_FUNC_DECL, KIND_RECORD_DECL,
+    KIND_SCOPED_IDENT, KIND_SECONDARY_CTOR, KIND_SIMPLE_IDENT, KIND_SOURCE_FILE, KIND_STATEMENTS,
+    KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_TYPE_IDENT, KIND_USER_TYPE, KIND_VALUE_ARG,
+    KIND_VALUE_ARGS, KIND_VAR_DECL, KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT, KOTLIN_DEFINITIONS,
     SWIFT_DEFINITIONS,
 };
 use crate::StrExt;
@@ -279,6 +280,9 @@ pub(crate) fn parse_swift(content: &str) -> FileData {
         // ── container assignment (parent class/struct for each member) ───────
         assign_containers(&mut data.symbols);
 
+        // ── synthesize compiler-generated init() for types with no explicit one ─
+        synthesize_swift_implicit_init(root, bytes, &mut data.symbols);
+
         finalize_parse(data, root, bytes);
     })
 }
@@ -512,6 +516,127 @@ fn primary_ctor_class_params(root: Node, bytes: &[u8], cls: &SymbolEntry) -> Vec
             Some(stripped)
         })
         .collect()
+}
+
+// ─── Swift implicit-initializer synthesis ────────────────────────────────────
+
+/// Synthesize the compiler-provided initializer for Swift `struct`/`class`
+/// types that declare no explicit `init`.
+///
+/// Swift gives every `struct` a memberwise initializer — one parameter per
+/// stored property, in declaration order, required unless the property has a
+/// default value — when the struct declares no initializer of its own. A
+/// `class` only gets a synthesized zero-arg `init()` when every stored
+/// property already has a default value (Swift's "default initializers"
+/// rule); otherwise it has no usable initializer without one being declared
+/// explicitly, so nothing is synthesized. Computed properties
+/// (`var x: Int { … }`) hold no storage and are excluded either way.
+///
+/// Without this, a call like `Point(x: 1, y: 2)` has no signature to
+/// validate against (the struct's own CST node never carries constructor
+/// params — Swift has no Kotlin-style inline primary constructor), causing
+/// call-arg diagnostics to falsely treat every non-empty struct/class
+/// construction as a 0-argument call.
+fn synthesize_swift_implicit_init(root: Node, bytes: &[u8], symbols: &mut Vec<SymbolEntry>) {
+    let types: Vec<SymbolEntry> = symbols
+        .iter()
+        .filter(|s| matches!(s.kind, SymbolKind::STRUCT | SymbolKind::CLASS))
+        .cloned()
+        .collect();
+
+    for ty in types {
+        let has_explicit_init = symbols.iter().any(|s| {
+            s.kind == SymbolKind::CONSTRUCTOR && s.container.as_deref() == Some(ty.name.as_str())
+        });
+        if has_explicit_init {
+            continue;
+        }
+
+        let props: Vec<(String, bool)> = symbols
+            .iter()
+            .filter(|s| {
+                s.kind == SymbolKind::PROPERTY && s.container.as_deref() == Some(ty.name.as_str())
+            })
+            .filter_map(|p| swift_stored_property_signature(root, bytes, &p.range))
+            .collect();
+
+        let (params, param_counts) = if ty.kind == SymbolKind::STRUCT {
+            let total = props.len() as u8;
+            let required = props.iter().filter(|(_, has_default)| !has_default).count() as u8;
+            let text = props
+                .iter()
+                .map(|(text, _)| text.clone())
+                .collect::<Vec<_>>()
+                .join(", ");
+            (text, (required, total))
+        } else {
+            if props.iter().any(|(_, has_default)| !has_default) {
+                continue;
+            }
+            (String::new(), (0, 0))
+        };
+
+        symbols.push(SymbolEntry {
+            name: queries::SWIFT_INIT_NAME.to_owned(),
+            kind: SymbolKind::CONSTRUCTOR,
+            visibility: ty.visibility,
+            range: ty.range,
+            selection_range: ty.selection_range,
+            detail: format!("init({params})"),
+            params,
+            param_counts,
+            container: Some(ty.name.clone()),
+            cold: None,
+            trailing_lambda: false,
+            deprecated: ty.deprecated,
+        });
+    }
+}
+
+/// For a Swift stored property whose declaration starts at `range`, return
+/// `(param_text, has_default_value)` for use in a synthesized initializer, or
+/// `None` if the property is computed (`var x: Int { … }`) and therefore
+/// holds no storage.
+fn swift_stored_property_signature(
+    root: Node,
+    bytes: &[u8],
+    range: &Range,
+) -> Option<(String, bool)> {
+    let start_point = tree_sitter::Point {
+        row: range.start.line as usize,
+        column: range.start.character as usize,
+    };
+    let node = root.descendant_for_point_range(start_point, start_point)?;
+    let decl = find_ancestor_decl(node);
+    if decl.kind() != KIND_PROP_DECL {
+        return None;
+    }
+    let mut has_default = false;
+    let mut is_computed = false;
+    let mut cursor = decl.walk();
+    if cursor.goto_first_child() {
+        loop {
+            match cursor.node().kind() {
+                KIND_COMPUTED_PROPERTY => is_computed = true,
+                KIND_EQ => has_default = true,
+                _ => {}
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    if is_computed {
+        return None;
+    }
+    let text = decl.utf8_text(bytes).ok()?;
+    let text: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let stripped = text
+        .strip_prefix("let ")
+        .or_else(|| text.strip_prefix("var "))
+        .unwrap_or(text.as_str())
+        .to_owned();
+    Some((stripped, has_default))
 }
 
 // ─── Container assignment (post-extraction pass) ─────────────────────────────
@@ -1378,25 +1503,51 @@ fn extract_params_and_counts(root: Node, bytes: &[u8], range: &Range) -> (String
         return (String::new(), (0, 0));
     };
     let decl = find_ancestor_decl(node);
+    match params_container_node(decl) {
+        Some(container) => (
+            extract_inner_text(&container, bytes),
+            count_params_from_node(&container),
+        ),
+        None => (String::new(), (0, 0)),
+    }
+}
+
+/// Locate the node that directly holds a declaration's parameter list.
+///
+/// Kotlin/Java wrap parameters in a dedicated child node
+/// (`function_value_parameters` / `formal_parameters` / `primary_constructor`).
+/// Swift's grammar has no such wrapper — `(`, `parameter`, `)` are direct
+/// children of the declaration node itself (`function_declaration`,
+/// `init_declaration`, `protocol_function_declaration`) — so fall back to
+/// `decl` itself when it directly contains a `(` token.
+fn params_container_node(decl: Node) -> Option<Node> {
     let mut cursor = decl.walk();
     if cursor.goto_first_child() {
         loop {
-            let child = cursor.node();
-            let kind = child.kind();
+            let kind = cursor.node().kind();
             if kind == KIND_FUN_VALUE_PARAMS
                 || kind == KIND_FORMAL_PARAMS
                 || kind == KIND_PRIMARY_CTOR
             {
-                let text = extract_inner_text(&child, bytes);
-                let counts = count_params_from_node(&child);
-                return (text, counts);
+                return Some(cursor.node());
             }
             if !cursor.goto_next_sibling() {
                 break;
             }
         }
     }
-    (String::new(), (0, 0))
+    let mut cursor = decl.walk();
+    if cursor.goto_first_child() {
+        loop {
+            if cursor.node().kind() == KIND_LPAREN {
+                return Some(decl);
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    None
 }
 
 /// Returns `true` when the last value parameter of the function at `range` has a function
@@ -1410,7 +1561,7 @@ fn last_value_param_is_function_type(root: Node, _bytes: &[u8], range: &Range) -
         return false;
     };
     let decl = find_ancestor_decl(node);
-    let Some(params) = decl.first_child_of_kind(KIND_FUN_VALUE_PARAMS) else {
+    let Some(params) = params_container_node(decl) else {
         return false;
     };
     let param_nodes = params.children_of_kind(KIND_PARAMETER);
@@ -1538,6 +1689,8 @@ fn find_ancestor_decl(mut node: Node) -> Node {
                 | KIND_CTOR_DECL
                 | KIND_METHOD_DECL
                 | KIND_RECORD_DECL
+                | KIND_INIT_DECL
+                | KIND_PROTOCOL_FUNC_DECL
                 | KIND_SOURCE_FILE
         ) {
             return node;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,18 +10,18 @@ use crate::queries::{
     self, KIND_ANNOTATION_TYPE_DECL, KIND_CALLABLE_REF, KIND_CALL_EXPR, KIND_CALL_SUFFIX,
     KIND_CLASS_BODY, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ, KIND_COMPUTED_PROPERTY,
     KIND_CTOR_DECL, KIND_DELEGATION_SPEC, KIND_ENUM_CONSTANT, KIND_ENUM_DECL, KIND_EQ,
-    KIND_EXTENDS_INTERFACES, KIND_FIELD_DECL, KIND_FORMAL_PARAM, KIND_FORMAL_PARAMS, KIND_FUN,
-    KIND_FUNCTION_TYPE, KIND_FUN_BODY, KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS, KIND_IDENTIFIER,
-    KIND_IMPORT_ALIAS, KIND_IMPORT_DECL, KIND_IMPORT_HEADER, KIND_IMPORT_LIST, KIND_INFIX_EXPR,
-    KIND_INHERITANCE_SPEC, KIND_INHERITANCE_SPECS, KIND_INIT_DECL, KIND_INTERFACE_DECL,
-    KIND_LAMBDA_LIT, KIND_LPAREN, KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MOD_FINAL,
-    KIND_MOD_STATIC, KIND_NAV_EXPR, KIND_NULLABLE_TYPE, KIND_OBJECT_DECL, KIND_PACKAGE_DECL,
-    KIND_PACKAGE_HEADER, KIND_PARAMETER, KIND_PREFIX_EXPR, KIND_PRIMARY_CTOR, KIND_PROP_DECL,
-    KIND_PROP_DELEGATE, KIND_PROTOCOL_DECL, KIND_PROTOCOL_FUNC_DECL, KIND_RECORD_DECL,
-    KIND_SCOPED_IDENT, KIND_SECONDARY_CTOR, KIND_SIMPLE_IDENT, KIND_SOURCE_FILE, KIND_STATEMENTS,
-    KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_TYPE_IDENT, KIND_USER_TYPE, KIND_VALUE_ARG,
-    KIND_VALUE_ARGS, KIND_VAR_DECL, KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT, KOTLIN_DEFINITIONS,
-    SWIFT_DEFINITIONS,
+    KIND_EXTENDS_INTERFACES, KIND_EXTENSION_KW, KIND_FIELD_DECL, KIND_FORMAL_PARAM,
+    KIND_FORMAL_PARAMS, KIND_FUN, KIND_FUNCTION_TYPE, KIND_FUN_BODY, KIND_FUN_DECL,
+    KIND_FUN_VALUE_PARAMS, KIND_IDENTIFIER, KIND_IMPORT_ALIAS, KIND_IMPORT_DECL,
+    KIND_IMPORT_HEADER, KIND_IMPORT_LIST, KIND_INFIX_EXPR, KIND_INHERITANCE_SPEC,
+    KIND_INHERITANCE_SPECS, KIND_INIT_DECL, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_LPAREN,
+    KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MOD_FINAL, KIND_MOD_STATIC, KIND_NAV_EXPR,
+    KIND_NULLABLE_TYPE, KIND_OBJECT_DECL, KIND_PACKAGE_DECL, KIND_PACKAGE_HEADER, KIND_PARAMETER,
+    KIND_PREFIX_EXPR, KIND_PRIMARY_CTOR, KIND_PROP_DECL, KIND_PROP_DELEGATE, KIND_PROTOCOL_DECL,
+    KIND_PROTOCOL_FUNC_DECL, KIND_RECORD_DECL, KIND_SCOPED_IDENT, KIND_SECONDARY_CTOR,
+    KIND_SIMPLE_IDENT, KIND_SOURCE_FILE, KIND_STATEMENTS, KIND_SUPERCLASS, KIND_SUPER_INTERFACES,
+    KIND_TYPE_IDENT, KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VALUE_ARGS, KIND_VAR_DECL,
+    KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
 };
 use crate::StrExt;
 
@@ -538,15 +538,28 @@ fn primary_ctor_class_params(root: Node, bytes: &[u8], cls: &SymbolEntry) -> Vec
 /// call-arg diagnostics to falsely treat every non-empty struct/class
 /// construction as a 0-argument call.
 fn synthesize_swift_implicit_init(root: Node, bytes: &[u8], symbols: &mut Vec<SymbolEntry>) {
+    // `extension Foo { ... }` is indexed with the same `SymbolKind::CLASS` as
+    // an actual `class`/`struct` (both are `class_declaration` in the Swift
+    // grammar, see `SWIFT_DEFINITIONS`) — exclude it here. An extension can
+    // only add *convenience* initializers, never a designated one, and per
+    // Swift's own rule it never suppresses or replaces the type's own
+    // memberwise/default initializer (only initializers declared in the
+    // type's *original* implementation do that).
     let types: Vec<SymbolEntry> = symbols
         .iter()
         .filter(|s| matches!(s.kind, SymbolKind::STRUCT | SymbolKind::CLASS))
+        .filter(|s| !swift_class_decl_is_extension(root, &s.range))
         .cloned()
         .collect();
 
     for ty in types {
+        // Only an `init` declared inside the type's own body counts — one
+        // added by a same-named `extension` elsewhere must not suppress
+        // synthesis (see comment above).
         let has_explicit_init = symbols.iter().any(|s| {
-            s.kind == SymbolKind::CONSTRUCTOR && s.container.as_deref() == Some(ty.name.as_str())
+            s.kind == SymbolKind::CONSTRUCTOR
+                && s.container.as_deref() == Some(ty.name.as_str())
+                && range_contains_lines(&ty.range, &s.range)
         });
         if has_explicit_init {
             continue;
@@ -591,6 +604,42 @@ fn synthesize_swift_implicit_init(root: Node, bytes: &[u8], symbols: &mut Vec<Sy
             deprecated: ty.deprecated,
         });
     }
+}
+
+/// Returns `true` when `outer` fully encloses `inner` by line range — the
+/// same nesting test `assign_containers` uses to determine containment.
+fn range_contains_lines(outer: &Range, inner: &Range) -> bool {
+    outer.start.line <= inner.start.line && outer.end.line >= inner.end.line
+}
+
+/// Returns `true` if the Swift `class`/`struct`/`extension` declaration
+/// starting at `range` is actually an `extension` — the Swift grammar
+/// reuses the same `class_declaration` node kind for all four, distinguished
+/// only by an anonymous keyword child (see `SWIFT_DEFINITIONS`).
+fn swift_class_decl_is_extension(root: Node, range: &Range) -> bool {
+    let start_point = tree_sitter::Point {
+        row: range.start.line as usize,
+        column: range.start.character as usize,
+    };
+    let Some(node) = root.descendant_for_point_range(start_point, start_point) else {
+        return false;
+    };
+    let decl = find_ancestor_decl(node);
+    if decl.kind() != KIND_CLASS_DECL {
+        return false;
+    }
+    let mut cursor = decl.walk();
+    if cursor.goto_first_child() {
+        loop {
+            if cursor.node().kind() == KIND_EXTENSION_KW {
+                return true;
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    false
 }
 
 /// For a Swift stored property whose declaration starts at `range`, return

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -780,6 +780,120 @@ fn swift_init() {
     assert!(sym(&data, "init").is_some());
 }
 
+// ── Swift params / param_counts CST extraction ──────────────────────────────
+//
+// tree-sitter-swift has no `function_value_parameters`/`formal_parameters`
+// wrapper node like Kotlin/Java — `(`, `parameter`, `)` are direct children
+// of the declaration node itself. Regression coverage for that mismatch.
+
+#[test]
+fn swift_func_param_signature() {
+    let data = parse_swift("func greet(name: String, age: Int) {}");
+    let s = sym(&data, "greet").unwrap();
+    assert_eq!(s.params, "name: String, age: Int");
+    assert_eq!(s.param_counts, (2, 2));
+}
+
+#[test]
+fn swift_func_params_zero_args() {
+    let data = parse_swift("func noop() {}");
+    let s = sym(&data, "noop").unwrap();
+    assert_eq!(s.params, "");
+    assert_eq!(s.param_counts, (0, 0));
+}
+
+#[test]
+fn swift_func_params_with_default_value() {
+    let data = parse_swift("func create(name: String, age: Int = 0) {}");
+    let s = sym(&data, "create").unwrap();
+    assert_eq!(s.param_counts, (1, 2));
+}
+
+#[test]
+fn swift_init_param_signature() {
+    let data = parse_swift("class Foo { init(a: Int, b: String) {} }");
+    let s = sym(&data, "init").unwrap();
+    assert_eq!(s.params, "a: Int, b: String");
+    assert_eq!(s.param_counts, (2, 2));
+}
+
+#[test]
+fn swift_protocol_func_param_signature() {
+    let data = parse_swift("protocol Greeter { func greet(name: String, times: Int) -> String }");
+    let s = sym(&data, "greet").unwrap();
+    assert_eq!(s.param_counts, (2, 2));
+}
+
+#[test]
+fn swift_method_params_in_struct() {
+    let data = parse_swift(
+        "struct Point { func distance(to other: Point, scale: Double = 1.0) -> Double { 0 } }",
+    );
+    let s = sym(&data, "distance").unwrap();
+    assert_eq!(s.param_counts, (1, 2));
+}
+
+// ── Swift implicit-initializer synthesis ────────────────────────────────────
+
+#[test]
+fn swift_struct_memberwise_init_synthesized_when_no_explicit_init() {
+    let data = parse_swift("struct Point {\n    let x: Int\n    let y: Int\n}");
+    let init = sym(&data, "init").expect("memberwise init should be synthesized");
+    assert_eq!(init.kind, SymbolKind::CONSTRUCTOR);
+    assert_eq!(init.container.as_deref(), Some("Point"));
+    assert_eq!(init.param_counts, (2, 2));
+    assert_eq!(init.params, "x: Int, y: Int");
+}
+
+#[test]
+fn swift_struct_memberwise_init_default_value_is_optional() {
+    let data = parse_swift("struct Point {\n    let x: Int\n    var y: Int = 0\n}");
+    let init = sym(&data, "init").unwrap();
+    assert_eq!(init.param_counts, (1, 2));
+}
+
+#[test]
+fn swift_struct_computed_property_excluded_from_memberwise_init() {
+    let data = parse_swift(
+        "struct Point {\n    let x: Int\n    let y: Int\n    var sum: Int { return x + y }\n}",
+    );
+    let init = sym(&data, "init").unwrap();
+    assert_eq!(
+        init.param_counts,
+        (2, 2),
+        "computed property must not count toward the memberwise init"
+    );
+}
+
+#[test]
+fn swift_struct_explicit_init_suppresses_memberwise_synthesis() {
+    let data = parse_swift("struct Point {\n    let x: Int\n    init(x: Int) { self.x = x }\n}");
+    let inits: Vec<_> = data.symbols.iter().filter(|s| s.name == "init").collect();
+    assert_eq!(
+        inits.len(),
+        1,
+        "explicit init present — must not also synthesize a memberwise one: {inits:?}"
+    );
+    assert_eq!(inits[0].param_counts, (1, 1));
+}
+
+#[test]
+fn swift_class_default_init_synthesized_when_all_properties_have_defaults() {
+    let data = parse_swift("class Config {\n    var retries: Int = 3\n}");
+    let init = sym(&data, "init").expect("zero-arg default init should be synthesized");
+    assert_eq!(init.param_counts, (0, 0));
+}
+
+#[test]
+fn swift_class_no_init_synthesized_when_property_lacks_default() {
+    let data = parse_swift("class Config {\n    var retries: Int\n}");
+    assert!(
+        sym(&data, "init").is_none(),
+        "no explicit init and a non-defaulted property — Swift has no valid \
+         initializer here, so none should be synthesized"
+    );
+}
+
 #[test]
 fn swift_imports() {
     let data = parse_swift("import Foundation\nimport UIKit\nclass A {}");

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -895,6 +895,49 @@ fn swift_class_no_init_synthesized_when_property_lacks_default() {
 }
 
 #[test]
+fn swift_bare_extension_gets_no_synthesized_init() {
+    // `extension` reuses the same `class_declaration`/`SymbolKind::CLASS`
+    // representation as an actual class in this grammar — must not be
+    // mistaken for a type needing its own synthesized initializer.
+    let data = parse_swift("extension Foo {\n    func bar() {}\n}\n");
+    assert!(
+        sym(&data, "init").is_none(),
+        "a bare extension must not get a bogus synthesized init()"
+    );
+}
+
+#[test]
+fn swift_extension_convenience_init_does_not_suppress_memberwise_synthesis() {
+    // Swift's own rule: the memberwise initializer is only discarded by
+    // initializers declared in the struct's *original* implementation — one
+    // added later via an `extension` does not suppress it.
+    let data = parse_swift(concat!(
+        "struct Point {\n",
+        "    let x: Int\n",
+        "    let y: Int\n",
+        "}\n",
+        "extension Point {\n",
+        "    init(other: Point) { self.x = other.x; self.y = other.y }\n",
+        "}\n",
+    ));
+    let inits: Vec<_> = data.symbols.iter().filter(|s| s.name == "init").collect();
+    assert_eq!(
+        inits.len(),
+        2,
+        "expected both the struct's own memberwise init and the extension's \
+         convenience init: {inits:?}"
+    );
+    assert!(
+        inits.iter().any(|s| s.param_counts == (2, 2)),
+        "memberwise init (x, y) missing: {inits:?}"
+    );
+    assert!(
+        inits.iter().any(|s| s.param_counts == (1, 1)),
+        "extension's convenience init(other:) missing: {inits:?}"
+    );
+}
+
+#[test]
 fn swift_imports() {
     let data = parse_swift("import Foundation\nimport UIKit\nclass A {}");
     assert_eq!(data.imports.len(), 2);

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -393,6 +393,7 @@ pub(crate) const KIND_INHERITANCE_SPEC: &str = "inheritance_specifier";
 pub(crate) const KIND_INIT_DECL: &str = "init_declaration";
 pub(crate) const KIND_PROTOCOL_FUNC_DECL: &str = "protocol_function_declaration";
 pub(crate) const KIND_COMPUTED_PROPERTY: &str = "computed_property";
+pub(crate) const KIND_EXTENSION_KW: &str = "extension";
 
 // ─── Generic / type parameter node kinds (shared across Kotlin, Java, Swift) ─
 pub(crate) const KIND_TYPE_PARAMS: &str = "type_parameters";

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -390,6 +390,9 @@ pub(crate) const KIND_TYPE_LIST: &str = "type_list";
 pub(crate) const KIND_PROTOCOL_DECL: &str = "protocol_declaration";
 pub(crate) const KIND_INHERITANCE_SPECS: &str = "inheritance_specifiers";
 pub(crate) const KIND_INHERITANCE_SPEC: &str = "inheritance_specifier";
+pub(crate) const KIND_INIT_DECL: &str = "init_declaration";
+pub(crate) const KIND_PROTOCOL_FUNC_DECL: &str = "protocol_function_declaration";
+pub(crate) const KIND_COMPUTED_PROPERTY: &str = "computed_property";
 
 // ─── Generic / type parameter node kinds (shared across Kotlin, Java, Swift) ─
 pub(crate) const KIND_TYPE_PARAMS: &str = "type_parameters";
@@ -428,6 +431,8 @@ pub(crate) const KIND_MODIFIERS: &str = "modifiers";
 pub(crate) const KIND_COLON: &str = ":";
 pub(crate) const KIND_EQ: &str = "=";
 pub(crate) const KIND_DOT: &str = ".";
+pub(crate) const KIND_LPAREN: &str = "(";
+pub(crate) const KIND_RPAREN: &str = ")";
 pub(crate) const KIND_PARAMETER: &str = "parameter";
 pub(crate) const KIND_FUN_VALUE_PARAMS: &str = "function_value_parameters";
 pub(crate) const KIND_FUNCTION_TYPE: &str = "function_type";


### PR DESCRIPTION
## Summary
- `tree-sitter-swift` has no `function_value_parameters`/`formal_parameters`/`primary_constructor` wrapper node like Kotlin/Java — `(`, `parameter`, `)` are direct children of the declaration node itself. This silently made every Swift `func`/`init`/protocol-method report `params=""` and `param_counts=(0,0)`.
- That cascaded into false-positive "wrong argument count" diagnostics on nearly every non-trivial Swift struct/class construction, since constructor calls resolve against the type's own symbol, which never carries inline constructor params in Swift.
- Also fixes a related bug where signature help would fire bogus popups while simply typing a Swift function/init's own parameter list (same root grammar-shape mismatch), while still firing correctly for calls inside that declaration's body.

## Changes
- `find_ancestor_decl` now recognizes `init_declaration`/`protocol_function_declaration` instead of walking past them.
- New `params_container_node()` falls back to the declaration node itself when it directly holds a `(` (Swift's flat parameter-list shape) — used by both param extraction and trailing-lambda detection.
- New `synthesize_swift_implicit_init()` synthesizes a real `init` symbol for structs/classes with no explicit initializer, mirroring the existing Kotlin data-class `copy()` synthesis: memberwise init for structs (defaulted/computed properties handled correctly per Swift semantics), zero-arg default init for classes only when every stored property has a default.
- `collect_params_from_file()` routes Swift struct/class calls through sibling `init` symbols instead of the type's own always-empty signature, so genuinely overloaded explicit inits correctly resolve to `Overloaded` (diagnostic suppressed) via the existing arity-dedup logic.
- `cst_call_info_skip()` no longer fires bogus signature help while typing inside a Swift `func`/`init`'s own parameter list, using a precise point-in-param-span check (not just "inside the declaration," since Swift's flat grammar means one node spans both the signature and the body).

## Test plan
- [x] 30 new tests: `parser_tests.rs` (param counts for func/init/protocol methods, memberwise/default init synthesis, computed-property exclusion), `call_arg_diagnostics_tests.rs` (no false positive on struct/class construction, explicit init, overload suppression), `signature_help_tests.rs` (no false trigger inside definitions, still fires inside enclosing function bodies).
- [x] Full suite: `cargo test` — 1634 passed, 0 failed.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)