### PR TITLE
fix(infer): AGENTS.md + catalogue-doc audit cleanup in indexer/infer

### DIFF
--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -380,7 +380,7 @@ fn cst_call_arg_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String>
             KIND_VALUE_ARG => break Some(cur),
             KIND_LAMBDA_LIT => break None,
             _ => match cur.parent() {
-                Some(p) => cur = p,
+                Some(parent) => cur = parent,
                 None => break None,
             },
         }
@@ -390,8 +390,8 @@ fn cst_call_arg_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String>
     let mut node = value_arg;
     let call_expr = loop {
         match node.parent() {
-            Some(p) if p.kind() == KIND_CALL_EXPR => break Some(p),
-            Some(p) => node = p,
+            Some(parent) if parent.kind() == KIND_CALL_EXPR => break Some(parent),
+            Some(parent) => node = parent,
             None => break None,
         }
     }?;

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -224,6 +224,67 @@ pub(super) fn forward_resolve_segments(
     Some((receiver_type, method))
 }
 
+/// How `resolve_callee_chain` must treat a navigation chain's final segment
+/// to report `(receiver_type, method_name)` correctly.
+///
+/// A chain's final segment plays one of two distinct roles, and
+/// `forward_resolve_segments`'s Suffix handling treats them very
+/// differently: it tries `resolve_member_type_on` first and only falls back
+/// to "flow the receiver type through unchanged" for names in
+/// `SCOPE_FUNCTIONS`. Deciding which role applies up front — instead of
+/// always walking the full list and hoping the fallback fires — is what this
+/// type exists to make explicit.
+enum FinalCalleeSegment<'segments, 'node> {
+    /// The final segment is a plain (non-scope-function) method name being
+    /// invoked as the call itself (e.g. "map" in `container.items.map { }`),
+    /// not a member to fold into the receiver's type. It must never reach
+    /// `forward_resolve_segments`'s member-lookup: were it walked, a
+    /// same-named field or method on the receiver would be resolved as if
+    /// it were a further navigation step, corrupting the receiver type.
+    /// Resolve `receiver_segments` alone to get `receiver_type`, and report
+    /// `method_name` as-is.
+    CallTarget {
+        receiver_segments: &'segments [NavSegment<'node>],
+        method_name: String,
+    },
+    /// The final segment must be visited by a full forward walk over every
+    /// segment, not excluded: either it is a scope function
+    /// (`let`/`also`/`run`/`apply`/`takeIf`/`takeUnless`), whose Suffix
+    /// handling both flows the receiver type through unchanged *and* applies
+    /// side effects tied to actually visiting that segment (e.g.
+    /// `?.`-driven nullability stripping) — dropping it via slicing silently
+    /// loses those effects, which is what broke
+    /// `nullable_let_chain_it_type_resolves`,
+    /// `this_type_apply_on_constructor_call_infers_receiver`, and 7 other
+    /// scope-function-terminated chain tests the one time this was tried —
+    /// or the chain's last element isn't a Suffix at all (`Root`/`CallExpr`).
+    /// `forward_resolve_segments` already reports `(receiver_type,
+    /// method_name)` for the whole chain, so hand it the untouched list.
+    WalkFull,
+}
+
+/// Classify how `resolve_callee_chain` should treat `segments`' final entry.
+/// See `FinalCalleeSegment` for what each outcome means and why.
+///
+/// This classification must NOT be pushed down into
+/// `forward_resolve_segments`/`resolve_segments_type` themselves: their
+/// "resolve every segment I'm handed" contract is relied on elsewhere (see
+/// mod_tests.rs's `unresolved_final_suffix_fails_the_strict_walk`) and by
+/// `resolve_call_expr_type`'s own already-correct pre-sliced call.
+fn classify_final_callee_segment<'segments, 'node>(
+    segments: &'segments [NavSegment<'node>],
+) -> FinalCalleeSegment<'segments, 'node> {
+    match segments.last() {
+        Some(NavSegment::Suffix { name, .. }) if !SCOPE_FUNCTIONS.contains(&name.as_str()) => {
+            FinalCalleeSegment::CallTarget {
+                receiver_segments: &segments[..segments.len() - 1],
+                method_name: name.clone(),
+            }
+        }
+        _ => FinalCalleeSegment::WalkFull,
+    }
+}
+
 /// Resolve the callee navigation chain left-to-right, returning the type
 /// of the expression before the final method call, and the final method name.
 ///
@@ -243,41 +304,13 @@ pub(super) fn resolve_callee_chain(
             if segments.is_empty() {
                 return None;
             }
-            // Mirror resolve_call_expr_type's pre-slice (this same file,
-            // ~line 436-449): when the final segment is a plain
-            // (non-scope-function) method name -- e.g. "map" in
-            // `container.items.map { }` -- it is the method being called
-            // with the trailing lambda, not itself a member access to fold
-            // into the receiver's type, so exclude it before resolving.
-            //
-            // Scope functions (let/also/run/apply/takeIf/takeUnless) are
-            // deliberately NOT excluded here, exactly like
-            // resolve_call_expr_type's own SCOPE_FUNCTIONS check gates its
-            // pre-slice: forward_resolve_segments already flows the
-            // receiver type through a scope-function Suffix unchanged, and
-            // that full-list walk also carries side effects tied to
-            // processing that exact segment (e.g. `?.`-driven nullability
-            // stripping) that only fire while it is actually visited.
-            // Slicing it away unconditionally silently drops those side
-            // effects -- caught by running the full suite after the initial
-            // unconditional-slice attempt, which broke
-            // `nullable_let_chain_it_type_resolves`,
-            // `this_type_apply_on_constructor_call_infers_receiver`, and 7
-            // other scope-function-terminated chain tests.
-            //
-            // Do NOT push this exclusion into
-            // forward_resolve_segments/resolve_segments_type themselves --
-            // their "resolve every segment I'm handed" contract is relied on
-            // elsewhere (see mod_tests.rs's
-            // unresolved_final_suffix_fails_the_strict_walk) and by
-            // resolve_call_expr_type's own already-correct pre-sliced call.
-            match segments.last() {
-                Some(NavSegment::Suffix { name, .. })
-                    if !SCOPE_FUNCTIONS.contains(&name.as_str()) =>
-                {
-                    let method_name = name.clone();
+            match classify_final_callee_segment(&segments) {
+                FinalCalleeSegment::CallTarget {
+                    receiver_segments,
+                    method_name,
+                } => {
                     let receiver_type = resolve_segments_type(
-                        &segments[..segments.len() - 1],
+                        receiver_segments,
                         bytes,
                         deps,
                         uri,
@@ -285,7 +318,7 @@ pub(super) fn resolve_callee_chain(
                     )?;
                     Some((receiver_type, method_name))
                 }
-                _ => forward_resolve_segments(
+                FinalCalleeSegment::WalkFull => forward_resolve_segments(
                     &segments,
                     bytes,
                     deps,

--- a/src/indexer/infer/cst_lambda.rs
+++ b/src/indexer/infer/cst_lambda.rs
@@ -76,66 +76,92 @@ pub(crate) fn classify_this_lambda_context(
     let callee_raw = strip_trailing_call_args(trimmed).replace("?.", ".");
     let callee = callee_raw.trim();
 
-    // ── Case A: `receiver.method` ────────────────────────────────────────────
     if let Some(dot_pos) = find_last_dot_at_depth_zero(callee) {
-        let receiver_expr = callee[..dot_pos].trim_end();
-        let receiver_var = last_ident_in(receiver_expr);
-        let method = callee[dot_pos + 1..].trim_start().ident_prefix();
-
-        if !receiver_var.is_empty() && !method.is_empty() {
-            // Indexed function with a receiver-lambda last param → always Resolved.
-            if let Some(this_type) = fun_trailing_lambda_this_type(&method, deps, uri) {
-                return ThisLambdaCtx::Resolved(this_type);
-            }
-            // Known stdlib scope functions (`run`, `apply`).
-            if RECEIVER_THIS_FNS.contains(&method.as_str()) {
-                if let Some(raw) = deps.find_var_type(receiver_var, uri) {
-                    let base = raw.ident_prefix();
-                    if !base.is_empty() {
-                        return ThisLambdaCtx::Resolved(base);
-                    }
-                }
-                if receiver_var.starts_with_uppercase() {
-                    return ThisLambdaCtx::Resolved(receiver_var.to_owned());
-                }
-                // In a known scope-fn lambda but type not found.
-                return ThisLambdaCtx::Receiver;
-            }
-        }
-        // Other dot-call (forEach, map, …): `this` = enclosing class.
-        return ThisLambdaCtx::NotReceiver;
+        return classify_dot_call_receiver(callee, dot_pos, deps, uri);
     }
 
-    // ── Case B: `with(receiver) { this }` ───────────────────────────────────
     let trailing_fn = last_ident_in(callee);
     if trailing_fn == "with" {
-        if let Some(recv_name) = extract_first_arg(trimmed) {
-            if let Some(raw) = deps.find_var_type(recv_name, uri) {
+        return classify_with_call_receiver(trimmed, deps, uri);
+    }
+
+    classify_bare_builder_call(trailing_fn, deps, uri)
+}
+
+/// Case A: `receiver.method { this }`. If `method` has an indexed
+/// receiver-lambda type → `Resolved`. If `method` ∈ `RECEIVER_THIS_FNS`
+/// (`run`, `apply`): resolve the receiver variable's type → `Resolved`; if
+/// unresolvable → `Receiver`. Any other dot-call method (`forEach`, `map`,
+/// …) means `this` is the enclosing class → `NotReceiver`.
+fn classify_dot_call_receiver(
+    callee: &str,
+    dot_pos: usize,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> ThisLambdaCtx {
+    let receiver_expr = callee[..dot_pos].trim_end();
+    let receiver_var = last_ident_in(receiver_expr);
+    let method = callee[dot_pos + 1..].trim_start().ident_prefix();
+
+    if !receiver_var.is_empty() && !method.is_empty() {
+        // Indexed function with a receiver-lambda last param → always Resolved.
+        if let Some(this_type) = fun_trailing_lambda_this_type(&method, deps, uri) {
+            return ThisLambdaCtx::Resolved(this_type);
+        }
+        // Known stdlib scope functions (`run`, `apply`).
+        if RECEIVER_THIS_FNS.contains(&method.as_str()) {
+            if let Some(raw) = deps.find_var_type(receiver_var, uri) {
                 let base = raw.ident_prefix();
                 if !base.is_empty() {
                     return ThisLambdaCtx::Resolved(base);
                 }
             }
-            let base = recv_name.ident_prefix();
-            if base.starts_with_uppercase() {
+            if receiver_var.starts_with_uppercase() {
+                return ThisLambdaCtx::Resolved(receiver_var.to_owned());
+            }
+            // In a known scope-fn lambda but type not found.
+            return ThisLambdaCtx::Receiver;
+        }
+    }
+    // Other dot-call (forEach, map, …): `this` = enclosing class.
+    ThisLambdaCtx::NotReceiver
+}
+
+/// Case B: `with(receiver) { this }`. Resolves the receiver's type from the
+/// call's first argument → `Resolved`; falls back to `Receiver` when the
+/// call is confirmed `with` but the receiver's type can't be determined.
+fn classify_with_call_receiver(trimmed: &str, deps: &impl InferDeps, uri: &Url) -> ThisLambdaCtx {
+    if let Some(recv_name) = extract_first_arg(trimmed) {
+        if let Some(raw) = deps.find_var_type(recv_name, uri) {
+            let base = raw.ident_prefix();
+            if !base.is_empty() {
                 return ThisLambdaCtx::Resolved(base);
             }
         }
-        return ThisLambdaCtx::Receiver;
+        let base = recv_name.ident_prefix();
+        if base.starts_with_uppercase() {
+            return ThisLambdaCtx::Resolved(base);
+        }
     }
+    ThisLambdaCtx::Receiver
+}
 
-    // ── Case C: bare builder call `Foo { this }` ────────────────────────────
-    // A plain (non-`receiver.method`, non-`with`) call whose last parameter is a
-    // receiver-lambda — Compose builders (`Column`, `LazyColumn`, `Box`, …) and any
-    // DSL of the form `fun Foo(content: Receiver.() -> Unit)`. Reuses the same
-    // signature-derived receiver resolution as Case A (works for JAR functions, whose
-    // `detail` carries the rendered `Receiver.() -> R` last param).
+/// Case C: bare builder call `Foo { this }` — a plain (non-`receiver.method`,
+/// non-`with`) call whose last parameter is a receiver-lambda. Covers Compose
+/// builders (`Column`, `LazyColumn`, `Box`, …) and any DSL of the form
+/// `fun Foo(content: Receiver.() -> Unit)`. Reuses the same signature-derived
+/// receiver resolution as Case A (works for JAR functions, whose `detail`
+/// carries the rendered `Receiver.() -> R` last param).
+fn classify_bare_builder_call(
+    trailing_fn: &str,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> ThisLambdaCtx {
     if !trailing_fn.is_empty() {
         if let Some(this_type) = fun_trailing_lambda_this_type(trailing_fn, deps, uri) {
             return ThisLambdaCtx::Resolved(this_type);
         }
     }
-
     ThisLambdaCtx::NotReceiver
 }
 
@@ -624,8 +650,8 @@ pub(super) fn cst_this_context(
                 ThisLambdaCtx::NotReceiver => {}
             }
         }
-        let Some(p) = cur.parent() else { break };
-        cur = p;
+        let Some(parent) = cur.parent() else { break };
+        cur = parent;
     }
     ThisContext::NotFound
 }

--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -30,24 +30,24 @@ pub(crate) fn is_declaration_site(node: Node<'_>) -> bool {
     let Some(parent) = node.parent() else {
         return false;
     };
-    let pk = parent.kind();
-    if pk == KIND_CLASS_DECL
-        || pk == KIND_OBJECT_DECL
-        || pk == KIND_COMPANION_OBJ
-        || pk == KIND_TYPE_ALIAS
+    let parent_kind = parent.kind();
+    if parent_kind == KIND_CLASS_DECL
+        || parent_kind == KIND_OBJECT_DECL
+        || parent_kind == KIND_COMPANION_OBJ
+        || parent_kind == KIND_TYPE_ALIAS
     {
         return node.kind() == KIND_TYPE_IDENT;
     }
-    if pk == KIND_FUN_DECL
-        || pk == KIND_PARAMETER
-        || pk == KIND_ENUM_ENTRY
-        || pk == KIND_VAR_DECL
-        || pk == KIND_CLASS_PARAM
-        || pk == KIND_CATCH_BLOCK
+    if parent_kind == KIND_FUN_DECL
+        || parent_kind == KIND_PARAMETER
+        || parent_kind == KIND_ENUM_ENTRY
+        || parent_kind == KIND_VAR_DECL
+        || parent_kind == KIND_CLASS_PARAM
+        || parent_kind == KIND_CATCH_BLOCK
     {
         return node.kind() == KIND_SIMPLE_IDENT;
     }
-    if pk == KIND_TYPE_PARAM {
+    if parent_kind == KIND_TYPE_PARAM {
         return node.kind() == KIND_SIMPLE_IDENT || node.kind() == KIND_TYPE_IDENT;
     }
     false
@@ -90,16 +90,36 @@ pub(crate) fn is_indexed_declaration_site(node: Node<'_>) -> bool {
 }
 
 pub(crate) fn navigation_receiver_node(node: Node<'_>) -> Option<Node<'_>> {
-    (0..node.child_count())
-        .filter_map(|i| node.child(i))
-        .find(|child| child.is_named() && child.kind() != crate::queries::KIND_NAV_SUFFIX)
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            if child.is_named() && child.kind() != crate::queries::KIND_NAV_SUFFIX {
+                return Some(child);
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    None
 }
 
 pub(crate) fn navigation_member_ident(node: Node<'_>) -> Option<Node<'_>> {
     let suffix = node.first_child_of_kind(crate::queries::KIND_NAV_SUFFIX)?;
-    (0..suffix.child_count())
-        .filter_map(|i| suffix.child(i))
-        .find(|child| child.kind() == KIND_SIMPLE_IDENT || child.kind() == KIND_TYPE_IDENT)
+    let mut cursor = suffix.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            if child.kind() == KIND_SIMPLE_IDENT || child.kind() == KIND_TYPE_IDENT {
+                return Some(child);
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    None
 }
 
 pub(crate) fn is_call_callee(node: Node<'_>) -> bool {
@@ -202,10 +222,12 @@ pub(crate) fn classify_symbol_at(
     // not directly nested one-per-dot — check both the node's parent (in case
     // the grammar ever emits a bare single-segment import directly under
     // `import_header`) and its grandparent through that `identifier` wrapper.
-    let is_import_segment = node.parent().is_some_and(|p| {
-        p.kind() == KIND_IMPORT_HEADER
-            || (p.kind() == KIND_IDENTIFIER
-                && p.parent().is_some_and(|gp| gp.kind() == KIND_IMPORT_HEADER))
+    let is_import_segment = node.parent().is_some_and(|parent| {
+        parent.kind() == KIND_IMPORT_HEADER
+            || (parent.kind() == KIND_IDENTIFIER
+                && parent
+                    .parent()
+                    .is_some_and(|grandparent| grandparent.kind() == KIND_IMPORT_HEADER))
     });
     if is_import_segment {
         return Some(SymbolAtCursor {
@@ -253,8 +275,9 @@ pub(crate) fn classify_symbol_at(
     // Bare reference (local var, top-level name, etc.) — no receiver, scope
     // resolution deferred (see Global Constraints). Callers fall through to
     // today's NameScan path for these.
-    let is_call = node.parent().is_some_and(|p| {
-        p.kind() == KIND_CALL_EXPR && p.child(0).map(|c| c.id()) == Some(node.id())
+    let is_call = node.parent().is_some_and(|parent| {
+        parent.kind() == KIND_CALL_EXPR
+            && parent.child(0).map(|child| child.id()) == Some(node.id())
     });
     Some(SymbolAtCursor {
         name,
@@ -275,7 +298,7 @@ pub(crate) enum NavigationSource<T> {
     NameScan(T),
 }
 
-/// Resolve `sym`'s identity to its definition site(s).
+/// Resolve `symbol`'s identity to its definition site(s).
 ///
 /// `CstResolved` when the CST gave enough information to trust the result
 /// (a declaration is trivially its own definition; a receiver-typed member
@@ -284,33 +307,34 @@ pub(crate) enum NavigationSource<T> {
 /// today's name-based `find_definition_qualified(name, None, uri)` (which
 /// can span multiple same-named workspace symbols).
 pub(crate) fn resolve_identity(
-    sym: &SymbolAtCursor,
+    symbol: &SymbolAtCursor,
     indexer: &Indexer,
     uri: &Url,
 ) -> NavigationSource<Definitions> {
-    match &sym.role {
+    match &symbol.role {
         SymbolRole::Declaration { indexed } => {
-            let locs = Definitions(indexer.find_definition_qualified(&sym.name, None, uri));
+            let locations = Definitions(indexer.find_definition_qualified(&symbol.name, None, uri));
             // Only declarations `KOTLIN_DEFINITIONS` actually indexes can be
             // trusted CST-resolved; an unindexed one (bare param, val/var-less
             // constructor param, type param) falls through to an unanchored
             // same-file scan or workspace-wide scan — label it NameScan (see
             // `is_indexed_declaration_site`).
             if *indexed {
-                NavigationSource::CstResolved(locs)
+                NavigationSource::CstResolved(locations)
             } else {
-                NavigationSource::NameScan(locs)
+                NavigationSource::NameScan(locations)
             }
         }
         SymbolRole::Reference {
             receiver_type: Some(receiver_type),
             ..
         } => {
-            let locs = indexer.find_definition_qualified(&sym.name, Some(receiver_type), uri);
-            if locs.is_empty() {
-                NavigationSource::NameScan(Definitions(locs))
+            let locations =
+                indexer.find_definition_qualified(&symbol.name, Some(receiver_type), uri);
+            if locations.is_empty() {
+                NavigationSource::NameScan(Definitions(locations))
             } else {
-                NavigationSource::CstResolved(Definitions(locs))
+                NavigationSource::CstResolved(Definitions(locations))
             }
         }
         SymbolRole::Reference {
@@ -318,7 +342,7 @@ pub(crate) fn resolve_identity(
             ..
         }
         | SymbolRole::ImportSegment => NavigationSource::NameScan(Definitions(
-            indexer.find_definition_qualified(&sym.name, None, uri),
+            indexer.find_definition_qualified(&symbol.name, None, uri),
         )),
     }
 }
@@ -503,10 +527,9 @@ fn declares_name_directly<'a>(scope: Node<'a>, name: &str, bytes: &[u8]) -> Opti
         if node.id() != scope.id() && scope_boundary_at(node).is_some() {
             continue;
         }
-        for i in 0..node.child_count() {
-            if let Some(child) = node.child(i) {
-                stack.push(child);
-            }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
         }
     }
     None
@@ -526,10 +549,8 @@ fn visit_statements_with_generations<'a>(
     bytes: &[u8],
     visit: &mut impl FnMut(Node<'a>, usize),
 ) {
-    for i in 0..statements.child_count() {
-        let Some(statement) = statements.child(i) else {
-            continue;
-        };
+    let mut cursor = statements.walk();
+    for statement in statements.children(&mut cursor) {
         match declares_name_directly(statement, name, bytes) {
             Some(declaration_node) => {
                 visit_unshadowed_name_matches(
@@ -586,10 +607,8 @@ fn visit_unshadowed_name_matches<'a>(
         visit_statements_with_generations(node, name, generation, already_shadowed, bytes, visit);
         return;
     }
-    for i in 0..node.child_count() {
-        let Some(child) = node.child(i) else {
-            continue;
-        };
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
         let child_shadowed = already_shadowed
             || (scope_boundary_at(child).is_some()
                 && declares_name_directly(child, name, bytes).is_some());

--- a/src/indexer/infer/expr_type.rs
+++ b/src/indexer/infer/expr_type.rs
@@ -196,9 +196,19 @@ fn infer_navigation_expr_type(
 /// Return the receiver sub-node of a `navigation_expression` (the part before
 /// the final `.`).  Equivalent to `semantic_tokens::helpers::navigation_receiver_node`.
 fn nav_receiver_node(node: Node<'_>) -> Option<Node<'_>> {
-    (0..node.child_count())
-        .filter_map(|i| node.child(i))
-        .find(|child| child.is_named() && child.kind() != KIND_NAV_SUFFIX)
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            if child.is_named() && child.kind() != KIND_NAV_SUFFIX {
+                return Some(child);
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    None
 }
 
 /// Return the member identifier inside the `navigation_suffix` of a
@@ -206,9 +216,19 @@ fn nav_receiver_node(node: Node<'_>) -> Option<Node<'_>> {
 /// `semantic_tokens::helpers::navigation_member_ident`.
 fn nav_member_ident(node: Node<'_>) -> Option<Node<'_>> {
     let suffix = node.first_child_of_kind(KIND_NAV_SUFFIX)?;
-    (0..suffix.child_count())
-        .filter_map(|i| suffix.child(i))
-        .find(|child| child.kind() == KIND_SIMPLE_IDENT || child.kind() == KIND_TYPE_IDENT)
+    let mut cursor = suffix.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            if child.kind() == KIND_SIMPLE_IDENT || child.kind() == KIND_TYPE_IDENT {
+                return Some(child);
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    None
 }
 
 /// Return `true` if `node` is the callee (first child) of a `call_expression`.
@@ -241,16 +261,11 @@ fn infer_if_expr_type<D: InferDeps>(
     deps: &D,
     uri: &Url,
 ) -> Option<String> {
-    let has_else = (0..node.child_count())
-        .filter_map(|i| node.child(i))
-        .any(|child| child.kind() == KIND_ELSE);
-    if !has_else {
-        return None;
-    }
+    node.first_child_of_kind(KIND_ELSE)?;
 
-    let mut bodies = (0..node.child_count())
-        .filter_map(|i| node.child(i))
-        .filter(|child| child.kind() == KIND_CONTROL_STRUCTURE_BODY);
+    let mut bodies = node
+        .children_of_kind(KIND_CONTROL_STRUCTURE_BODY)
+        .into_iter();
     let then_expr = bodies.next()?.child(0)?;
     let else_expr = bodies.next()?.child(0)?;
     let then_type = infer_expr_type(then_expr, bytes, deps, uri)?;

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -23,8 +23,12 @@
 //! - `it_this`     — resolving `it`/`this` element types inside Kotlin lambda bodies
 //! - `type_subst`  — generic type-parameter substitution
 //! - `chain`       — CST navigation-chain type resolution
+//! - `cst_cursor`  — shared tree-sitter cursor-walk helpers
+//! - `cst_symbol`  — CST identifier classification (declaration vs. reference, receiver type)
 //! - `cst_lambda`         — CST-backed ThisLambdaCtx + lambda context helpers
 //! - `lambda_resolution`  — `LambdaParamResolution` typed intermediate (Phase 2)
+//! - `expr_type`   — expression-node type inference (backs `CstQuery::expr_type`)
+//! - `speculative`  — marker-insertion speculative reparse for dot-completion receivers
 
 pub(super) mod args;
 pub(super) mod chain;

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -618,8 +618,8 @@ pub(crate) fn find_fun_signature_with_receiver(
     name: &str,
     receiver: Option<&str>,
 ) -> Option<String> {
-    if let Some(recv) = receiver {
-        let Some(receiver_type) = infer_receiver_type(idx, ReceiverKind::Variable(recv), uri)
+    if let Some(receiver) = receiver {
+        let Some(receiver_type) = infer_receiver_type(idx, ReceiverKind::Variable(receiver), uri)
         else {
             // Receiver present but type could not be resolved — avoid a global
             // name-only scan that may return a completely unrelated function.

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -619,12 +619,13 @@ pub(crate) fn find_fun_signature_with_receiver(
     receiver: Option<&str>,
 ) -> Option<String> {
     if let Some(recv) = receiver {
-        let Some(rt) = infer_receiver_type(idx, ReceiverKind::Variable(recv), uri) else {
+        let Some(receiver_type) = infer_receiver_type(idx, ReceiverKind::Variable(recv), uri)
+        else {
             // Receiver present but type could not be resolved — avoid a global
             // name-only scan that may return a completely unrelated function.
             return None;
         };
-        let locs = idx.resolve_symbol(&rt.outer, None, uri);
+        let locs = idx.resolve_symbol(&receiver_type.outer, None, uri);
         for loc in &locs {
             if let Some(data) = idx.files.get(loc.uri.as_str()) {
                 if let Some(sig) = collect_fun_params_text(name, loc.uri.as_str(), idx) {
@@ -634,7 +635,7 @@ pub(crate) fn find_fun_signature_with_receiver(
                 let type_end = data
                     .symbols
                     .iter()
-                    .find(|s| s.name == rt.outer)
+                    .find(|s| s.name == receiver_type.outer)
                     .map(|s| s.range.end.line)
                     .unwrap_or(u32::MAX);
                 for symbol_entry in data
@@ -669,7 +670,7 @@ pub(crate) fn find_method_params_in_class(
     method_name: &str,
 ) -> Option<String> {
     let (container, type_base) = match class_name.rsplit_once('.') {
-        Some((c, b)) => (Some(c), b),
+        Some((container, base)) => (Some(container), base),
         None => (None, class_name),
     };
     let locations = idx.definitions.get(type_base)?;
@@ -749,10 +750,10 @@ fn collect_params_from_file(
 ) -> Vec<(String, (u8, u8))> {
     // Look up data from source files first, then the compiled-JAR cache. Track which:
     // only compiled-JAR (sidecar) symbols lack default-value markers.
-    let (data, is_compiled_jar) = if let Some(d) = idx.files.get(file_uri) {
-        (d, false)
-    } else if let Some(d) = idx.jar_files.get(file_uri) {
-        (d, true)
+    let (data, is_compiled_jar) = if let Some(file_data) = idx.files.get(file_uri) {
+        (file_data, false)
+    } else if let Some(file_data) = idx.jar_files.get(file_uri) {
+        (file_data, true)
     } else {
         return vec![];
     };

--- a/src/indexer/infer/type_subst.rs
+++ b/src/indexer/infer/type_subst.rs
@@ -32,8 +32,8 @@ pub(super) fn build_type_arg_subst(
     };
     let type_args: Vec<String> = split_top_level_commas(inner)
         .into_iter()
-        .map(|s| s.trim().strip_nullable().to_owned())
-        .filter(|s| !s.is_empty())
+        .map(|raw_arg| raw_arg.trim().strip_nullable().to_owned())
+        .filter(|trimmed_arg| !trimmed_arg.is_empty())
         .collect();
     type_params.into_iter().zip(type_args).collect()
 }
@@ -49,22 +49,22 @@ pub(super) fn type_args_inner(type_name: &str) -> Option<&str> {
 }
 
 /// Split a generic parameter list at top-level commas, respecting nested `<>`.
-pub(super) fn split_top_level_commas(s: &str) -> Vec<&str> {
+pub(super) fn split_top_level_commas(param_list: &str) -> Vec<&str> {
     let mut result = Vec::new();
     let mut depth = 0i32;
     let mut start = 0;
-    for (i, c) in s.char_indices() {
-        match c {
+    for (i, char) in param_list.char_indices() {
+        match char {
             '<' => depth += 1,
             '>' => depth -= 1,
             ',' if depth == 0 => {
-                result.push(&s[start..i]);
+                result.push(&param_list[start..i]);
                 start = i + 1;
             }
             _ => {}
         }
     }
-    result.push(&s[start..]);
+    result.push(&param_list[start..]);
     result
 }
 
@@ -80,8 +80,8 @@ pub(super) fn build_fn_subst(
     params
         .iter()
         .zip(args.iter())
-        .filter(|(_, a)| a.as_str() != "_")
-        .map(|(p, a)| (p.clone(), a.clone()))
+        .filter(|(_, argument)| argument.as_str() != "_")
+        .map(|(param, argument)| (param.clone(), argument.clone()))
         .collect()
 }
 
@@ -134,7 +134,7 @@ fn match_type_args_recursive(
         return;
     }
     // If the declared type is one of the function's type params, map it directly.
-    if params.iter().any(|p| p == decl_base) {
+    if params.iter().any(|param| param == decl_base) {
         map.insert(decl_base.to_owned(), conc_base.to_owned());
         return;
     }
@@ -143,21 +143,21 @@ fn match_type_args_recursive(
     {
         let d_args = split_top_level_commas(d_inner);
         let c_args = split_top_level_commas(c_inner);
-        for (d, c) in d_args.iter().zip(c_args.iter()) {
-            match_type_args_recursive(d, c, params, map);
+        for (declared_arg, concrete_arg) in d_args.iter().zip(c_args.iter()) {
+            match_type_args_recursive(declared_arg, concrete_arg, params, map);
         }
     }
 }
 
 /// Check whether `name` is a declared type parameter of the given function.
 pub(super) fn is_declared_type_param(name: &str, fun_type_params: &[String]) -> bool {
-    fun_type_params.iter().any(|p| p == name)
+    fun_type_params.iter().any(|param| param == name)
 }
 
 /// Returns `true` if `name` looks like a generic type parameter: a short
 /// all-uppercase identifier like `T`, `R`, `IN`, `OUT`, `KEY`, `VAL`.
 pub(crate) fn is_generic_param(name: &str) -> bool {
-    !name.is_empty() && name.len() <= 3 && name.chars().all(|c| c.is_uppercase())
+    !name.is_empty() && name.len() <= 3 && name.chars().all(|char| char.is_uppercase())
 }
 
 /// Extract the first type argument from `type_name`, preserving the full generic
@@ -229,7 +229,7 @@ pub(super) fn resolve_chain_receiver_type(
     }
 
     // Strip trailing lambda `{ ... }` and call args `(...)`.
-    let stripped = strip_trailing_lambda_and_args(receiver_expr);
+    let stripped = strip_trailing_args(strip_trailing_lambda(receiver_expr));
     if stripped.is_empty() {
         return None;
     }
@@ -268,27 +268,30 @@ pub(super) fn resolve_chain_receiver_type(
     None
 }
 
-/// Strip trailing lambda `{ ... }` and call args `(...)` from a receiver expression.
+/// Strip a trailing lambda `{ ... }` from a receiver expression, if present.
 ///
-/// Handles: `expr(args) { lambda }` → `expr`
-// TODO: split into strip_trailing_lambda() + strip_trailing_args() per design-rules
-fn strip_trailing_lambda_and_args(s: &str) -> &str {
-    let mut result = s.trim_end();
-    // Strip trailing `{ ... }` (trailing lambda)
+/// Handles: `expr { lambda }` → `expr`
+fn strip_trailing_lambda(string: &str) -> &str {
+    let result = string.trim_end();
     if result.ends_with('}') {
         if let Some(open) = rfind_balanced(result, '{', '}') {
-            result = result[..open].trim_end();
+            return result[..open].trim_end();
         }
     }
-    // Strip trailing `(...)` (call args)
-    result = strip_trailing_call_args(result);
-    result.trim_end()
+    result
+}
+
+/// Strip trailing call args `(...)` from a receiver expression, if present.
+///
+/// Handles: `expr(args)` → `expr`
+fn strip_trailing_args(string: &str) -> &str {
+    strip_trailing_call_args(string).trim_end()
 }
 
 /// Find the matching opening delimiter scanning right-to-left.
-fn rfind_balanced(s: &str, open: char, close: char) -> Option<usize> {
+fn rfind_balanced(string: &str, open: char, close: char) -> Option<usize> {
     let mut depth = 0i32;
-    for (i, ch) in s.char_indices().rev() {
+    for (i, ch) in string.char_indices().rev() {
         if ch == close {
             depth += 1;
         } else if ch == open {
@@ -305,10 +308,10 @@ fn rfind_balanced(s: &str, open: char, close: char) -> Option<usize> {
 
 /// Capitalize the first character of a string (Kotlin naming convention:
 /// `buildingSavingsReducer` → `BuildingSavingsReducer`).
-pub(super) fn capitalize_first_char(s: &str) -> String {
-    let mut chars = s.chars();
+pub(super) fn capitalize_first_char(string: &str) -> String {
+    let mut chars = string.chars();
     match chars.next() {
-        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+        Some(char) => char.to_uppercase().collect::<String>() + chars.as_str(),
         None => String::new(),
     }
 }
@@ -316,10 +319,10 @@ pub(super) fn capitalize_first_char(s: &str) -> String {
 /// Find the position of the last `.` that is at parenthesis/bracket depth 0
 /// (scanning left-to-right so that `fn(Enum.VALUE,` returns None — the dot
 /// is at depth 1 inside the argument list).
-pub(crate) fn find_last_dot_at_depth_zero(s: &str) -> Option<usize> {
+pub(crate) fn find_last_dot_at_depth_zero(string: &str) -> Option<usize> {
     let mut depth: i32 = 0;
     let mut last_dot: Option<usize> = None;
-    for (i, ch) in s.char_indices() {
+    for (i, ch) in string.char_indices() {
         match ch {
             '(' | '[' => depth += 1,
             ')' | ']' => depth -= 1,


### PR DESCRIPTION
## Summary
A prior 2-agent audit validated `src/indexer/infer/mod.rs` and its submodules against:
1. the CST-resolution-unification design doc (`docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md`)
2. `AGENTS.md`'s Code Quality / Rust-Specific rules

This PR is the min/max mitigation pass on the findings: all low/medium-effort fixes, done as 6 independent worktree-isolated changes then integrated. Two structural findings (catalogue capabilities fragmented across `indexer.rs`/`infer/mod.rs`; `Resolution::Ambiguous` never constructed) are deliberately **out of scope** — they need their own design doc, not a mechanical fix.

- `mod.rs`: fixed stale submodule table in the catalogue doc comment (4 missing entries)
- `type_subst.rs`: renamed banned single-letter identifiers to full words; split `strip_trailing_lambda_and_args` into `strip_trailing_lambda` + `strip_trailing_args` (per its own long-standing TODO)
- `cst_symbol.rs` / `args.rs`: renamed banned abbreviations (`sym`, `locs`, `pk`, `p`, `gp`, `c`); replaced index-arithmetic child loops with `TreeCursor`/`NodeExt`
- `expr_type.rs`: replaced 4 index-arithmetic child loops with cursor API / existing `NodeExt` helpers
- `sig.rs`: renamed banned abbreviations (`rt`, destructured `c`/`b`, `d`) to full words
- `cst_lambda.rs`: renamed banned `p`; extracted `classify_this_lambda_context`'s 3 comment-delimited cases into named helper functions (`classify_dot_call_receiver`, `classify_with_call_receiver`, `classify_bare_builder_call`)
- `chain.rs`: replaced a 28-line prose justification in `resolve_callee_chain` with a real type, `FinalCalleeSegment::{CallTarget, WalkFull}`, so the compiler enforces the distinction instead of a comment

All pure refactors — no intended behavior change.

## Test plan
- [x] `cargo test` (workspace): 1636 passed, 0 failed, 3 ignored (plus all other test binaries green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] Each of the 6 sub-changes verified independently (tests+clippy) before integration; merged with zero conflicts (disjoint files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)