### PR TITLE
fix(infer): strip catalogue scaffolding that #245/#246 left unconsumed

### DIFF
--- a/src/features/call_arg_diagnostics.rs
+++ b/src/features/call_arg_diagnostics.rs
@@ -168,7 +168,7 @@ fn check_call_args(
             params_text,
             param_counts,
         }) => (params_text, param_counts),
-        Resolution::Ambiguous(_) | Resolution::Unresolved => return None,
+        Resolution::Ambiguous | Resolution::Unresolved => return None,
     };
 
     // A `Resolved` result only reflects what's resolvable from the workspace and

--- a/src/features/completion_context.rs
+++ b/src/features/completion_context.rs
@@ -4,8 +4,7 @@ use crate::features::completion::param_names_from_sig;
 use crate::features::traits::{LiveTreeAccess, SignatureIndex};
 use crate::indexer::{
     cursor_node_at, find_this_context, lambda_doc_at, receiver_node_for_marker, speculative_doc,
-    split_params_at_depth_zero, CstQuery, Indexer, LambdaScopeInfo, Resolution, ResolveIo,
-    ThisContext,
+    split_params_at_depth_zero, CstQuery, Indexer, LambdaScopeInfo, Resolution, ThisContext,
 };
 use crate::queries::{KIND_CALL_EXPR, KIND_SIMPLE_IDENT, KIND_SUPER_EXPR, KIND_THIS_EXPR};
 use crate::resolver::complete::DotReceiver;
@@ -136,7 +135,7 @@ pub(crate) fn derive_dot_receiver(
     let resolved = if node.kind() == KIND_SIMPLE_IDENT {
         None
     } else {
-        match CstQuery::new(node, &doc, index, uri, ResolveIo::NoRg).expr_type() {
+        match CstQuery::new(node, &doc, index, uri).expr_type() {
             Resolution::Resolved(resolved_type) => Some(resolved_type.as_type_str().to_owned()),
             _ => None,
         }
@@ -282,7 +281,7 @@ fn collect_lambda_scopes(index: &Indexer, uri: &Url, position: Position) -> Vec<
     let Some(node) = cursor_node_at(doc, cursor) else {
         return Vec::new();
     };
-    CstQuery::new(node, doc, index, uri, ResolveIo::NoRg)
+    CstQuery::new(node, doc, index, uri)
         .lambda_scope()
         .into_iter()
         .map(LambdaScope::from)

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -58,7 +58,7 @@ pub(crate) use self::infer::{
     },
     type_subst::find_last_dot_at_depth_zero,
 };
-pub(crate) use self::infer::{CstQuery, Resolution, ResolveIo};
+pub(crate) use self::infer::{CstQuery, Resolution};
 
 mod cache;
 pub(crate) use self::cache::workspace_cache_path;

--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -9,7 +9,7 @@
 
 use tree_sitter::Node;
 
-use crate::indexer::{CstQuery, Indexer, NodeExt, Resolution, ResolveIo};
+use crate::indexer::{CstQuery, Indexer, NodeExt, Resolution};
 use crate::queries::{
     KIND_BINDING_PATTERN_KIND, KIND_CALL_EXPR, KIND_CATCH_BLOCK, KIND_CLASS_DECL, KIND_CLASS_PARAM,
     KIND_COMPANION_OBJ, KIND_CONTROL_STRUCTURE_BODY, KIND_ENUM_ENTRY, KIND_FINALLY_BLOCK,
@@ -255,7 +255,7 @@ pub(crate) fn classify_symbol_at(
             // doesn't silently masquerade as a real receiver type (house
             // decoy: `untypeable_receiver_yields_no_receiver_type`).
             let receiver_type = navigation_receiver_node(nav).and_then(|receiver| {
-                match CstQuery::new(receiver, doc, indexer, uri, ResolveIo::IndexOnly).expr_type() {
+                match CstQuery::new(receiver, doc, indexer, uri).expr_type() {
                     Resolution::Resolved(t) if indexer.has_type_definition(t.as_type_str()) => {
                         Some(t.as_type_str().to_owned())
                     }

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -9,9 +9,8 @@
 //!
 //! | Type              | Role                                                         |
 //! |-------------------|--------------------------------------------------------------|
-//! | `CstQuery`        | Bound CST query: node + doc + deps + URI + IO policy        |
-//! | `Fqn`             | `Ambiguous` candidate identifier (newtype over `String`, defining-URI placeholder today) |
-//! | `Resolution<T>`   | Three-way outcome: `Resolved(T)` / `Ambiguous(Vec<Fqn>)` / `Unresolved` |
+//! | `CstQuery`        | Bound CST query: node + doc + deps + URI                     |
+//! | `Resolution<T>`   | Three-way outcome: `Resolved(T)` / `Ambiguous` / `Unresolved` |
 //! | `ResolvedType`    | A resolved expression type with its nullable flag            |
 //!
 //! ## Known gaps
@@ -72,10 +71,6 @@ pub(super) mod type_subst;
 #[path = "mod_tests.rs"]
 mod tests;
 
-// ─── re-exports from resolver (IO policy) ─────────────────────────────────────
-
-pub(crate) use crate::resolver::resolve::ResolveIo;
-
 // ─── catalogue types ──────────────────────────────────────────────────────────
 
 use tower_lsp::lsp_types::Url;
@@ -86,27 +81,13 @@ use crate::StrExt as _;
 
 use self::deps::InferDeps;
 
-/// Identifies one candidate in a `Resolution::Ambiguous` result. Named for its
-/// intended end state (an importable fully-qualified name), but today's only
-/// producer (`sig.rs`'s `build_result`) populates it with the candidate's
-/// defining-file URI plus its arity envelope (`"<uri>#<required>/<total>"`) as
-/// a placeholder identifier — not yet a real FQN-shaped value. The arity
-/// suffix keeps candidates unique when two overloads share a defining file
-/// (same URI, different arity would otherwise collide). Field constructed by
-/// `Ambiguous` candidates; not yet read by any consumer.
-#[derive(Debug, Clone)]
-pub(crate) struct Fqn(#[allow(dead_code)] pub(crate) String);
-
 /// Outcome of resolving something to `T`. Reused across the catalogue so an
 /// agent learns the three outcomes once and reads them off every signature.
 #[derive(Debug, Clone)]
 pub(crate) enum Resolution<T> {
     Resolved(T),
-    /// Multiple candidates — callers may surface all or pick one heuristically.
-    /// The `Vec<Fqn>` payload is constructed (`sig.rs::build_result`) but every
-    /// current matcher (`resolved`, `resolved_ref`, `call_arg_diagnostics.rs`)
-    /// discards it via `_` — no consumer inspects candidates yet.
-    Ambiguous(#[allow(dead_code)] Vec<Fqn>),
+    /// Multiple candidates — the caller should skip rather than guess.
+    Ambiguous,
     Unresolved,
 }
 
@@ -116,16 +97,7 @@ impl<T> Resolution<T> {
     pub(crate) fn resolved(self) -> Option<T> {
         match self {
             Resolution::Resolved(value) => Some(value),
-            Resolution::Ambiguous(_) | Resolution::Unresolved => None,
-        }
-    }
-
-    /// `Resolved(t) -> Some(&t)`, else `None`.
-    #[allow(dead_code)] // wiring seam; used by later catalogue methods
-    pub(crate) fn resolved_ref(&self) -> Option<&T> {
-        match self {
-            Resolution::Resolved(value) => Some(value),
-            Resolution::Ambiguous(_) | Resolution::Unresolved => None,
+            Resolution::Ambiguous | Resolution::Unresolved => None,
         }
     }
 }
@@ -153,7 +125,7 @@ impl ResolvedType {
         &self.type_name
     }
 
-    #[allow(dead_code)] // not yet consumed; available for later catalogue methods
+    #[allow(dead_code)] // read only by tests pinning `from_inferred`'s nullable computation
     pub(crate) fn is_nullable(&self) -> bool {
         self.nullable
     }
@@ -162,7 +134,7 @@ impl ResolvedType {
 // ─── CstQuery — the unified CST resolution context ───────────────────────────
 
 /// A bound CST query: a single expression node together with its document,
-/// dependency seam, URI, and IO policy.
+/// dependency seam, and URI.
 ///
 /// Constructing a `CstQuery` is cheap (no allocation); the per-request cost is
 /// in the methods that call through to the inference engine.
@@ -177,35 +149,18 @@ pub(crate) struct CstQuery<'a, D: InferDeps> {
     doc: &'a LiveDoc,
     deps: &'a D,
     uri: &'a Url,
-    /// IO policy carried for later catalogue methods that branch on it.
-    #[allow(dead_code)]
-    io: ResolveIo,
 }
 
 impl<'a, D: InferDeps> CstQuery<'a, D> {
     /// Construct a query for `node` within `doc`, using `deps` for index
     /// lookups and `uri` to identify the file.
-    pub(crate) fn new(
-        node: Node<'a>,
-        doc: &'a LiveDoc,
-        deps: &'a D,
-        uri: &'a Url,
-        io: ResolveIo,
-    ) -> Self {
+    pub(crate) fn new(node: Node<'a>, doc: &'a LiveDoc, deps: &'a D, uri: &'a Url) -> Self {
         Self {
             node,
             doc,
             deps,
             uri,
-            io,
         }
-    }
-
-    /// Return a new query pointing at `node` but sharing all other context.
-    /// Used by walk steps that move to a child or sibling node.
-    #[allow(dead_code)] // wiring seam for later walk tasks
-    fn at(&self, node: Node<'a>) -> Self {
-        Self { node, ..*self }
     }
 
     /// Build the completion scope for every lambda enclosing the bound node.

--- a/src/indexer/infer/mod_tests.rs
+++ b/src/indexer/infer/mod_tests.rs
@@ -1,6 +1,6 @@
 use tower_lsp::lsp_types::Url;
 
-use crate::indexer::infer::{CstQuery, ResolveIo};
+use crate::indexer::infer::CstQuery;
 use crate::indexer::Indexer;
 use crate::queries::KIND_FUN_BODY;
 
@@ -34,15 +34,9 @@ fn cst_query_expr_type_resolves_int_literal() {
     let uri = test_url("/CstQuery.kt");
     indexer.index_content(&uri, source);
 
-    let resolved = CstQuery::new(
-        int_literal_node,
-        &live_doc,
-        &indexer,
-        &uri,
-        ResolveIo::IndexOnly,
-    )
-    .expr_type()
-    .resolved();
+    let resolved = CstQuery::new(int_literal_node, &live_doc, &indexer, &uri)
+        .expr_type()
+        .resolved();
     assert_eq!(
         resolved.map(|t| t.as_type_str().to_owned()).as_deref(),
         Some("Int")
@@ -59,15 +53,9 @@ fn cst_query_expr_type_unresolved_for_unknown_nav() {
     let uri = test_url("/B.kt");
     indexer.index_content(&uri, source);
 
-    let resolved = CstQuery::new(
-        nav_expr_node,
-        &live_doc,
-        &indexer,
-        &uri,
-        ResolveIo::IndexOnly,
-    )
-    .expr_type()
-    .resolved();
+    let resolved = CstQuery::new(nav_expr_node, &live_doc, &indexer, &uri)
+        .expr_type()
+        .resolved();
     assert!(
         resolved.is_none(),
         "unresolvable nav expr should yield Unresolved"
@@ -84,8 +72,7 @@ fn resolved_type_nullable_flag() {
     let uri = test_url("/C.kt");
     indexer.index_content(&uri, source);
 
-    let resolution =
-        CstQuery::new(null_node, &live_doc, &indexer, &uri, ResolveIo::IndexOnly).expr_type();
+    let resolution = CstQuery::new(null_node, &live_doc, &indexer, &uri).expr_type();
     let resolved = resolution
         .resolved()
         .expect("null should resolve to Nothing?");
@@ -103,7 +90,7 @@ fn resolved_type_non_nullable() {
     let uri = test_url("/D.kt");
     indexer.index_content(&uri, source);
 
-    let resolved = CstQuery::new(int_node, &live_doc, &indexer, &uri, ResolveIo::IndexOnly)
+    let resolved = CstQuery::new(int_node, &live_doc, &indexer, &uri)
         .expr_type()
         .resolved()
         .expect("Int should resolve");
@@ -265,7 +252,7 @@ fn scope_fn_callee_nav_resolves_via_the_segment_walk() {
         )
         .expect("node covering the let call");
     assert_eq!(call.kind(), "call_expression", "got {}", call.kind());
-    let resolved = CstQuery::new(call, &live_doc, &indexer, &uri, ResolveIo::NoRg)
+    let resolved = CstQuery::new(call, &live_doc, &indexer, &uri)
         .expr_type()
         .resolved();
     assert_eq!(

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -8,7 +8,7 @@
 
 use tower_lsp::lsp_types::{SymbolKind, Url};
 
-use super::{Fqn, Resolution};
+use super::Resolution;
 use crate::indexer::Indexer;
 use crate::resolver::{infer_receiver_type, ReceiverKind};
 use crate::types::{SourceSet, SymbolEntry};
@@ -741,7 +741,7 @@ fn collect_params_from_file(
     caller_uri: &str,
     scope: ResolutionScope,
     receiver_base: Option<&str>,
-) -> Vec<(String, (u8, u8), String /* defining uri */)> {
+) -> Vec<(String, (u8, u8))> {
     // Look up data from source files first, then the compiled-JAR cache. Track which:
     // only compiled-JAR (sidecar) symbols lack default-value markers.
     let (data, is_compiled_jar) = if let Some(file_data) = idx.files.get(file_uri) {
@@ -819,7 +819,7 @@ fn collect_params_from_file(
         .iter()
         .filter(name_matches)
         .filter(receiver_matches)
-        .flat_map(|s| -> Vec<(String, (u8, u8), String)> {
+        .flat_map(|s| -> Vec<(String, (u8, u8))> {
             // Swift structs/classes never carry constructor params on their own
             // CST node (no Kotlin-style inline primary constructor) — the real
             // signature lives on a nested `init` (explicit or synthesized at
@@ -835,7 +835,7 @@ fn collect_params_from_file(
                         c.kind == SymbolKind::CONSTRUCTOR
                             && c.container.as_deref() == Some(s.name.as_str())
                     })
-                    .map(|c| (c.params.clone(), c.param_counts, file_uri.to_string()))
+                    .map(|c| (c.params.clone(), c.param_counts))
                     .collect();
             }
             let params_text = match extract_params_or_fallback(s, &data.lines) {
@@ -847,7 +847,7 @@ fn collect_params_from_file(
             } else {
                 s.param_counts
             };
-            vec![(params_text, counts, file_uri.to_string())]
+            vec![(params_text, counts)]
         })
         .collect()
 }
@@ -923,12 +923,11 @@ fn resolve_qualified(call: &CallSite<'_>, qualifier: &str, idx: &Indexer) -> Res
     crate::indexer::jar::ensure_jar_definitions_for(idx, call.name, &mut cache_backed_only);
 
     if total_definition_count(call.name, idx) > crate::indexer::MAX_BY_NAME_DEFS {
-        // known-ambiguous (ubiquitous name), candidates not enumerated for
-        // performance — see `total_definition_count`.
-        return Resolution::Ambiguous(vec![]);
+        // known-ambiguous (ubiquitous name) — see `total_definition_count`.
+        return Resolution::Ambiguous;
     }
 
-    let mut found: Vec<(String, (u8, u8), String)> = Vec::new();
+    let mut found: Vec<(String, (u8, u8))> = Vec::new();
 
     // Phase 1: definitions + jar_definitions — source and JAR symbols.
     {
@@ -1016,9 +1015,8 @@ fn resolve_unqualified(call: &CallSite<'_>, idx: &Indexer) -> Resolution<Signatu
     // hot path, and the wide arity envelope would resolve to `Ambiguous` regardless —
     // so bail without scanning. (Same-file calls above already resolved exactly.)
     if total_definition_count(call.name, idx) > crate::indexer::MAX_BY_NAME_DEFS {
-        // known-ambiguous (ubiquitous name), candidates not enumerated for
-        // performance — see `total_definition_count`.
-        return Resolution::Ambiguous(vec![]);
+        // known-ambiguous (ubiquitous name) — see `total_definition_count`.
+        return Resolution::Ambiguous;
     }
 
     let caller_source_set = idx
@@ -1028,7 +1026,7 @@ fn resolve_unqualified(call: &CallSite<'_>, idx: &Indexer) -> Resolution<Signatu
         .unwrap_or_default();
 
     // Cross-file: definitions + jar_definitions with import + nested-class filtering.
-    let mut all: Vec<(String, (u8, u8), String)> = Vec::new();
+    let mut all: Vec<(String, (u8, u8))> = Vec::new();
     let mut locations: Vec<tower_lsp::lsp_types::Location> = Vec::new();
     if let Some(locs) = idx.definitions.get(call.name) {
         // Reconstitute interned `SymbolLoc`s at this boundary.
@@ -1063,36 +1061,27 @@ fn resolve_unqualified(call: &CallSite<'_>, idx: &Indexer) -> Resolution<Signatu
     build_result(all)
 }
 
-/// Build a `Resolution<Signature>` from a list of `(params_text, param_counts,
-/// defining_uri)` triples.
+/// Build a `Resolution<Signature>` from a list of `(params_text, param_counts)` pairs.
 ///
 /// Deduplicates by arity envelope. If there are multiple distinct envelopes,
 /// the function is considered overloaded (`Ambiguous`) and the caller should
 /// skip the diagnostic.
-fn build_result(entries: Vec<(String, (u8, u8), String)>) -> Resolution<Signature> {
+fn build_result(entries: Vec<(String, (u8, u8))>) -> Resolution<Signature> {
     if entries.is_empty() {
         return Resolution::Unresolved;
     }
     // Deduplicate by arity envelope.
     let mut seen: std::collections::HashSet<(u8, u8)> = std::collections::HashSet::new();
-    let mut deduped: Vec<(String, (u8, u8), String)> = Vec::new();
-    for (text, counts, defining_uri) in entries {
+    let mut deduped: Vec<(String, (u8, u8))> = Vec::new();
+    for (text, counts) in entries {
         if seen.insert(counts) {
-            deduped.push((text, counts, defining_uri));
+            deduped.push((text, counts));
         }
     }
     if deduped.len() > 1 {
-        // Arity suffix keeps candidates unique when two overloads share a
-        // defining file — the URI alone collides for same-file overloads.
-        let candidates = deduped
-            .into_iter()
-            .map(|(_, (required, total), defining_uri)| {
-                Fqn(format!("{defining_uri}#{required}/{total}"))
-            })
-            .collect();
-        return Resolution::Ambiguous(candidates);
+        return Resolution::Ambiguous;
     }
-    let (params_text, (required, total), _defining_uri) = deduped.into_iter().next().unwrap();
+    let (params_text, (required, total)) = deduped.into_iter().next().unwrap();
     Resolution::Resolved(Signature {
         params_text,
         param_counts: (required as usize, total as usize),

--- a/src/indexer/infer/sig_tests.rs
+++ b/src/indexer/infer/sig_tests.rs
@@ -409,10 +409,7 @@ fn resolve_unqualified_bails_on_ubiquitous_name() {
     };
 
     assert!(
-        matches!(
-            resolve_call_signature(&call, &idx),
-            Resolution::Ambiguous(_)
-        ),
+        matches!(resolve_call_signature(&call, &idx), Resolution::Ambiguous),
         "a name with > MAX_BY_NAME_DEFS definitions must bail to Ambiguous, not scan them all"
     );
 }
@@ -514,7 +511,7 @@ fn resolve_qualified_jar_extension_overloads_with_source_member() {
 
     // Both 0-arg member + 1-arg extension → Ambiguous.
     match resolve_call_signature(&call, &idx) {
-        Resolution::Ambiguous(_) => {}
+        Resolution::Ambiguous => {}
         other => panic!("expected Ambiguous (0-arg member + 1-arg extension), got {other:?}"),
     }
 }
@@ -634,10 +631,7 @@ fn resolve_qualified_bails_on_ubiquitous_name_even_with_receiver_extension() {
     // doing so would ignore the 0-arg member that members-win-over-extensions
     // semantics would actually call.
     assert!(
-        matches!(
-            resolve_call_signature(&call, &idx),
-            Resolution::Ambiguous(_)
-        ),
+        matches!(resolve_call_signature(&call, &idx), Resolution::Ambiguous),
         "capped qualified path must bail entirely, not return Resolved from Phase 2 alone"
     );
 }

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -5,8 +5,8 @@ use tower_lsp::lsp_types::{
 };
 use tree_sitter::Node;
 
+use crate::indexer::CstQuery;
 use crate::indexer::{find_it_element_type, find_this_element_type, Indexer, LiveDoc, NodeExt};
-use crate::indexer::{CstQuery, ResolveIo};
 use crate::queries::{
     KIND_KW_AS, KIND_KW_BY, KIND_KW_CONSTRUCTOR, KIND_KW_GET, KIND_KW_IN, KIND_KW_IS, KIND_KW_SET,
     KIND_KW_WHERE, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_NAV_EXPR, KIND_SIMPLE_IDENT,
@@ -159,7 +159,7 @@ fn resolve_member_access(
         let is_call = is_call_callee(node);
         let resolved_type = navigation_receiver_node(node)
             .and_then(|receiver| {
-                CstQuery::new(receiver, doc, indexer, uri, ResolveIo::IndexOnly)
+                CstQuery::new(receiver, doc, indexer, uri)
                     .expr_type()
                     .resolved()
             })


### PR DESCRIPTION
## Summary
- `mod.rs` had accumulated six "wiring seam for later" items behind `#[allow(dead_code)]`: `Fqn`, `Resolution::Ambiguous`'s `Vec<Fqn>` payload, `Resolution::resolved_ref`, `CstQuery::at`, and `CstQuery`'s `io` field. None had a real reader — audited each via grep across the whole tree, not assumed.
- `Resolution::Ambiguous(_)` was matched via `_` at its only call site (`call_arg_diagnostics.rs`) — the candidate list was write-only.
- `CstQuery.io: ResolveIo` was fed real, distinct values (`IndexOnly`/`NoRg`) by 4 genuine call sites, but no `InferDeps` trait method takes an `io` parameter at all — it could never have gated anything. The `Indexer` impl's methods reachable from `CstQuery` are hardcoded index-only already (see the comment at `indexer.rs:402-405`), so the field's own doc comment ("carried for later catalogue methods that branch on it") was never true.
- This is the same category of issue as the `receiver_type()`/`call_return_type()` revert earlier in this effort: infrastructure that reads as "designed for a future consumer" instead of correct in hindsight.

## Changes
- `Resolution::Ambiguous` → unit variant. `Fqn` deleted, along with the `defining_uri` threading through `sig.rs`'s `collect_params_from_file` → `resolve_qualified`/`resolve_unqualified` → `build_result` that existed solely to populate it.
- `CstQuery` drops the inert `io` field/param; its 4 real call sites no longer pass a policy that was silently discarded.
- `resolved_ref()` and `CstQuery::at()` deleted — zero callers anywhere, including tests.
- `ResolvedType::is_nullable()` kept as-is: unlike the above, its computation is real (`from_inferred` always computes `nullable`) and tests genuinely exercise it. Only the comment changed, from a "later" promise to an accurate description (test-only reader today).

## Test plan
- [x] `cargo build --bin kmp-lsp` — clean
- [x] `cargo clippy --bin kmp-lsp --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --bin kmp-lsp` — 1636 passed, 0 failed
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeEquPJ6s1zBjcNfKdH1sK