### PR TITLE
refactor(infer): CST catalogue lambda-triad wiring — merge duplicate walks, wire all_this_receivers

### DIFF
--- a/docs/superpowers/plans/2026-08-03-cst-catalogue-lambda-triad-wiring.md
+++ b/docs/superpowers/plans/2026-08-03-cst-catalogue-lambda-triad-wiring.md
@@ -1,0 +1,374 @@
+# CST Resolution Catalogue — Lambda `this`/receiver Walk Consolidation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close a real, verified duplicate-walk gap between `src/indexer/infer/cst_lambda.rs` and
+the `CstQuery` catalogue (`src/indexer/infer/mod.rs`), continuing design doc step 3 ("collapse the
+lambda triad") without repeating the two prior reverts' root cause (capability added with no real,
+same-task consumer).
+
+**Two prior reverts — do not repeat the pattern:**
+1. `CstQuery::receiver_type()`/`call_return_type()` were added with unit tests only; no real
+   consumer was ever wired in the same or a following task; both were deleted.
+2. `Resolution::Ambiguous(Vec<Fqn>)`/`Fqn`/`resolved_ref()`/`CstQuery::at()`/`CstQuery.io` were
+   shipped `#[allow(dead_code)]` behind "wiring seam for later" comments with zero real callers;
+   all were deleted (PR #247).
+
+Every task below adds at most one small piece of new surface, and in the **same task** deletes the
+old code path it replaces and re-verifies the real production call site(s) still pass. Where a real,
+already-existing production call site could not be found for a capability, it is not planned here —
+see "Explicitly descoped" at the end.
+
+**Architecture:** No new walk invented. `src/indexer/infer/cst_lambda.rs` currently contains **two
+separate, byte-for-byte-shaped ancestor-walk loops** that both do "walk `lambda_literal` ancestors
+from a node, classify each via `lambda_this_ctx`":
+
+- `all_this_receivers_at` (`cst_lambda.rs:510-534`) — collects every `Resolved` receiver.
+- `cst_this_context` (`cst_lambda.rs:638-657`) — stops at the first `Resolved`/`Receiver`.
+
+Verified via grep (excluding test files): each has **exactly one caller**, both in `it_this.rs`
+(`cst_lambda.rs:510` ← `it_this.rs:115`; `cst_lambda.rs:638` ← `it_this.rs:90`) — so merging them is
+a pure, low-risk, fully move-don't-rewrite consolidation with the existing test suite
+(`it_this_tests.rs`) as the regression net; nothing downstream changes.
+
+Once merged, `all_this_receivers_at` becomes the real target for a genuine new `CstQuery` method:
+`it_this::all_lambda_receivers_at` (the only production-facing name — real call site
+`src/features/missing_import_diagnostics.rs:244`, verified, unchanged by this plan) is the
+position→node bridge; today it calls `cst_lambda::all_this_receivers_at` directly. Task 2 adds
+`CstQuery::all_this_receivers()` and — in the same task — redirects that bridge onto it, deleting
+the direct call. This mirrors the exact pattern `completion_context.rs::collect_lambda_scopes`
+already uses for `CstQuery::lambda_scope()` (position→node bridge, then a `CstQuery` call).
+
+**Tech stack:** Rust, tree-sitter (`tree_sitter::Node`), binary-only crate (`kmp-lsp`,
+`cargo test --bin kmp-lsp`; `--lib` runs 0 tests).
+
+**Spec:** `docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md` (step 3,
+"collapse the lambda triad").
+
+---
+
+## Verification performed before writing this plan (so the next reader doesn't have to redo it)
+
+- Re-grepped every `it_this.rs` public function's callers repo-wide, filtered to real production
+  (non-test, non-doc-comment, non-`indexer.rs`-re-export) call sites:
+  - `find_it_element_type`: `features/completion.rs`, `semantic_tokens/resolve.rs`,
+    `indexer/scope.rs`, `indexer/infer/speculative.rs`.
+  - `find_this_context`: `indexer/scope.rs`, `features/completion_context.rs`.
+  - `find_this_element_type`: `semantic_tokens/resolve.rs`.
+  - `find_named_lambda_param_type`: `features/completion.rs`, `indexer/scope.rs`.
+  - `is_lambda_param`: `features/completion.rs`.
+  - `all_lambda_receivers_at`: `features/missing_import_diagnostics.rs:244` — **only one**.
+- `receiver.rs` (the design doc's "text-context heuristics" engine) **no longer exists** as a file —
+  already folded away; confirms the prior plan's finding that `it_this.rs`'s functions are
+  CST-driven internally, not text/line scans, is still accurate.
+- `cst_lambda::all_this_receivers_at` and `cst_lambda::cst_this_context` each have exactly one
+  caller, both in `it_this.rs`, confirmed by reading both functions' bodies directly — both are
+  independent copies of the same "walk ancestors, `if kind == KIND_LAMBDA_LIT { classify }`" loop,
+  differing only in whether they collect every match or return on the first one.
+- `CstQuery::new` is a 4-arg constructor (`node, doc, deps, uri`) — no `io` field (removed in
+  PR #247); `Indexer` implements `InferDeps`, so `CstQuery::new(node, doc, idx, uri)` type-checks
+  wherever `idx: &Indexer` is already in scope (as it is in every `it_this.rs` bridge function).
+  `mod.rs`'s "Known gaps" doc block is otherwise accurate as of this session.
+- `completion_context.rs::ScopeContext::build` (lines ~181-205) dual-purposes
+  `LambdaScopeInfo.it_type` for both the implicit `it` parameter and (via `resolve_labeled_receiver`)
+  `this@label` receiver resolution, and its last step
+  (`lambda_scopes.last_mut().it_type = index.infer_lambda_param_type_at(IT, uri, position)`)
+  overwrites whichever scope is last in the vec — confirmed by reading the file. This is the concrete
+  reason `LambdaScope` promotion (design doc's `this: ThisLambdaCtx` field) is descoped below rather
+  than attempted in this slice.
+
+---
+
+## Task 1: Merge the two duplicate `this`-classification ancestor walks in `cst_lambda.rs`
+
+**Rationale:** `all_this_receivers_at` and `cst_this_context` are two independently-written copies
+of "walk `lambda_literal` ancestors from a node, classify each via `lambda_this_ctx`" — exactly the
+kind of divergent-copy risk the design doc calls "the bug factory." Zero new public surface; the
+existing test suite (each function's sole caller's own tests) is the complete regression net.
+
+**Files:**
+- Modify: `src/indexer/infer/cst_lambda.rs`
+
+**Interfaces:**
+- New private helper, placed directly above `all_this_receivers_at`:
+  ```rust
+  /// Ancestor `lambda_literal` nodes from `start_node` outward (innermost first —
+  /// `start_node` itself first if it IS a `lambda_literal`), each classified via
+  /// [`lambda_this_ctx`]. The shared walk step behind [`all_this_receivers_at`]
+  /// (collects every `Resolved`) and [`cst_this_context`] (stops at the first
+  /// `Resolved`/`Receiver`) — previously two separate copies of the same
+  /// ancestor-walk-and-classify loop.
+  ///
+  /// Always walks the full ancestor chain before either caller inspects the
+  /// result, trading `cst_this_context`'s previous early-exit for one shared
+  /// shape. Lambda nesting in real Kotlin code is shallow (rarely >3-4 levels),
+  /// so the extra `lambda_this_ctx` calls on ancestors past the first match are
+  /// cheap.
+  fn this_lambda_ancestor_ctxs(
+      start_node: tree_sitter::Node<'_>,
+      doc: &crate::indexer::live_tree::LiveDoc,
+      deps: &impl InferDeps,
+      uri: &Url,
+  ) -> Vec<ThisLambdaCtx> {
+      let mut ctxs = Vec::new();
+      let mut cur = start_node;
+      loop {
+          if cur.kind() == KIND_LAMBDA_LIT {
+              ctxs.push(lambda_this_ctx(cur, doc, deps, uri));
+          }
+          let Some(parent) = cur.parent() else { break };
+          cur = parent;
+      }
+      ctxs
+  }
+  ```
+
+- [ ] **Step 1:** Add `this_lambda_ancestor_ctxs` above `all_this_receivers_at`
+  (`cst_lambda.rs:503`, right before its doc comment).
+
+- [ ] **Step 2:** Rewrite `all_this_receivers_at`'s body (keep its existing doc comment, it's still
+  accurate) to:
+  ```rust
+  pub(crate) fn all_this_receivers_at(
+      start_node: tree_sitter::Node<'_>,
+      doc: &crate::indexer::live_tree::LiveDoc,
+      deps: &impl InferDeps,
+      uri: &Url,
+  ) -> Vec<String> {
+      this_lambda_ancestor_ctxs(start_node, doc, deps, uri)
+          .into_iter()
+          .filter_map(|ctx| match ctx {
+              ThisLambdaCtx::Resolved(receiver_type) => Some(receiver_type),
+              ThisLambdaCtx::Receiver | ThisLambdaCtx::NotReceiver => None,
+          })
+          .collect()
+  }
+  ```
+
+- [ ] **Step 3:** Rewrite `cst_this_context`'s body (`cst_lambda.rs:638-657`, keep its doc comment)
+  to:
+  ```rust
+  pub(super) fn cst_this_context(
+      start_node: tree_sitter::Node<'_>,
+      doc: &crate::indexer::live_tree::LiveDoc,
+      idx: &impl InferDeps,
+      uri: &Url,
+  ) -> ThisContext {
+      for ctx in this_lambda_ancestor_ctxs(start_node, doc, idx, uri) {
+          match ctx {
+              ThisLambdaCtx::Resolved(t) => return ThisContext::Resolved(t),
+              ThisLambdaCtx::Receiver => return ThisContext::InsideReceiver,
+              ThisLambdaCtx::NotReceiver => {}
+          }
+      }
+      ThisContext::NotFound
+  }
+  ```
+
+- [ ] **Step 4: Run the full suite.**
+  Run: `cargo test --bin kmp-lsp`
+  Expected: all green, in particular every `it_this_tests.rs` test covering
+  `all_lambda_receivers_at` and `find_this_context`/`ThisContext`, plus the tests in
+  `indexer/scope_tests.rs` and `completion_context`'s own tests — the real production call sites
+  (`indexer/scope.rs`, `features/completion_context.rs`, `features/missing_import_diagnostics.rs`)
+  are exercised transitively through these.
+
+- [ ] **Step 5: Commit.**
+  ```bash
+  git add -A
+  git commit -m "refactor(infer): merge cst_lambda's two duplicate this-classification ancestor walks"
+  ```
+
+---
+
+## Task 2: Add `CstQuery::all_this_receivers()` and wire `it_this::all_lambda_receivers_at` onto it
+
+**Files:**
+- Modify: `src/indexer/infer/mod.rs` (add the method)
+- Modify: `src/indexer/infer/it_this.rs` (redirect the bridge function's implementation; adjust
+  imports)
+
+**Interfaces:**
+- New `CstQuery` method, added to the existing `impl<'a, D: InferDeps> CstQuery<'a, D>` block,
+  placed after `expr_type()`:
+  ```rust
+  /// Every enclosing lambda receiver type at the bound node, innermost-first —
+  /// the order Kotlin resolves an implicit-receiver call in (nearest wins). An
+  /// unresolvable or non-receiver lambda is skipped; the walk continues outward.
+  ///
+  /// Used to check a bare call/type reference against every candidate receiver
+  /// in scope (e.g. `item()` inside `with(x) { }` nested in a builder belongs to
+  /// the outer receiver even when `x`'s type can't be resolved).
+  pub(crate) fn all_this_receivers(&self) -> Vec<String> {
+      cst_lambda::all_this_receivers_at(self.node, self.doc, self.deps, self.uri)
+  }
+  ```
+
+- **Real production call site being swapped onto it:** `features/missing_import_diagnostics.rs:244`
+  (that file is unchanged by this task — it calls
+  `it_this::all_lambda_receivers_at(pos, indexer, uri)`, whose *implementation* changes below). This
+  is the identical pattern `completion_context.rs::collect_lambda_scopes` already uses for
+  `CstQuery::lambda_scope()`: a stable position-based bridge function whose body constructs a
+  `CstQuery` and calls the catalogue method.
+
+- [ ] **Step 1:** Add the method above to `mod.rs`. No new `use` needed — `cst_lambda` is already
+  `pub(super) mod cst_lambda;` and used by `lambda_scope()`.
+
+- [ ] **Step 2:** In `it_this.rs`, change the import block (currently around lines 26-29):
+  ```rust
+  use super::cst_lambda::{
+      cst_it_element_type, cst_named_lambda_param_type, cst_this_context, cursor_node_at,
+  };
+  use super::CstQuery;
+  ```
+  (dropped `all_this_receivers_at` from the `cst_lambda` import list — no longer called directly
+  from this file; added `use super::CstQuery;`.)
+
+- [ ] **Step 3:** Rewrite `all_lambda_receivers_at`'s body (`it_this.rs:107-116`, keep its doc
+  comment) to:
+  ```rust
+  pub(crate) fn all_lambda_receivers_at(pos: CursorPos, idx: &Indexer, uri: &Url) -> Vec<String> {
+      let Some(resolution) = lambda_doc_at(idx, uri, pos) else {
+          return vec![];
+      };
+      let doc = resolution.doc();
+      let Some(node) = cursor_node_at(doc, pos) else {
+          return vec![];
+      };
+      CstQuery::new(node, doc, idx, uri).all_this_receivers()
+  }
+  ```
+  This deletes the old direct call to `cst_lambda::all_this_receivers_at` — the old code path is
+  gone, not left as a parallel mechanism.
+
+- [ ] **Step 4: Run the full suite.**
+  Run: `cargo test --bin kmp-lsp`
+  Expected: all green — same regression net as Task 1's Step 4 (the `all_lambda_receivers_at` tests
+  in `it_this_tests.rs` exercise this exact code path unchanged from the outside).
+
+- [ ] **Step 5: Run clippy.**
+  Run: `cargo clippy --all-targets --all-features -- -D warnings`
+  Expected: clean — watch for an unused-import warning if Step 2's edit isn't exact.
+
+- [ ] **Step 6: Commit.**
+  ```bash
+  git add -A
+  git commit -m "feat(infer): add CstQuery::all_this_receivers, wire all_lambda_receivers_at onto it"
+  ```
+
+---
+
+## Task 3: Update `mod.rs`'s "Known gaps" doc comment
+
+**Files:**
+- Modify: `src/indexer/infer/mod.rs` (module doc comment, `it_this` bullet)
+
+**Rationale:** Design doc Goal 3 — the catalogue's own doc must stay honest about what's still
+outside it. After Task 2, `all_lambda_receivers_at` is no longer a capability that bypasses
+`CstQuery` internally (even though it's still a `CursorPos`-taking flat export by name) — the
+bullet must reflect that precisely, not overstate or understate what changed.
+
+- [ ] **Step 1:** Replace the current `it_this` bullet:
+  ```
+  //! - `it_this` (`find_it_element_type`, `find_this_context`, `find_this_element_type`,
+  //!   `find_named_lambda_param_type`, `is_lambda_param`, `all_lambda_receivers_at`) — CST-driven
+  //!   internally already (delegates to `cst_lambda`), but takes a `CursorPos` + does its own
+  //!   repair-gated node acquisition; folding into `CstQuery`'s bound-`Node` model needs a
+  //!   `CstQuery::at_position` bridge — deferred, see the design doc's lambda-triad/`LambdaScope`-
+  //!   promotion step.
+  ```
+  with:
+  ```
+  //! - `it_this` (`find_it_element_type`, `find_this_context`, `find_this_element_type`,
+  //!   `find_named_lambda_param_type`, `is_lambda_param`) — CST-driven internally already
+  //!   (delegates to `cst_lambda`), but takes a `CursorPos` + does its own repair-gated node
+  //!   acquisition; folding into `CstQuery`'s bound-`Node` model needs a `CstQuery::at_position`
+  //!   bridge — deferred, see the design doc's lambda-triad/`LambdaScope`-promotion step.
+  //!   `all_lambda_receivers_at` is the one exception: its position→node bridge now constructs a
+  //!   `CstQuery` and calls `all_this_receivers()` directly (2026-08-03) — still a flat
+  //!   `CursorPos`-taking export by name, but no longer bypasses the catalogue underneath.
+  ```
+
+- [ ] **Step 2: Run the full suite** (doc-only change).
+  Run: `cargo test --bin kmp-lsp`
+  Expected: all green.
+
+- [ ] **Step 3: Commit.**
+  ```bash
+  git add -A
+  git commit -m "docs(infer): mod.rs catalogue doc reflects all_lambda_receivers_at's CstQuery wiring"
+  ```
+
+---
+
+## Task 4: Final verification pass
+
+- [ ] **Step 1: Full suite.**
+  Run: `cargo test --bin kmp-lsp`
+  Expected: all green (binary-only crate — `cargo test --lib` runs 0 tests, not a signal).
+
+- [ ] **Step 2: Clippy, both gates.**
+  Run: `cargo clippy -- -D warnings` (AGENTS.md baseline)
+  Run: `cargo clippy --all-targets --all-features -- -D warnings` (catches issues only visible with
+  tests compiled)
+  Expected: both clean.
+
+- [ ] **Step 3: `cargo fmt --check`.**
+  Expected: no diff.
+
+- [ ] **Step 4: Confirm the consolidation left no orphaned duplicate.**
+  Run: `grep -n "fn all_this_receivers_at\|fn cst_this_context\|fn this_lambda_ancestor_ctxs" src/indexer/infer/cst_lambda.rs`
+  Expected: exactly one definition of each; `this_lambda_ancestor_ctxs` has exactly two callers
+  (`all_this_receivers_at`, `cst_this_context`) — confirm via
+  `grep -n "this_lambda_ancestor_ctxs" src/indexer/infer/cst_lambda.rs`.
+
+- [ ] **Step 5: Confirm no parallel mechanism was left for `all_lambda_receivers_at`.**
+  Run: `grep -rn "all_this_receivers_at" src --include="*.rs" | grep -v _tests.rs`
+  Expected: the `cst_lambda.rs` definition, `mod.rs`'s new `CstQuery::all_this_receivers` call, and
+  nothing calling `cst_lambda::all_this_receivers_at` directly from `it_this.rs` anymore.
+
+---
+
+## Explicitly descoped (and why — matching the reverted plan's own rigor bar)
+
+- **`CstQuery::at_position` bridge + folding `find_it_element_type`/`find_this_context`/
+  `find_named_lambda_param_type`/`is_lambda_param` fully into `CstQuery`'s bound-`Node` model.**
+  Real call sites exist (spread across `completion.rs`, `scope.rs`, `semantic_tokens/resolve.rs`,
+  `completion_context.rs`, `speculative.rs`) but they span 5 different feature files each with
+  slightly different repair-gating requirements (some need `lambda_doc_at`'s speculative
+  brace-repair, `missing_import_diagnostics.rs` — the one case handled here — does not, since it
+  runs on an already-fully-parsed doc). Wiring all of them in one slice is materially riskier than
+  Tasks 1-2 above; the natural next increment once someone is ready to design the bridge itself.
+- **`LambdaScope` promotion** (design doc: add `this: ThisLambdaCtx` field, upgrade `String`s to
+  `ReceiverType`). Investigated concretely this session and found a real landmine, not just
+  unscoped effort: `completion_context.rs::ScopeContext::build` reuses `LambdaScopeInfo.it_type` for
+  **two different concepts** — the implicit `it` parameter AND (via `resolve_labeled_receiver`) the
+  `this@label` receiver type — and its final line
+  (`lambda_scopes.last_mut().it_type = index.infer_lambda_param_type_at(IT, uri, position)`)
+  overwrites whichever scope happens to be last. Any change to `cst_lambda_scopes`'s current filter
+  (`lambda_scope_info` returns `None`, dropping the entry, when both `it_type` and `named_params` are
+  empty) changes which scope is "last" and therefore which scope receives that overwrite — a real,
+  silent behavior-changing risk that needs its own investigation + decoy-test-first task, not
+  something to bundle blind into this slice.
+- **`CstQuery::receiver_type()`/`call_return_type()`.** Unchanged from both prior revert
+  post-mortems: no real consumer was found this session either (the same three candidates —
+  `chain.rs`, `type_subst.rs`, `expr_type.rs::infer_navigation_expr_type` — are still not drop-in
+  fits, for the same reasons already documented). Only reconsider once a real consumer is named up
+  front, in the same task that adds the method.
+- **`chain.rs` collapse** (design doc step 4) — untouched, unstarted, out of this slice's blast
+  radius.
+- **`CstExpr` exhaustive dispatch, `RawTypeName`/`TypeName` split, construction-sealed
+  `ReceiverType`/`ResolvedType`** (design doc step 5, "Sweep") — untouched, confirmed still
+  unstarted by reading the actual code (`expr_type.rs::infer_expr_type` is still a plain `match`
+  with a `_ => None` arm; `ResolvedType` still wraps one bare `String`).
+- **CST-aware navigation** (design doc step 6) — depends on steps 3-5 landing first; untouched.
+
+## Testing & verification (gates, matching this repo's conventions)
+
+- `cargo test --bin kmp-lsp` after every task (binary-only crate; `--lib` is not a signal).
+- `cargo clippy --all-targets --all-features -- -D warnings` before each task's final commit.
+- No new `TestDeps` methods needed; no test files need new content — Tasks 1-2 are pure internal
+  refactors behind stable public signatures, so the existing `it_this_tests.rs` and
+  `missing_import_diagnostics.rs` test suites are the complete regression net.

--- a/src/features/call_arg_diagnostics.rs
+++ b/src/features/call_arg_diagnostics.rs
@@ -168,7 +168,7 @@ fn check_call_args(
             params_text,
             param_counts,
         }) => (params_text, param_counts),
-        Resolution::Ambiguous(_) | Resolution::Unresolved => return None,
+        Resolution::Ambiguous | Resolution::Unresolved => return None,
     };
 
     // A `Resolved` result only reflects what's resolvable from the workspace and

--- a/src/features/completion_context.rs
+++ b/src/features/completion_context.rs
@@ -4,8 +4,7 @@ use crate::features::completion::param_names_from_sig;
 use crate::features::traits::{LiveTreeAccess, SignatureIndex};
 use crate::indexer::{
     cursor_node_at, find_this_context, lambda_doc_at, receiver_node_for_marker, speculative_doc,
-    split_params_at_depth_zero, CstQuery, Indexer, LambdaScopeInfo, Resolution, ResolveIo,
-    ThisContext,
+    split_params_at_depth_zero, CstQuery, Indexer, LambdaScopeInfo, Resolution, ThisContext,
 };
 use crate::queries::{KIND_CALL_EXPR, KIND_SIMPLE_IDENT, KIND_SUPER_EXPR, KIND_THIS_EXPR};
 use crate::resolver::complete::DotReceiver;
@@ -136,7 +135,7 @@ pub(crate) fn derive_dot_receiver(
     let resolved = if node.kind() == KIND_SIMPLE_IDENT {
         None
     } else {
-        match CstQuery::new(node, &doc, index, uri, ResolveIo::NoRg).expr_type() {
+        match CstQuery::new(node, &doc, index, uri).expr_type() {
             Resolution::Resolved(resolved_type) => Some(resolved_type.as_type_str().to_owned()),
             _ => None,
         }
@@ -282,7 +281,7 @@ fn collect_lambda_scopes(index: &Indexer, uri: &Url, position: Position) -> Vec<
     let Some(node) = cursor_node_at(doc, cursor) else {
         return Vec::new();
     };
-    CstQuery::new(node, doc, index, uri, ResolveIo::NoRg)
+    CstQuery::new(node, doc, index, uri)
         .lambda_scope()
         .into_iter()
         .map(LambdaScope::from)

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -58,7 +58,7 @@ pub(crate) use self::infer::{
     },
     type_subst::find_last_dot_at_depth_zero,
 };
-pub(crate) use self::infer::{CstQuery, Resolution, ResolveIo};
+pub(crate) use self::infer::{CstQuery, Resolution};
 
 mod cache;
 pub(crate) use self::cache::workspace_cache_path;

--- a/src/indexer/infer/cst_lambda.rs
+++ b/src/indexer/infer/cst_lambda.rs
@@ -518,16 +518,18 @@ fn this_lambda_ancestor_ctxs(
     deps: &impl InferDeps,
     uri: &Url,
 ) -> Vec<ThisLambdaCtx> {
-    let mut ctxs = Vec::new();
-    let mut cur = start_node;
+    let mut contexts = Vec::new();
+    let mut current_node = start_node;
     loop {
-        if cur.kind() == KIND_LAMBDA_LIT {
-            ctxs.push(lambda_this_ctx(cur, doc, deps, uri));
+        if current_node.kind() == KIND_LAMBDA_LIT {
+            contexts.push(lambda_this_ctx(current_node, doc, deps, uri));
         }
-        let Some(parent) = cur.parent() else { break };
-        cur = parent;
+        let Some(parent) = current_node.parent() else {
+            break;
+        };
+        current_node = parent;
     }
-    ctxs
+    contexts
 }
 
 /// Every enclosing lambda receiver type at `start_node`, innermost-first — the
@@ -545,7 +547,7 @@ pub(crate) fn all_this_receivers_at(
 ) -> Vec<String> {
     this_lambda_ancestor_ctxs(start_node, doc, deps, uri)
         .into_iter()
-        .filter_map(|ctx| match ctx {
+        .filter_map(|context| match context {
             ThisLambdaCtx::Resolved(receiver_type) => Some(receiver_type),
             ThisLambdaCtx::Receiver | ThisLambdaCtx::NotReceiver => None,
         })
@@ -660,9 +662,9 @@ pub(super) fn cst_this_context(
     idx: &impl InferDeps,
     uri: &Url,
 ) -> ThisContext {
-    for ctx in this_lambda_ancestor_ctxs(start_node, doc, idx, uri) {
-        match ctx {
-            ThisLambdaCtx::Resolved(t) => return ThisContext::Resolved(t),
+    for context in this_lambda_ancestor_ctxs(start_node, doc, idx, uri) {
+        match context {
+            ThisLambdaCtx::Resolved(receiver_type) => return ThisContext::Resolved(receiver_type),
             ThisLambdaCtx::Receiver => return ThisContext::InsideReceiver,
             ThisLambdaCtx::NotReceiver => {}
         }

--- a/src/indexer/infer/cst_lambda.rs
+++ b/src/indexer/infer/cst_lambda.rs
@@ -500,6 +500,36 @@ pub(super) fn cst_lambda_scopes(
     scopes
 }
 
+/// Ancestor `lambda_literal` nodes from `start_node` outward (innermost first —
+/// `start_node` itself first if it IS a `lambda_literal`), each classified via
+/// [`lambda_this_ctx`]. The shared walk step behind [`all_this_receivers_at`]
+/// (collects every `Resolved`) and [`cst_this_context`] (stops at the first
+/// `Resolved`/`Receiver`) — previously two separate copies of the same
+/// ancestor-walk-and-classify loop.
+///
+/// Always walks the full ancestor chain before either caller inspects the
+/// result, trading `cst_this_context`'s previous early-exit for one shared
+/// shape. Lambda nesting in real Kotlin code is shallow (rarely >3-4 levels),
+/// so the extra `lambda_this_ctx` calls on ancestors past the first match are
+/// cheap.
+fn this_lambda_ancestor_ctxs(
+    start_node: tree_sitter::Node<'_>,
+    doc: &crate::indexer::live_tree::LiveDoc,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Vec<ThisLambdaCtx> {
+    let mut ctxs = Vec::new();
+    let mut cur = start_node;
+    loop {
+        if cur.kind() == KIND_LAMBDA_LIT {
+            ctxs.push(lambda_this_ctx(cur, doc, deps, uri));
+        }
+        let Some(parent) = cur.parent() else { break };
+        cur = parent;
+    }
+    ctxs
+}
+
 /// Every enclosing lambda receiver type at `start_node`, innermost-first — the
 /// order Kotlin actually resolves an implicit-receiver call in (nearest
 /// receiver wins; an unresolvable or non-receiver lambda is simply skipped,
@@ -513,24 +543,13 @@ pub(crate) fn all_this_receivers_at(
     deps: &impl InferDeps,
     uri: &Url,
 ) -> Vec<String> {
-    let mut receivers = Vec::new();
-    let mut cur = start_node;
-    loop {
-        if cur.kind() == KIND_LAMBDA_LIT {
-            // lambda_this_ctx (not the weaker text-only classify_this_lambda_context
-            // directly) — it resolves the callee via the CST call node first
-            // (enclosing_call_expression + call_fn_name), which is robust to
-            // multi-line call headers with named arguments before the trailing
-            // lambda (e.g. `LazyColumn(contentPadding = ..., ...) { item {} }`);
-            // the text-only path only ever sees the brace's own line.
-            if let ThisLambdaCtx::Resolved(receiver_type) = lambda_this_ctx(cur, doc, deps, uri) {
-                receivers.push(receiver_type);
-            }
-        }
-        let Some(parent) = cur.parent() else { break };
-        cur = parent;
-    }
-    receivers
+    this_lambda_ancestor_ctxs(start_node, doc, deps, uri)
+        .into_iter()
+        .filter_map(|ctx| match ctx {
+            ThisLambdaCtx::Resolved(receiver_type) => Some(receiver_type),
+            ThisLambdaCtx::Receiver | ThisLambdaCtx::NotReceiver => None,
+        })
+        .collect()
 }
 
 /// Build the completion scope for a single `lambda_literal`, or `None` when it
@@ -641,17 +660,12 @@ pub(super) fn cst_this_context(
     idx: &impl InferDeps,
     uri: &Url,
 ) -> ThisContext {
-    let mut cur = start_node;
-    loop {
-        if cur.kind() == KIND_LAMBDA_LIT {
-            match lambda_this_ctx(cur, doc, idx, uri) {
-                ThisLambdaCtx::Resolved(t) => return ThisContext::Resolved(t),
-                ThisLambdaCtx::Receiver => return ThisContext::InsideReceiver,
-                ThisLambdaCtx::NotReceiver => {}
-            }
+    for ctx in this_lambda_ancestor_ctxs(start_node, doc, idx, uri) {
+        match ctx {
+            ThisLambdaCtx::Resolved(t) => return ThisContext::Resolved(t),
+            ThisLambdaCtx::Receiver => return ThisContext::InsideReceiver,
+            ThisLambdaCtx::NotReceiver => {}
         }
-        let Some(parent) = cur.parent() else { break };
-        cur = parent;
     }
     ThisContext::NotFound
 }

--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -9,7 +9,7 @@
 
 use tree_sitter::Node;
 
-use crate::indexer::{CstQuery, Indexer, NodeExt, Resolution, ResolveIo};
+use crate::indexer::{CstQuery, Indexer, NodeExt, Resolution};
 use crate::queries::{
     KIND_BINDING_PATTERN_KIND, KIND_CALL_EXPR, KIND_CATCH_BLOCK, KIND_CLASS_DECL, KIND_CLASS_PARAM,
     KIND_COMPANION_OBJ, KIND_CONTROL_STRUCTURE_BODY, KIND_ENUM_ENTRY, KIND_FINALLY_BLOCK,
@@ -255,7 +255,7 @@ pub(crate) fn classify_symbol_at(
             // doesn't silently masquerade as a real receiver type (house
             // decoy: `untypeable_receiver_yields_no_receiver_type`).
             let receiver_type = navigation_receiver_node(nav).and_then(|receiver| {
-                match CstQuery::new(receiver, doc, indexer, uri, ResolveIo::IndexOnly).expr_type() {
+                match CstQuery::new(receiver, doc, indexer, uri).expr_type() {
                     Resolution::Resolved(t) if indexer.has_type_definition(t.as_type_str()) => {
                         Some(t.as_type_str().to_owned())
                     }

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -23,18 +23,18 @@ pub(super) use super::args::has_named_params_not_it;
 #[allow(unused_imports)]
 pub(super) use super::chain::resolve_member_type_on;
 pub(crate) use super::cst_lambda::ThisContext;
-use super::cst_lambda::{
-    all_this_receivers_at, cst_it_element_type, cst_named_lambda_param_type, cst_this_context,
-    cursor_node_at,
-};
 #[cfg(test)]
 #[allow(unused_imports)]
 pub(super) use super::cst_lambda::{
     classify_this_lambda_context, cst_lambda_param_type_via_call, cst_lambda_scopes,
     is_inside_receiver_lambda, lambda_before_brace_context, LambdaScopeInfo, ThisLambdaCtx,
 };
+use super::cst_lambda::{
+    cst_it_element_type, cst_named_lambda_param_type, cst_this_context, cursor_node_at,
+};
 use super::speculative::lambda_doc_at;
 use super::type_subst::is_generic_param;
+use super::CstQuery;
 
 /// Guard: the inference resolved to a bare generic placeholder (T, R, E).
 /// Without receiver context, this is not a meaningful type — fall through so
@@ -112,7 +112,7 @@ pub(crate) fn all_lambda_receivers_at(pos: CursorPos, idx: &Indexer, uri: &Url) 
     let Some(node) = cursor_node_at(doc, pos) else {
         return vec![];
     };
-    all_this_receivers_at(node, doc, idx, uri)
+    CstQuery::new(node, doc, idx, uri).all_this_receivers()
 }
 
 /// Resolve the element/receiver type for an EXPLICITLY NAMED lambda parameter

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -189,4 +189,15 @@ impl<'a, D: InferDeps> CstQuery<'a, D> {
             None => Resolution::Unresolved,
         }
     }
+
+    /// Every enclosing lambda receiver type at the bound node, innermost-first —
+    /// the order Kotlin resolves an implicit-receiver call in (nearest wins). An
+    /// unresolvable or non-receiver lambda is skipped; the walk continues outward.
+    ///
+    /// Used to check a bare call/type reference against every candidate receiver
+    /// in scope (e.g. `item()` inside `with(x) { }` nested in a builder belongs to
+    /// the outer receiver even when `x`'s type can't be resolved).
+    pub(crate) fn all_this_receivers(&self) -> Vec<String> {
+        cst_lambda::all_this_receivers_at(self.node, self.doc, self.deps, self.uri)
+    }
 }

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -9,9 +9,8 @@
 //!
 //! | Type              | Role                                                         |
 //! |-------------------|--------------------------------------------------------------|
-//! | `CstQuery`        | Bound CST query: node + doc + deps + URI + IO policy        |
-//! | `Fqn`             | `Ambiguous` candidate identifier (newtype over `String`, defining-URI placeholder today) |
-//! | `Resolution<T>`   | Three-way outcome: `Resolved(T)` / `Ambiguous(Vec<Fqn>)` / `Unresolved` |
+//! | `CstQuery`        | Bound CST query: node + doc + deps + URI                     |
+//! | `Resolution<T>`   | Three-way outcome: `Resolved(T)` / `Ambiguous` / `Unresolved` |
 //! | `ResolvedType`    | A resolved expression type with its nullable flag            |
 //!
 //! ## Known gaps
@@ -72,10 +71,6 @@ pub(super) mod type_subst;
 #[path = "mod_tests.rs"]
 mod tests;
 
-// ─── re-exports from resolver (IO policy) ─────────────────────────────────────
-
-pub(crate) use crate::resolver::resolve::ResolveIo;
-
 // ─── catalogue types ──────────────────────────────────────────────────────────
 
 use tower_lsp::lsp_types::Url;
@@ -86,27 +81,13 @@ use crate::StrExt as _;
 
 use self::deps::InferDeps;
 
-/// Identifies one candidate in a `Resolution::Ambiguous` result. Named for its
-/// intended end state (an importable fully-qualified name), but today's only
-/// producer (`sig.rs`'s `build_result`) populates it with the candidate's
-/// defining-file URI plus its arity envelope (`"<uri>#<required>/<total>"`) as
-/// a placeholder identifier — not yet a real FQN-shaped value. The arity
-/// suffix keeps candidates unique when two overloads share a defining file
-/// (same URI, different arity would otherwise collide). Field constructed by
-/// `Ambiguous` candidates; not yet read by any consumer.
-#[derive(Debug, Clone)]
-pub(crate) struct Fqn(#[allow(dead_code)] pub(crate) String);
-
 /// Outcome of resolving something to `T`. Reused across the catalogue so an
 /// agent learns the three outcomes once and reads them off every signature.
 #[derive(Debug, Clone)]
 pub(crate) enum Resolution<T> {
     Resolved(T),
-    /// Multiple candidates — callers may surface all or pick one heuristically.
-    /// The `Vec<Fqn>` payload is constructed (`sig.rs::build_result`) but every
-    /// current matcher (`resolved`, `resolved_ref`, `call_arg_diagnostics.rs`)
-    /// discards it via `_` — no consumer inspects candidates yet.
-    Ambiguous(#[allow(dead_code)] Vec<Fqn>),
+    /// Multiple candidates — the caller should skip rather than guess.
+    Ambiguous,
     Unresolved,
 }
 
@@ -116,16 +97,7 @@ impl<T> Resolution<T> {
     pub(crate) fn resolved(self) -> Option<T> {
         match self {
             Resolution::Resolved(value) => Some(value),
-            Resolution::Ambiguous(_) | Resolution::Unresolved => None,
-        }
-    }
-
-    /// `Resolved(t) -> Some(&t)`, else `None`.
-    #[allow(dead_code)] // wiring seam; used by later catalogue methods
-    pub(crate) fn resolved_ref(&self) -> Option<&T> {
-        match self {
-            Resolution::Resolved(value) => Some(value),
-            Resolution::Ambiguous(_) | Resolution::Unresolved => None,
+            Resolution::Ambiguous | Resolution::Unresolved => None,
         }
     }
 }
@@ -153,7 +125,7 @@ impl ResolvedType {
         &self.type_name
     }
 
-    #[allow(dead_code)] // not yet consumed; available for later catalogue methods
+    #[allow(dead_code)] // read only by tests pinning `from_inferred`'s nullable computation
     pub(crate) fn is_nullable(&self) -> bool {
         self.nullable
     }
@@ -162,7 +134,7 @@ impl ResolvedType {
 // ─── CstQuery — the unified CST resolution context ───────────────────────────
 
 /// A bound CST query: a single expression node together with its document,
-/// dependency seam, URI, and IO policy.
+/// dependency seam, and URI.
 ///
 /// Constructing a `CstQuery` is cheap (no allocation); the per-request cost is
 /// in the methods that call through to the inference engine.
@@ -177,35 +149,18 @@ pub(crate) struct CstQuery<'a, D: InferDeps> {
     doc: &'a LiveDoc,
     deps: &'a D,
     uri: &'a Url,
-    /// IO policy carried for later catalogue methods that branch on it.
-    #[allow(dead_code)]
-    io: ResolveIo,
 }
 
 impl<'a, D: InferDeps> CstQuery<'a, D> {
     /// Construct a query for `node` within `doc`, using `deps` for index
     /// lookups and `uri` to identify the file.
-    pub(crate) fn new(
-        node: Node<'a>,
-        doc: &'a LiveDoc,
-        deps: &'a D,
-        uri: &'a Url,
-        io: ResolveIo,
-    ) -> Self {
+    pub(crate) fn new(node: Node<'a>, doc: &'a LiveDoc, deps: &'a D, uri: &'a Url) -> Self {
         Self {
             node,
             doc,
             deps,
             uri,
-            io,
         }
-    }
-
-    /// Return a new query pointing at `node` but sharing all other context.
-    /// Used by walk steps that move to a child or sibling node.
-    #[allow(dead_code)] // wiring seam for later walk tasks
-    fn at(&self, node: Node<'a>) -> Self {
-        Self { node, ..*self }
     }
 
     /// Build the completion scope for every lambda enclosing the bound node.

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -19,11 +19,13 @@
 //! `CstQuery` — an agent looking for "type of X" should know they exist before reinventing them:
 //!
 //! - `it_this` (`find_it_element_type`, `find_this_context`, `find_this_element_type`,
-//!   `find_named_lambda_param_type`, `is_lambda_param`, `all_lambda_receivers_at`) — CST-driven
-//!   internally already (delegates to `cst_lambda`), but takes a `CursorPos` + does its own
-//!   repair-gated node acquisition; folding into `CstQuery`'s bound-`Node` model needs a
-//!   `CstQuery::at_position` bridge — deferred, see the design doc's lambda-triad/`LambdaScope`-
-//!   promotion step.
+//!   `find_named_lambda_param_type`, `is_lambda_param`) — CST-driven internally already
+//!   (delegates to `cst_lambda`), but takes a `CursorPos` + does its own repair-gated node
+//!   acquisition; folding into `CstQuery`'s bound-`Node` model needs a `CstQuery::at_position`
+//!   bridge — deferred, see the design doc's lambda-triad/`LambdaScope`-promotion step.
+//!   `all_lambda_receivers_at` is the one exception: its position→node bridge now constructs a
+//!   `CstQuery` and calls `all_this_receivers()` directly (2026-08-03) — still a flat
+//!   `CursorPos`-taking export by name, but no longer bypasses the catalogue underneath.
 //! - `sig` (signature/param-text helpers) — pure string/slice helpers, several IO-bound
 //!   (`find_fun_signature_full` may trigger on-demand rg indexing); not expression-type
 //!   resolution, out of `CstQuery`'s "type of a bound node" remit.

--- a/src/indexer/infer/mod_tests.rs
+++ b/src/indexer/infer/mod_tests.rs
@@ -1,6 +1,6 @@
 use tower_lsp::lsp_types::Url;
 
-use crate::indexer::infer::{CstQuery, ResolveIo};
+use crate::indexer::infer::CstQuery;
 use crate::indexer::Indexer;
 use crate::queries::KIND_FUN_BODY;
 
@@ -34,15 +34,9 @@ fn cst_query_expr_type_resolves_int_literal() {
     let uri = test_url("/CstQuery.kt");
     indexer.index_content(&uri, source);
 
-    let resolved = CstQuery::new(
-        int_literal_node,
-        &live_doc,
-        &indexer,
-        &uri,
-        ResolveIo::IndexOnly,
-    )
-    .expr_type()
-    .resolved();
+    let resolved = CstQuery::new(int_literal_node, &live_doc, &indexer, &uri)
+        .expr_type()
+        .resolved();
     assert_eq!(
         resolved.map(|t| t.as_type_str().to_owned()).as_deref(),
         Some("Int")
@@ -59,15 +53,9 @@ fn cst_query_expr_type_unresolved_for_unknown_nav() {
     let uri = test_url("/B.kt");
     indexer.index_content(&uri, source);
 
-    let resolved = CstQuery::new(
-        nav_expr_node,
-        &live_doc,
-        &indexer,
-        &uri,
-        ResolveIo::IndexOnly,
-    )
-    .expr_type()
-    .resolved();
+    let resolved = CstQuery::new(nav_expr_node, &live_doc, &indexer, &uri)
+        .expr_type()
+        .resolved();
     assert!(
         resolved.is_none(),
         "unresolvable nav expr should yield Unresolved"
@@ -84,8 +72,7 @@ fn resolved_type_nullable_flag() {
     let uri = test_url("/C.kt");
     indexer.index_content(&uri, source);
 
-    let resolution =
-        CstQuery::new(null_node, &live_doc, &indexer, &uri, ResolveIo::IndexOnly).expr_type();
+    let resolution = CstQuery::new(null_node, &live_doc, &indexer, &uri).expr_type();
     let resolved = resolution
         .resolved()
         .expect("null should resolve to Nothing?");
@@ -103,7 +90,7 @@ fn resolved_type_non_nullable() {
     let uri = test_url("/D.kt");
     indexer.index_content(&uri, source);
 
-    let resolved = CstQuery::new(int_node, &live_doc, &indexer, &uri, ResolveIo::IndexOnly)
+    let resolved = CstQuery::new(int_node, &live_doc, &indexer, &uri)
         .expr_type()
         .resolved()
         .expect("Int should resolve");
@@ -265,7 +252,7 @@ fn scope_fn_callee_nav_resolves_via_the_segment_walk() {
         )
         .expect("node covering the let call");
     assert_eq!(call.kind(), "call_expression", "got {}", call.kind());
-    let resolved = CstQuery::new(call, &live_doc, &indexer, &uri, ResolveIo::NoRg)
+    let resolved = CstQuery::new(call, &live_doc, &indexer, &uri)
         .expr_type()
         .resolved();
     assert_eq!(

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -8,7 +8,7 @@
 
 use tower_lsp::lsp_types::{SymbolKind, Url};
 
-use super::{Fqn, Resolution};
+use super::Resolution;
 use crate::indexer::Indexer;
 use crate::resolver::{infer_receiver_type, ReceiverKind};
 use crate::types::{SourceSet, SymbolEntry};
@@ -741,7 +741,7 @@ fn collect_params_from_file(
     caller_uri: &str,
     scope: ResolutionScope,
     receiver_base: Option<&str>,
-) -> Vec<(String, (u8, u8), String /* defining uri */)> {
+) -> Vec<(String, (u8, u8))> {
     // Look up data from source files first, then the compiled-JAR cache. Track which:
     // only compiled-JAR (sidecar) symbols lack default-value markers.
     let (data, is_compiled_jar) = if let Some(file_data) = idx.files.get(file_uri) {
@@ -819,7 +819,7 @@ fn collect_params_from_file(
         .iter()
         .filter(name_matches)
         .filter(receiver_matches)
-        .flat_map(|s| -> Vec<(String, (u8, u8), String)> {
+        .flat_map(|s| -> Vec<(String, (u8, u8))> {
             // Swift structs/classes never carry constructor params on their own
             // CST node (no Kotlin-style inline primary constructor) — the real
             // signature lives on a nested `init` (explicit or synthesized at
@@ -835,7 +835,7 @@ fn collect_params_from_file(
                         c.kind == SymbolKind::CONSTRUCTOR
                             && c.container.as_deref() == Some(s.name.as_str())
                     })
-                    .map(|c| (c.params.clone(), c.param_counts, file_uri.to_string()))
+                    .map(|c| (c.params.clone(), c.param_counts))
                     .collect();
             }
             let params_text = match extract_params_or_fallback(s, &data.lines) {
@@ -847,7 +847,7 @@ fn collect_params_from_file(
             } else {
                 s.param_counts
             };
-            vec![(params_text, counts, file_uri.to_string())]
+            vec![(params_text, counts)]
         })
         .collect()
 }
@@ -923,12 +923,11 @@ fn resolve_qualified(call: &CallSite<'_>, qualifier: &str, idx: &Indexer) -> Res
     crate::indexer::jar::ensure_jar_definitions_for(idx, call.name, &mut cache_backed_only);
 
     if total_definition_count(call.name, idx) > crate::indexer::MAX_BY_NAME_DEFS {
-        // known-ambiguous (ubiquitous name), candidates not enumerated for
-        // performance — see `total_definition_count`.
-        return Resolution::Ambiguous(vec![]);
+        // known-ambiguous (ubiquitous name) — see `total_definition_count`.
+        return Resolution::Ambiguous;
     }
 
-    let mut found: Vec<(String, (u8, u8), String)> = Vec::new();
+    let mut found: Vec<(String, (u8, u8))> = Vec::new();
 
     // Phase 1: definitions + jar_definitions — source and JAR symbols.
     {
@@ -1016,9 +1015,8 @@ fn resolve_unqualified(call: &CallSite<'_>, idx: &Indexer) -> Resolution<Signatu
     // hot path, and the wide arity envelope would resolve to `Ambiguous` regardless —
     // so bail without scanning. (Same-file calls above already resolved exactly.)
     if total_definition_count(call.name, idx) > crate::indexer::MAX_BY_NAME_DEFS {
-        // known-ambiguous (ubiquitous name), candidates not enumerated for
-        // performance — see `total_definition_count`.
-        return Resolution::Ambiguous(vec![]);
+        // known-ambiguous (ubiquitous name) — see `total_definition_count`.
+        return Resolution::Ambiguous;
     }
 
     let caller_source_set = idx
@@ -1028,7 +1026,7 @@ fn resolve_unqualified(call: &CallSite<'_>, idx: &Indexer) -> Resolution<Signatu
         .unwrap_or_default();
 
     // Cross-file: definitions + jar_definitions with import + nested-class filtering.
-    let mut all: Vec<(String, (u8, u8), String)> = Vec::new();
+    let mut all: Vec<(String, (u8, u8))> = Vec::new();
     let mut locations: Vec<tower_lsp::lsp_types::Location> = Vec::new();
     if let Some(locs) = idx.definitions.get(call.name) {
         // Reconstitute interned `SymbolLoc`s at this boundary.
@@ -1063,36 +1061,27 @@ fn resolve_unqualified(call: &CallSite<'_>, idx: &Indexer) -> Resolution<Signatu
     build_result(all)
 }
 
-/// Build a `Resolution<Signature>` from a list of `(params_text, param_counts,
-/// defining_uri)` triples.
+/// Build a `Resolution<Signature>` from a list of `(params_text, param_counts)` pairs.
 ///
 /// Deduplicates by arity envelope. If there are multiple distinct envelopes,
 /// the function is considered overloaded (`Ambiguous`) and the caller should
 /// skip the diagnostic.
-fn build_result(entries: Vec<(String, (u8, u8), String)>) -> Resolution<Signature> {
+fn build_result(entries: Vec<(String, (u8, u8))>) -> Resolution<Signature> {
     if entries.is_empty() {
         return Resolution::Unresolved;
     }
     // Deduplicate by arity envelope.
     let mut seen: std::collections::HashSet<(u8, u8)> = std::collections::HashSet::new();
-    let mut deduped: Vec<(String, (u8, u8), String)> = Vec::new();
-    for (text, counts, defining_uri) in entries {
+    let mut deduped: Vec<(String, (u8, u8))> = Vec::new();
+    for (text, counts) in entries {
         if seen.insert(counts) {
-            deduped.push((text, counts, defining_uri));
+            deduped.push((text, counts));
         }
     }
     if deduped.len() > 1 {
-        // Arity suffix keeps candidates unique when two overloads share a
-        // defining file — the URI alone collides for same-file overloads.
-        let candidates = deduped
-            .into_iter()
-            .map(|(_, (required, total), defining_uri)| {
-                Fqn(format!("{defining_uri}#{required}/{total}"))
-            })
-            .collect();
-        return Resolution::Ambiguous(candidates);
+        return Resolution::Ambiguous;
     }
-    let (params_text, (required, total), _defining_uri) = deduped.into_iter().next().unwrap();
+    let (params_text, (required, total)) = deduped.into_iter().next().unwrap();
     Resolution::Resolved(Signature {
         params_text,
         param_counts: (required as usize, total as usize),

--- a/src/indexer/infer/sig_tests.rs
+++ b/src/indexer/infer/sig_tests.rs
@@ -409,10 +409,7 @@ fn resolve_unqualified_bails_on_ubiquitous_name() {
     };
 
     assert!(
-        matches!(
-            resolve_call_signature(&call, &idx),
-            Resolution::Ambiguous(_)
-        ),
+        matches!(resolve_call_signature(&call, &idx), Resolution::Ambiguous),
         "a name with > MAX_BY_NAME_DEFS definitions must bail to Ambiguous, not scan them all"
     );
 }
@@ -514,7 +511,7 @@ fn resolve_qualified_jar_extension_overloads_with_source_member() {
 
     // Both 0-arg member + 1-arg extension → Ambiguous.
     match resolve_call_signature(&call, &idx) {
-        Resolution::Ambiguous(_) => {}
+        Resolution::Ambiguous => {}
         other => panic!("expected Ambiguous (0-arg member + 1-arg extension), got {other:?}"),
     }
 }
@@ -634,10 +631,7 @@ fn resolve_qualified_bails_on_ubiquitous_name_even_with_receiver_extension() {
     // doing so would ignore the 0-arg member that members-win-over-extensions
     // semantics would actually call.
     assert!(
-        matches!(
-            resolve_call_signature(&call, &idx),
-            Resolution::Ambiguous(_)
-        ),
+        matches!(resolve_call_signature(&call, &idx), Resolution::Ambiguous),
         "capped qualified path must bail entirely, not return Resolved from Phase 2 alone"
     );
 }

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -5,8 +5,8 @@ use tower_lsp::lsp_types::{
 };
 use tree_sitter::Node;
 
+use crate::indexer::CstQuery;
 use crate::indexer::{find_it_element_type, find_this_element_type, Indexer, LiveDoc, NodeExt};
-use crate::indexer::{CstQuery, ResolveIo};
 use crate::queries::{
     KIND_KW_AS, KIND_KW_BY, KIND_KW_CONSTRUCTOR, KIND_KW_GET, KIND_KW_IN, KIND_KW_IS, KIND_KW_SET,
     KIND_KW_WHERE, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_NAV_EXPR, KIND_SIMPLE_IDENT,
@@ -159,7 +159,7 @@ fn resolve_member_access(
         let is_call = is_call_callee(node);
         let resolved_type = navigation_receiver_node(node)
             .and_then(|receiver| {
-                CstQuery::new(receiver, doc, indexer, uri, ResolveIo::IndexOnly)
+                CstQuery::new(receiver, doc, indexer, uri)
                     .expr_type()
                     .resolved()
             })


### PR DESCRIPTION
## Summary

Stacked on #247 (needs the 4-arg `CstQuery::new` from that PR). Executes `docs/superpowers/plans/2026-08-03-cst-catalogue-lambda-triad-wiring.md` via subagent-driven-development, continuing the CST-resolution-unification design doc's step 3 ("collapse the lambda triad") — narrowly scoped to what has a real, verified production consumer today, after two prior attempts to extend this same catalogue were reverted for shipping capability with no real consumer wired in the same task.

- **Task 1** (`4cb566a`): `cst_lambda.rs` had two independent copies of the same "walk `lambda_literal` ancestors, classify each" loop (`all_this_receivers_at`, `cst_this_context`). Merged into one shared `this_lambda_ancestor_ctxs` helper. Pure internal dedup, zero call-site changes.
- **Task 2** (`11559fd`): Added `CstQuery::all_this_receivers()` to the catalogue facade and, in the same commit, deleted the old direct call from `it_this::all_lambda_receivers_at` — wiring the method's real, sole production consumer (`features/missing_import_diagnostics.rs:244`) through it immediately. Verified end-to-end by the task reviewer: exactly one call chain, no leftover parallel path.
- **Task 3** (`bfb4740`): Updated `mod.rs`'s "Known gaps" doc comment to reflect that `all_lambda_receivers_at` no longer bypasses the catalogue.
- **Task 4**: Final verification (test suite, clippy x2, fmt, orphan-duplicate greps) — all clean.

Final whole-branch review (Fable): **Ready to merge**, zero Critical/Important findings. Two Minor notes, neither blocking: a pre-existing incompleteness in `it_this.rs`'s own doc block (out of this slice's scope), and the full-walk-vs-early-exit tradeoff in the new shared helper (explicitly disclosed in its doc comment, already accepted at the Task 1 review).

Explicitly descoped (see plan doc for full reasoning): the `CstQuery::at_position` bridge for the other `it_this` functions, `LambdaScope` promotion (a real landmine was found in `completion_context.rs::ScopeContext::build`'s dual-purposed `it_type` field), `receiver_type()`/`call_return_type()` (still no real consumer), and `chain.rs` collapse.

## Test plan
- [x] `cargo test --bin kmp-lsp` — 1636 passed, 0 failed
- [x] `cargo clippy -- -D warnings` and `cargo clippy --all-targets --all-features -- -D warnings` — both clean
- [x] `cargo fmt --check` — clean
- [x] Every task reviewed individually (spec + quality) before merge; final whole-branch review confirms cross-task coherence and the no-orphaned-scaffolding discipline actually held

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeEquPJ6s1zBjcNfKdH1sK