### PR TITLE
fix(workspace): deflake retype_cycle_indexer_state_supports_diagnostics

### DIFF
--- a/src/workspace/file_change_handler.rs
+++ b/src/workspace/file_change_handler.rs
@@ -219,6 +219,23 @@ impl FileChangeHandler {
         }
         self.diagnostic_generation.remove(&key);
     }
+
+    /// Wait for `uri`'s currently pending debounced reindex task to finish.
+    ///
+    /// Test-only: production code never waits on this synchronously (the
+    /// debounce is fire-and-forget by design — that's the whole point of
+    /// debouncing). Awaiting the real `JoinHandle` here — rather than
+    /// sleeping for a guessed duration and hoping the 300ms debounce plus
+    /// semaphore-acquire plus `spawn_blocking(index_content)` finished in
+    /// time — is what makes a test using this deterministic instead of a
+    /// race against wall-clock time and machine load.
+    #[cfg(test)]
+    pub(crate) async fn wait_for_pending_reindex(&mut self, uri: &Url) {
+        let key = uri.to_string();
+        if let Some(handle) = self.pending_reindex.remove(&key) {
+            let _ = handle.await;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/workspace/file_change_handler_tests.rs
+++ b/src/workspace/file_change_handler_tests.rs
@@ -65,7 +65,7 @@ async fn retype_cycle_indexer_state_supports_diagnostics() {
     handler
         .handle_file_changed(uri.clone(), change(with_call))
         .await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+    handler.wait_for_pending_reindex(&uri).await;
 
     // Indexer should have the file with `loadData` defined.
     assert!(
@@ -85,7 +85,7 @@ async fn retype_cycle_indexer_state_supports_diagnostics() {
     handler
         .handle_file_changed(uri.clone(), change(without_call))
         .await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+    handler.wait_for_pending_reindex(&uri).await;
 
     let diags2 = {
         let doc = parse_live(without_call, tree_sitter_kotlin::language()).unwrap();
@@ -100,7 +100,7 @@ async fn retype_cycle_indexer_state_supports_diagnostics() {
     handler
         .handle_file_changed(uri.clone(), change(with_call))
         .await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+    handler.wait_for_pending_reindex(&uri).await;
 
     // The indexer state must support diagnostics on the retyped content.
     let diags3 = {


### PR DESCRIPTION
## Summary

Found while verifying `main` after merging #247/#248/#249/#250: `retype_cycle_indexer_state_supports_diagnostics` failed deterministically (3/3) when run in isolation. Confirmed pre-existing and unrelated to that work — checked out the pre-session `main` (080782f) in a scratch worktree and it fails identically there.

**Root cause**: the test waited for `FileChangeHandler`'s debounced reindex (300ms internal sleep + semaphore-acquire + `spawn_blocking(index_content)`) by sleeping a guessed 400ms, instead of actually waiting for the task to finish. That's a race against wall-clock time and machine load, not a real assertion — it happened to pass under the full suite's parallel load (where relative scheduling worked out) and fail in tight isolation on this sandbox.

**Fix**: `reschedule_debounced_reindex` already stores each debounce task's `JoinHandle` in `pending_reindex` — nothing ever awaited it directly. Added `FileChangeHandler::wait_for_pending_reindex` (`#[cfg(test)]`-gated; production code intentionally never blocks on this, that would defeat debouncing) which removes and awaits the real handle. Replaced all three sleeps in the test with it.

## Test plan
- [x] Ran the test in isolation 15/15 times after the fix — all passed deterministically (~1.07-1.09s each, consistent, matching the real debounce duration rather than a padded guess)
- [x] `cargo test --bin kmp-lsp` — 1635 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeEquPJ6s1zBjcNfKdH1sK