### PR TITLE
fix(missing-import): catch bare navigation roots, stop misfiring on foreign diagnostics

### DIFF
--- a/src/features/missing_import_diagnostics.rs
+++ b/src/features/missing_import_diagnostics.rs
@@ -368,7 +368,7 @@ pub(crate) fn missing_import_actions(
     diagnostics
         .iter()
         .filter(|diagnostic| {
-            diagnostic.code == Some(NumberOrString::String(MISSING_IMPORT_CODE.into()))
+            matches!(&diagnostic.code, Some(NumberOrString::String(code)) if code == MISSING_IMPORT_CODE)
         })
         .filter_map(|diagnostic| {
             let name = flagged_name_from_message(&diagnostic.message)?;

--- a/src/features/missing_import_diagnostics.rs
+++ b/src/features/missing_import_diagnostics.rs
@@ -24,12 +24,20 @@ use tree_sitter::Node;
 use crate::indexer::live_tree::LiveDoc;
 use crate::indexer::{all_lambda_receivers_at, Indexer};
 use crate::queries::{
-    KIND_CALL_EXPR, KIND_DOT, KIND_FUN_DECL, KIND_IMPORT_HEADER, KIND_PACKAGE_HEADER,
-    KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_TYPE_PARAM, KIND_TYPE_PARAMS, KIND_USER_TYPE,
+    KIND_CALL_EXPR, KIND_DOT, KIND_FUN_DECL, KIND_IMPORT_HEADER, KIND_NAV_EXPR,
+    KIND_PACKAGE_HEADER, KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_TYPE_PARAM, KIND_TYPE_PARAMS,
+    KIND_USER_TYPE,
 };
 use crate::resolver::{fqns_for_name, receiver_provides_member, resolve_in_scope_strict};
 use crate::types::CursorPos;
 use crate::LinesExt;
+use crate::StrExt;
+
+/// Diagnostic code identifying a diagnostic as this module's own. `source` alone
+/// (`"kmp-lsp"`) isn't enough to tell our diagnostics apart from every other
+/// feature's — `missing_import_actions` needs a precise, collision-proof match
+/// before it parses a diagnostic's message as a flagged name.
+const MISSING_IMPORT_CODE: &str = "missing-import";
 
 /// A flagged reference: the bare name and where it occurs.
 pub(crate) struct MissingImportFlag {
@@ -148,6 +156,33 @@ fn collect_candidates(
                         name: text.to_owned(),
                         line: callee.start_position().row as u32,
                         col: callee.start_position().column as u32,
+                        receivers: active_receivers.to_vec(),
+                    });
+                }
+            }
+        }
+    } else if kind == KIND_SIMPLE_IDENT {
+        // A capitalized identifier at the root of a navigation expression
+        // (`EnumType.CONSTANT`, `SomeObject.member`) — tree-sitter-kotlin only
+        // ever emits `type_identifier` in type-annotation positions, never in
+        // expression positions, so a bare object/enum-constant reference like
+        // this parses as `simple_identifier`, indistinguishable in kind from an
+        // ordinary lowercase receiver variable. Restricted to the navigation
+        // root (no preceding sibling — a `navigation_suffix` identifier, i.e.
+        // the member being accessed, is deliberately not a candidate here) and
+        // to Kotlin's type/object capitalization convention, so this doesn't
+        // fire on `someVar.member`.
+        let is_capitalized_nav_root = node.prev_sibling().is_none()
+            && node
+                .parent()
+                .is_some_and(|parent| parent.kind() == KIND_NAV_EXPR);
+        if is_capitalized_nav_root {
+            if let Ok(text) = node.utf8_text(src) {
+                if text.starts_with_uppercase() && !active.contains(text) {
+                    out.push(Candidate {
+                        name: text.to_owned(),
+                        line: node.start_position().row as u32,
+                        col: node.start_position().column as u32,
                         receivers: active_receivers.to_vec(),
                     });
                 }
@@ -299,6 +334,7 @@ pub(crate) fn missing_import_diagnostics(
             ),
             severity: Some(DiagnosticSeverity::WARNING),
             source: Some("kmp-lsp".into()),
+            code: Some(NumberOrString::String(MISSING_IMPORT_CODE.into())),
             message: format!("'{}' is not imported and not in scope", flag.name),
             ..Default::default()
         })
@@ -313,7 +349,12 @@ pub(crate) fn missing_import_diagnostics(
 /// than re-walking the CST: the client already told us which of our own
 /// diagnostics apply at this position via `CodeActionContext::diagnostics`,
 /// and the message format is ours to parse (`missing_import_diagnostics`,
-/// above, is the only producer).
+/// above, is the only producer for diagnostics carrying `MISSING_IMPORT_CODE`).
+/// Gated on that `code`, not just `source` — `source` is the shared
+/// `"kmp-lsp"` string every diagnostic in this LSP carries, so it can't tell
+/// this module's diagnostics apart from e.g. `fill_when`'s non-exhaustive-`when`
+/// diagnostic, whose message ("'when' is missing branches: …") also happens to
+/// start with a quoted word.
 pub(crate) fn missing_import_actions(
     indexer: &Indexer,
     uri: &Url,
@@ -326,7 +367,9 @@ pub(crate) fn missing_import_actions(
 
     diagnostics
         .iter()
-        .filter(|diagnostic| diagnostic.source.as_deref() == Some("kmp-lsp"))
+        .filter(|diagnostic| {
+            diagnostic.code == Some(NumberOrString::String(MISSING_IMPORT_CODE.into()))
+        })
         .filter_map(|diagnostic| {
             let name = flagged_name_from_message(&diagnostic.message)?;
             Some((diagnostic, name))

--- a/src/features/missing_import_diagnostics_tests.rs
+++ b/src/features/missing_import_diagnostics_tests.rs
@@ -149,6 +149,85 @@ fn offers_an_import_quickfix_for_a_flagged_diagnostic() {
     );
 }
 
+/// Regression: `EnumType.CONSTANT` (or any `Type.member` navigation root) parses
+/// as a bare `simple_identifier`, not `type_identifier` — tree-sitter-kotlin only
+/// emits `type_identifier` in type-annotation positions, never expression
+/// positions. `collect_candidates` only ever looked at `type_identifier` nodes for
+/// bare-class detection, so a capitalized navigation root like this was never even
+/// considered as a candidate — an unimported `DarkThemeConfig` referenced only as
+/// `DarkThemeConfig.LIGHT` inside a `when` branch produced zero diagnostics.
+#[test]
+fn flags_an_unimported_enum_constant_used_as_navigation_root() {
+    let (uri, idx, src) = setup(&[
+        (
+            "/lib/DarkThemeConfig.kt",
+            "package com.example.lib\nenum class DarkThemeConfig { LIGHT, DARK }\n",
+        ),
+        (
+            "/app/Caller.kt",
+            "package app\nfun use(x: Int): Boolean = when (x) {\n    1 -> DarkThemeConfig.LIGHT == DarkThemeConfig.LIGHT\n    else -> false\n}\n",
+        ),
+    ]);
+    let diags = run_diagnostics(&idx, &uri, &src);
+    assert_eq!(
+        diags.len(),
+        1,
+        "expected one diagnostic for the unimported DarkThemeConfig navigation root: {diags:?}"
+    );
+    assert!(diags[0].message.contains("DarkThemeConfig"));
+}
+
+/// Regression: a capitalized navigation root that's already resolvable (imported,
+/// same-package, a local declaration, etc.) must still be exempted — this proves
+/// the fix only widens *candidate collection*, not the existing reachability logic.
+#[test]
+fn no_diagnostic_for_an_imported_enum_constant_used_as_navigation_root() {
+    let (uri, idx, src) = setup(&[
+        (
+            "/lib/DarkThemeConfig.kt",
+            "package com.example.lib\nenum class DarkThemeConfig { LIGHT, DARK }\n",
+        ),
+        (
+            "/app/Caller.kt",
+            "package app\nimport com.example.lib.DarkThemeConfig\nfun use(x: Int): Boolean = when (x) {\n    1 -> DarkThemeConfig.LIGHT == DarkThemeConfig.LIGHT\n    else -> false\n}\n",
+        ),
+    ]);
+    let diags = run_diagnostics(&idx, &uri, &src);
+    assert!(
+        diags.is_empty(),
+        "explicit import should suppress the navigation-root candidate too: {diags:?}"
+    );
+}
+
+/// Regression: `missing_import_actions` identified "one of ours" purely by
+/// `diagnostic.source == "kmp-lsp"`, a string shared by every diagnostic producer
+/// in the LSP, then blindly parsed the message as `'Name' is ...`. `fill_when`'s
+/// non-exhaustive-`when` diagnostic ("'when' is missing branches: ...") also
+/// starts with a quoted word, so it parses as a flagged name "when" — and in a
+/// real project, JAR symbols coincidentally named `when` (e.g. Kotlin compiler
+/// internals) give `fqns_for_name` real FQNs to offer, producing a nonsensical
+/// "Import 'when'" quick-fix attached to the when-exhaustiveness diagnostic. This
+/// test reproduces the same collision shape (a foreign, quote-prefixed message
+/// whose leading word happens to name a real importable symbol) without depending
+/// on tree-sitter's handling of the literal keyword `when`.
+#[test]
+fn no_import_action_for_a_foreign_diagnostic_that_starts_with_a_quoted_importable_name() {
+    let (uri, idx, _src) = setup(&[
+        ("/lib/Foo.kt", "package com.example.lib\nclass Foo\n"),
+        ("/app/Caller.kt", "package app\nfun use() {}\n"),
+    ]);
+    let foreign = vec![Diagnostic {
+        message: "'Foo' is missing branches: A, B".to_owned(),
+        source: Some("kmp-lsp".to_owned()),
+        ..Default::default()
+    }];
+    let actions = missing_import_actions(&idx, &uri, &foreign);
+    assert!(
+        actions.is_empty(),
+        "must not offer an import fix for a foreign diagnostic that merely starts with a quoted word: {actions:?}"
+    );
+}
+
 #[test]
 fn no_import_action_for_an_unrelated_diagnostic() {
     let (uri, idx, _src) = setup(&[("/app/Caller.kt", "package app\nfun use() {}\n")]);

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -8,13 +8,13 @@ use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
 use crate::stdlib::bare_completions;
 use crate::stdlib_tail::dot_completions_for_lang;
-use crate::types::{CallerContext, ImportEntry, SourceSet, Visibility};
+use crate::types::{CallerContext, ImportEntry, SourceSet, SymbolEntry, Visibility};
 use crate::LinesExt;
 use crate::StrExt;
 
 use super::infer::{infer_receiver_type, infer_receiver_type_at, ReceiverKind, ReceiverType};
 use super::infer_lines::infer_callable_param_return_type;
-use super::resolve::jar_symbol_package;
+use super::resolve::{jar_symbol_package, range_encloses};
 use super::{
     already_imported, ensure_file_data, fqns_for_name, resolve_symbol_no_rg, walk_hierarchy,
     Resolver, MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
@@ -1077,17 +1077,65 @@ fn symbols_from_nested_type(
             .collect();
     }
 
-    let type_start = type_symbol.range.start;
-    let type_end = type_symbol.range.end;
+    // Membership by `container` (assigned per-symbol at parse time by
+    // `assign_containers`, `parser.rs` — the tightest *immediate* enclosing
+    // class/object/interface, not a range-arithmetic approximation of it) is
+    // precise by construction: a member declared inside a nested type's own
+    // body has THAT nested type as its container, never the outer one, so it
+    // can never leak into the outer type's member list regardless of nesting
+    // depth. A prior range-containment version of this function needed
+    // several rounds of edge-case patching (a nested type's own members
+    // leaking into its enclosing type, then into every OTHER sibling type's
+    // *inherited* completion via `walk_hierarchy`) precisely because "is this
+    // symbol inside that range" is an approximation of "is this symbol's
+    // immediate parent that type" — `container` answers the real question
+    // directly, the same way the JAR branch above already does.
+    //
+    // `container` is a bare name, though, not a unique identity — two
+    // DIFFERENT nested types sharing a simple name in this file (`A.Config`
+    // and `B.Config`) would have their members merged by a name-only check.
+    // `type_symbol` is already the one specific instance this lookup
+    // resolved to, so additionally requiring the candidate's range to fall
+    // inside `type_symbol`'s own range disambiguates without reintroducing
+    // the depth bug: a *nested* type's members have a different `container`
+    // entirely (their own nested type's name, not `inner_name`), so they
+    // never reach this check regardless of range.
+    //
+    // Kotlin resolves `Outer.member` through `Outer`'s own companion object
+    // when `Outer` itself has no such member (implicit companion
+    // forwarding) — so a companion's members belong in `Outer`'s own
+    // completion list too. Companion detection and range-disambiguation
+    // mirror `resolve_companion_member` (`resolver/resolve.rs`) exactly, the
+    // established pattern elsewhere in this codebase for the identical
+    // question: `detail` matched as a `"companion"` TOKEN, not a prefix or
+    // substring, since a modifier or an annotation on its own line can
+    // precede the keywords (`private companion object`, `@JvmStatic` above
+    // it) and a comment can even split the two words apart; and `container`
+    // alone can't identify a companion's members either, for the same
+    // same-name reason as above — Kotlin gives every anonymous companion the
+    // literal name "Companion", so two unrelated classes' companions in one
+    // file share that container string.
+    let companions: Vec<&SymbolEntry> = symbols
+        .iter()
+        .filter(|s| s.container.as_deref() == Some(inner_name))
+        .filter(|s| range_encloses(type_symbol.range, s.range))
+        .filter(|s| {
+            s.kind == SymbolKind::OBJECT
+                && s.detail
+                    .split_whitespace()
+                    .any(|token| token == "companion")
+        })
+        .collect();
+
     symbols
         .iter()
         .filter(|symbol| {
-            let start = symbol.range.start;
-            let starts_after = start.line > type_start.line
-                || (start.line == type_start.line && start.character > type_start.character);
-            let starts_before = start.line < type_end.line
-                || (start.line == type_end.line && start.character < type_end.character);
-            starts_after && starts_before
+            (symbol.container.as_deref() == Some(inner_name)
+                && range_encloses(type_symbol.range, symbol.range))
+                || companions.iter().any(|companion| {
+                    symbol.container.as_deref() == Some(companion.name.as_str())
+                        && range_encloses(companion.range, symbol.range)
+                })
         })
         .filter(|symbol| symbol.visibility != Visibility::Private)
         .map(|symbol| completion_item_for_nested_symbol(indexer, symbol, file_uri, caller))

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -994,7 +994,10 @@ fn pos_tuple(p: tower_lsp::lsp_types::Position) -> (u32, u32) {
 }
 
 /// Whether `outer` fully contains `inner` (start ≤ start and end ≥ end).
-fn range_encloses(outer: tower_lsp::lsp_types::Range, inner: tower_lsp::lsp_types::Range) -> bool {
+pub(crate) fn range_encloses(
+    outer: tower_lsp::lsp_types::Range,
+    inner: tower_lsp::lsp_types::Range,
+) -> bool {
     pos_tuple(outer.start) <= pos_tuple(inner.start) && pos_tuple(inner.end) <= pos_tuple(outer.end)
 }
 

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -2352,6 +2352,223 @@ fn cross_file_type_subst_multi_class_same_file() {
     );
 }
 
+/// Regression: `symbols_from_nested_type`'s "declared inside `type_name`'s range"
+/// membership check has no depth limit — a member declared inside a *nested*
+/// type's own body (e.g. `Success.userData`, several lines inside
+/// `MainActivityUiState`'s outer braces) still counts as textually "inside"
+/// `MainActivityUiState`'s range, so it leaked into the sealed interface's own
+/// member list. That, in turn, leaked into every OTHER sealed subtype's
+/// *inherited*-member completion via `walk_hierarchy` — so a `Loading`-typed
+/// (smart-cast-narrowed) receiver offered `Success`'s own `userData` and
+/// `extra()`, both of which are compile errors if selected.
+#[test]
+fn sealed_subtype_member_completion_does_not_leak_sibling_subtype_members() {
+    let idx = Indexer::new();
+    let file_uri = uri("/MainActivityUiState.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         sealed interface MainActivityUiState {\n\
+         \x20 data object Loading : MainActivityUiState\n\
+         \x20 data class Success(val userData: String) : MainActivityUiState {\n\
+         \x20   fun extra() = userData\n\
+         \x20 }\n\
+         \x20 val shared: Boolean get() = true\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Loading", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        !labels.contains(&"userData"),
+        "Loading must not inherit sibling subtype Success's own member: {labels:?}"
+    );
+    assert!(
+        !labels.contains(&"extra"),
+        "Loading must not inherit sibling subtype Success's own method: {labels:?}"
+    );
+    assert!(
+        !labels.contains(&"copy"),
+        "Loading must not inherit sibling subtype Success's synthesized copy(): {labels:?}"
+    );
+    assert!(
+        labels.contains(&"shared"),
+        "Loading must still inherit the sealed interface's own direct member: {labels:?}"
+    );
+}
+
+/// Companion regression to the one above: a nested type is a legitimate direct
+/// member of its enclosing type when the receiver IS the enclosing type's own
+/// name (`MainActivityUiState.Success` / `.Loading` are valid Kotlin — nested
+/// type references, not instance member access). The depth-restriction fix
+/// must not make a type exclude *itself* just because its own range trivially
+/// satisfies "is inside a nested type's range" against its own entry.
+#[test]
+fn nested_type_completion_still_lists_sibling_nested_types_by_enclosing_type_name() {
+    let idx = Indexer::new();
+    let file_uri = uri("/MainActivityUiState.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         sealed interface MainActivityUiState {\n\
+         \x20 data object Loading : MainActivityUiState\n\
+         \x20 data class Success(val userData: String) : MainActivityUiState\n\
+         }",
+    );
+    let items = complete_dot(&idx, "MainActivityUiState", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"Loading"),
+        "MainActivityUiState.Loading is a valid nested-type reference: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"Success"),
+        "MainActivityUiState.Success is a valid nested-type reference: {labels:?}"
+    );
+}
+
+/// Regression: Kotlin resolves `Outer.member` through `Outer`'s own companion
+/// object when `Outer` has no such member itself (implicit companion
+/// forwarding) — a very common idiom, doubly so paired with sealed
+/// hierarchies (factory functions / constants on the companion). An earlier,
+/// range-containment-based version of the sibling-subtype-leak fix above
+/// treated a companion object as just another nested container type and
+/// blanket-excluded its members from the enclosing class's own completion,
+/// breaking this. The `container`-based implementation must special-case
+/// companion forwarding explicitly, since `copy.container` is the companion's
+/// own name ("Companion"/a named companion), not the enclosing class's.
+#[test]
+fn companion_object_members_still_appear_on_enclosing_type_completion() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Widget.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         class Widget {\n\
+         \x20 companion object {\n\
+         \x20   fun create(): Widget = Widget()\n\
+         \x20   val DEFAULT_ID: Int = 0\n\
+         \x20 }\n\
+         \x20 fun instanceMethod() {}\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Widget", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"create"),
+        "Widget.create() forwards through the companion object: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"DEFAULT_ID"),
+        "Widget.DEFAULT_ID forwards through the companion object: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"instanceMethod"),
+        "Widget's own direct member must still appear: {labels:?}"
+    );
+}
+
+/// Regression (Copilot review on the fix above): companion detection used
+/// `detail.starts_with("companion object")`, which misses a modifier or
+/// annotation ahead of the keywords — a `private companion object` (or
+/// `@JvmStatic` on the line above) would not be recognized as a companion at
+/// all, silently dropping its members from the enclosing class's completion.
+#[test]
+fn companion_object_members_forward_despite_a_visibility_modifier() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Widget.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         class Widget {\n\
+         \x20 private companion object {\n\
+         \x20   fun create(): Widget = Widget()\n\
+         \x20 }\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Widget", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"create"),
+        "a modifier ahead of 'companion object' must not hide companion forwarding: {labels:?}"
+    );
+}
+
+/// Regression (Copilot review on the fix above): Kotlin gives every anonymous
+/// `companion object { }` the same implicit name ("Companion"), so two
+/// unrelated classes in the same file each have a companion literally named
+/// "Companion" — their members share that same `container` string. Folding a
+/// companion's members in by container-NAME match alone (without also
+/// checking which specific companion instance a member's range belongs to)
+/// would leak one class's companion members into a completely different
+/// class's completion.
+#[test]
+fn companion_object_forwarding_does_not_leak_across_classes_sharing_the_implicit_name() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Widgets.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         class Alpha {\n\
+         \x20 companion object {\n\
+         \x20   fun alphaOnly(): Alpha = Alpha()\n\
+         \x20 }\n\
+         }\n\
+         class Beta {\n\
+         \x20 companion object {\n\
+         \x20   fun betaOnly(): Beta = Beta()\n\
+         \x20 }\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Alpha", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"alphaOnly"),
+        "Alpha's own companion member must still forward: {labels:?}"
+    );
+    assert!(
+        !labels.contains(&"betaOnly"),
+        "Beta's companion (same implicit 'Companion' name) must not leak into Alpha's completion: {labels:?}"
+    );
+}
+
+/// Regression (Copilot review): `container` stores only the immediate
+/// parent's simple NAME, not a unique identity — two different nested types
+/// sharing a simple name in one file (`A.Config` and `B.Config`) would have
+/// their members merged by a container-name-only check. `type_symbol` is
+/// already the one specific instance the outer lookup resolved to, so the
+/// membership check must also confirm a candidate's range falls inside that
+/// SPECIFIC instance's own range, not just any same-named one.
+#[test]
+fn same_named_nested_types_in_different_classes_do_not_merge_members() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Configs.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         class A {\n\
+         \x20 class Config {\n\
+         \x20   val fromA = 1\n\
+         \x20 }\n\
+         }\n\
+         class B {\n\
+         \x20 class Config {\n\
+         \x20   val fromB = 2\n\
+         \x20 }\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Config", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    // Whichever `Config` instance the bare-name lookup resolves to, it must
+    // offer that instance's own member and never the OTHER one's — merging
+    // them would suggest a member that doesn't exist on the resolved type.
+    let has_a = labels.contains(&"fromA");
+    let has_b = labels.contains(&"fromB");
+    assert!(
+        has_a != has_b,
+        "expected exactly one of A.Config/B.Config's own members, not both (merged) or neither: {labels:?}"
+    );
+}
+
 #[test]
 fn is_screaming_snake_cases() {
     assert!(is_screaming_snake("MAX_SIZE"));


### PR DESCRIPTION
## Summary

Two real bugs found live-testing against nowinandroid's `MainActivityViewModel.kt` — reported by the user as "when I delete imports, there is no diagnostics again" and "when statement is getting offered imports in quick actions, which isn't right".

1. **Missing-import diagnostic silently skips `Type.CONSTANT` references.** Deleting the `DarkThemeConfig` import (still referenced only via `DarkThemeConfig.FOLLOW_SYSTEM` inside a `when` branch) produced zero diagnostics. `collect_candidates` (`missing_import_diagnostics.rs`) only ever inspected `type_identifier` nodes for bare-class detection — but tree-sitter-kotlin only emits `type_identifier` in type-annotation positions; a class/object/enum used as the root of an expression-position navigation (`Type.member`) parses as a plain `simple_identifier`, indistinguishable in *kind* from an ordinary lowercase variable reference. Fixed by also treating a capitalized `simple_identifier` at the root of a `navigation_expression` as a candidate (gated on capitalization + "not already qualified", matching the existing `type_identifier` handling's philosophy).

2. **"Import 'X'" quick-fix misfires on the when-exhaustiveness diagnostic.** `missing_import_actions` identified "one of ours" purely by `diagnostic.source == "kmp-lsp"` — a string shared by *every* diagnostic producer in this LSP — then blindly parsed the message as `'Name' is ...`. `fill_when`'s non-exhaustive-`when` diagnostic (`"'when' is missing branches: ..."`) also starts with a quoted word, so it parsed as flagged name `"when"` — and real JAR symbols coincidentally named `when` (Kotlin compiler internals) gave `fqns_for_name` a real FQN to offer, producing a nonsensical "Import 'when'" quick-fix attached to the exhaustiveness diagnostic. Fixed by tagging the missing-import diagnostic with a `code` (`"missing-import"`) and filtering on that instead of the shared `source` string.

## Test plan
- [x] New regression tests (TDD — confirmed red before the fix, green after): `flags_an_unimported_enum_constant_used_as_navigation_root`, `no_diagnostic_for_an_imported_enum_constant_used_as_navigation_root`, `no_import_action_for_a_foreign_diagnostic_that_starts_with_a_quoted_importable_name`
- [x] Verified end-to-end against the actual file that triggered the report: `kmp-lsp diagnose` on nowinandroid's `MainActivityViewModel.kt` with the `DarkThemeConfig` import deleted — before the fix: no diagnostics; after: `59:17 [warning]: 'DarkThemeConfig' is not imported and not in scope`
- [x] `cargo fmt --check`, `cargo clippy --bin kmp-lsp --tests` clean
- [x] `cargo test --bin kmp-lsp`: 1684 passed (1681 baseline + 3 new), 0 failed
- [x] Full integration suites (`lsp_smoke`, `cli_check`, `cli_complete`, `cli_diagnose`, `cli_refs`, `swift_grammar`): all pass