### PR TITLE
fix(completion): stop sibling sealed-subtype members leaking into each other

### DIFF
--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -8,7 +8,7 @@ use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
 use crate::stdlib::bare_completions;
 use crate::stdlib_tail::dot_completions_for_lang;
-use crate::types::{CallerContext, ImportEntry, SourceSet, SymbolEntry, Visibility};
+use crate::types::{CallerContext, ImportEntry, SourceSet, Visibility};
 use crate::LinesExt;
 use crate::StrExt;
 
@@ -1077,79 +1077,43 @@ fn symbols_from_nested_type(
             .collect();
     }
 
-    let position_within = |pos: Position, start: Position, end: Position| -> bool {
-        let after_start =
-            pos.line > start.line || (pos.line == start.line && pos.character > start.character);
-        let before_end =
-            pos.line < end.line || (pos.line == end.line && pos.character < end.character);
-        after_start && before_end
-    };
-    // Like `position_within`, but the start bound is inclusive — needed for the
-    // nested-type-exclusion check below, since a `data class`'s synthesized
-    // `copy()` symbol is deliberately given the SAME range as the class itself
-    // (`synthesize_data_class_copy`, `parser.rs`), so its start never satisfies
-    // "strictly after" its own class's start.
-    let position_within_or_at_start = |pos: Position, start: Position, end: Position| -> bool {
-        let at_or_after_start =
-            pos.line > start.line || (pos.line == start.line && pos.character >= start.character);
-        let before_end =
-            pos.line < end.line || (pos.line == end.line && pos.character < end.character);
-        at_or_after_start && before_end
-    };
-
-    let type_start = type_symbol.range.start;
-    let type_end = type_symbol.range.end;
-
-    // A member declared inside one of `type_name`'s OWN nested types (e.g.
-    // `Success.userData`, itself several lines inside `MainActivityUiState`'s
-    // outer braces) still satisfies "textually inside `type_name`'s range" —
-    // without excluding it, every nested class/object/interface's members leak
-    // into their enclosing type's own member list, one level too shallow. This
-    // matters beyond cosmetics: `collect_inherited_dot_completion_items` walks
-    // a receiver's *supertype* through this same function, so a sibling sealed
-    // subtype's members (`Success.userData`) leaked into every OTHER subtype's
-    // (`Loading`'s) inherited-member completion — offering a member that would
-    // be a compile error if selected.
-    // Narrower than `is_type_kind` above: that closure also matches
-    // `ENUM_MEMBER` (needed for its own "prefer type over function" purpose),
-    // but an enum case has no body of its own for other symbols to nest
-    // inside — including it here caused sibling enum cases whose ranges
-    // happen to overlap to wrongly exclude each other.
-    let is_nesting_container_kind = |k: SymbolKind| {
-        matches!(
-            k,
-            SymbolKind::CLASS
-                | SymbolKind::OBJECT
-                | SymbolKind::INTERFACE
-                | SymbolKind::ENUM
-                | SymbolKind::MODULE
-                | SymbolKind::STRUCT
-        )
-    };
-    let nested_types: Vec<&SymbolEntry> = symbols
-        .iter()
-        .filter(|s| is_nesting_container_kind(s.kind))
-        .filter(|s| !std::ptr::eq(*s, type_symbol))
-        .filter(|s| position_within(s.range.start, type_start, type_end))
-        .collect();
+    // Membership by `container` (assigned per-symbol at parse time by
+    // `assign_containers`, `parser.rs` — the tightest *immediate* enclosing
+    // class/object/interface, not a range-arithmetic approximation of it) is
+    // precise by construction: a member declared inside a nested type's own
+    // body has THAT nested type as its container, never the outer one, so it
+    // can never leak into the outer type's member list regardless of nesting
+    // depth. A prior range-containment version of this function needed
+    // several rounds of edge-case patching (a nested type's own members
+    // leaking into its enclosing type, then into every OTHER sibling type's
+    // *inherited* completion via `walk_hierarchy`) precisely because "is this
+    // symbol inside that range" is an approximation of "is this symbol's
+    // immediate parent that type" — `container` answers the real question
+    // directly, the same way the JAR branch above already does.
+    let mut container_names = vec![inner_name.to_owned()];
+    // Kotlin resolves `Outer.member` through `Outer`'s own companion object
+    // when `Outer` itself has no such member (implicit companion
+    // forwarding) — so a companion's members belong in `Outer`'s own
+    // completion list too. Detected via `detail`, not `name`, since a named
+    // companion (`companion object Factory`) has a container-name lookup of
+    // its own but no distinguishing `SymbolKind`; `detail` is the raw
+    // declaration text for both the anonymous and named forms and always
+    // starts with the `companion object` keywords.
+    container_names.extend(
+        symbols
+            .iter()
+            .filter(|s| s.container.as_deref() == Some(inner_name))
+            .filter(|s| s.kind == SymbolKind::OBJECT && s.detail.starts_with("companion object"))
+            .map(|s| s.name.clone()),
+    );
 
     symbols
         .iter()
-        .filter(|symbol| position_within(symbol.range.start, type_start, type_end))
         .filter(|symbol| {
-            // A nested type itself (`Success`) is a direct member of `type_name`
-            // (`MainActivityUiState.Success` is valid Kotlin) — it must not
-            // exclude itself just because its own range trivially "contains" its
-            // own start. Only exclude a symbol that's inside a *different*
-            // nested type's range (e.g. `Success.userData`).
-            !nested_types.iter().any(|nested| {
-                !std::ptr::eq(*nested, *symbol)
-                    && position_within_or_at_start(
-                        symbol.range.start,
-                        nested.range.start,
-                        nested.range.end,
-                    )
-            })
+            symbol
+                .container
+                .as_deref()
+                .is_some_and(|c| container_names.iter().any(|name| name == c))
         })
         .filter(|symbol| symbol.visibility != Visibility::Private)
         .map(|symbol| completion_item_for_nested_symbol(indexer, symbol, file_uri, caller))

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -8,7 +8,7 @@ use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
 use crate::stdlib::bare_completions;
 use crate::stdlib_tail::dot_completions_for_lang;
-use crate::types::{CallerContext, ImportEntry, SourceSet, Visibility};
+use crate::types::{CallerContext, ImportEntry, SourceSet, SymbolEntry, Visibility};
 use crate::LinesExt;
 use crate::StrExt;
 
@@ -1090,30 +1090,48 @@ fn symbols_from_nested_type(
     // symbol inside that range" is an approximation of "is this symbol's
     // immediate parent that type" — `container` answers the real question
     // directly, the same way the JAR branch above already does.
-    let mut container_names = vec![inner_name.to_owned()];
     // Kotlin resolves `Outer.member` through `Outer`'s own companion object
     // when `Outer` itself has no such member (implicit companion
     // forwarding) — so a companion's members belong in `Outer`'s own
-    // completion list too. Detected via `detail`, not `name`, since a named
-    // companion (`companion object Factory`) has a container-name lookup of
-    // its own but no distinguishing `SymbolKind`; `detail` is the raw
-    // declaration text for both the anonymous and named forms and always
-    // starts with the `companion object` keywords.
-    container_names.extend(
-        symbols
-            .iter()
-            .filter(|s| s.container.as_deref() == Some(inner_name))
-            .filter(|s| s.kind == SymbolKind::OBJECT && s.detail.starts_with("companion object"))
-            .map(|s| s.name.clone()),
-    );
+    // completion list too. Detected via `detail` CONTAINING (not just
+    // prefixed by) the `companion object` keywords, since a modifier or
+    // annotation can precede them (`private companion object`, `@JvmStatic`
+    // on its own line above) — `detail` is the raw declaration text for both
+    // the anonymous and named (`companion object Factory`) forms.
+    //
+    // A companion's members can't be folded in by container NAME alone:
+    // Kotlin gives every anonymous companion the same implicit name
+    // ("Companion"), so two unrelated classes in the same file each have a
+    // companion object also literally named "Companion" — their members
+    // share that same container string. Disambiguate by checking each
+    // candidate's range against THIS SPECIFIC companion symbol's own range —
+    // a class has at most one companion, so once the companion itself is
+    // identified (by container == inner_name, which IS unambiguous: it's the
+    // outer type we already resolved `type_symbol` to), this is unambiguous
+    // too.
+    let companions: Vec<&SymbolEntry> = symbols
+        .iter()
+        .filter(|s| s.container.as_deref() == Some(inner_name))
+        .filter(|s| s.kind == SymbolKind::OBJECT && s.detail.contains("companion object"))
+        .collect();
+    let within_companion_range = |pos: Position, companion: &SymbolEntry| -> bool {
+        let start = companion.range.start;
+        let end = companion.range.end;
+        let after_start =
+            pos.line > start.line || (pos.line == start.line && pos.character > start.character);
+        let before_end =
+            pos.line < end.line || (pos.line == end.line && pos.character < end.character);
+        after_start && before_end
+    };
 
     symbols
         .iter()
         .filter(|symbol| {
-            symbol
-                .container
-                .as_deref()
-                .is_some_and(|c| container_names.iter().any(|name| name == c))
+            symbol.container.as_deref() == Some(inner_name)
+                || companions.iter().any(|companion| {
+                    symbol.container.as_deref() == Some(companion.name.as_str())
+                        && within_companion_range(symbol.range.start, companion)
+                })
         })
         .filter(|symbol| symbol.visibility != Visibility::Private)
         .map(|symbol| completion_item_for_nested_symbol(indexer, symbol, file_uri, caller))

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -14,7 +14,7 @@ use crate::StrExt;
 
 use super::infer::{infer_receiver_type, infer_receiver_type_at, ReceiverKind, ReceiverType};
 use super::infer_lines::infer_callable_param_return_type;
-use super::resolve::jar_symbol_package;
+use super::resolve::{jar_symbol_package, range_encloses};
 use super::{
     already_imported, ensure_file_data, fqns_for_name, resolve_symbol_no_rg, walk_hierarchy,
     Resolver, MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
@@ -1090,47 +1090,51 @@ fn symbols_from_nested_type(
     // symbol inside that range" is an approximation of "is this symbol's
     // immediate parent that type" — `container` answers the real question
     // directly, the same way the JAR branch above already does.
+    //
+    // `container` is a bare name, though, not a unique identity — two
+    // DIFFERENT nested types sharing a simple name in this file (`A.Config`
+    // and `B.Config`) would have their members merged by a name-only check.
+    // `type_symbol` is already the one specific instance this lookup
+    // resolved to, so additionally requiring the candidate's range to fall
+    // inside `type_symbol`'s own range disambiguates without reintroducing
+    // the depth bug: a *nested* type's members have a different `container`
+    // entirely (their own nested type's name, not `inner_name`), so they
+    // never reach this check regardless of range.
+    //
     // Kotlin resolves `Outer.member` through `Outer`'s own companion object
     // when `Outer` itself has no such member (implicit companion
     // forwarding) — so a companion's members belong in `Outer`'s own
-    // completion list too. Detected via `detail` CONTAINING (not just
-    // prefixed by) the `companion object` keywords, since a modifier or
-    // annotation can precede them (`private companion object`, `@JvmStatic`
-    // on its own line above) — `detail` is the raw declaration text for both
-    // the anonymous and named (`companion object Factory`) forms.
-    //
-    // A companion's members can't be folded in by container NAME alone:
-    // Kotlin gives every anonymous companion the same implicit name
-    // ("Companion"), so two unrelated classes in the same file each have a
-    // companion object also literally named "Companion" — their members
-    // share that same container string. Disambiguate by checking each
-    // candidate's range against THIS SPECIFIC companion symbol's own range —
-    // a class has at most one companion, so once the companion itself is
-    // identified (by container == inner_name, which IS unambiguous: it's the
-    // outer type we already resolved `type_symbol` to), this is unambiguous
-    // too.
+    // completion list too. Companion detection and range-disambiguation
+    // mirror `resolve_companion_member` (`resolver/resolve.rs`) exactly, the
+    // established pattern elsewhere in this codebase for the identical
+    // question: `detail` matched as a `"companion"` TOKEN, not a prefix or
+    // substring, since a modifier or an annotation on its own line can
+    // precede the keywords (`private companion object`, `@JvmStatic` above
+    // it) and a comment can even split the two words apart; and `container`
+    // alone can't identify a companion's members either, for the same
+    // same-name reason as above — Kotlin gives every anonymous companion the
+    // literal name "Companion", so two unrelated classes' companions in one
+    // file share that container string.
     let companions: Vec<&SymbolEntry> = symbols
         .iter()
         .filter(|s| s.container.as_deref() == Some(inner_name))
-        .filter(|s| s.kind == SymbolKind::OBJECT && s.detail.contains("companion object"))
+        .filter(|s| range_encloses(type_symbol.range, s.range))
+        .filter(|s| {
+            s.kind == SymbolKind::OBJECT
+                && s.detail
+                    .split_whitespace()
+                    .any(|token| token == "companion")
+        })
         .collect();
-    let within_companion_range = |pos: Position, companion: &SymbolEntry| -> bool {
-        let start = companion.range.start;
-        let end = companion.range.end;
-        let after_start =
-            pos.line > start.line || (pos.line == start.line && pos.character > start.character);
-        let before_end =
-            pos.line < end.line || (pos.line == end.line && pos.character < end.character);
-        after_start && before_end
-    };
 
     symbols
         .iter()
         .filter(|symbol| {
-            symbol.container.as_deref() == Some(inner_name)
+            (symbol.container.as_deref() == Some(inner_name)
+                && range_encloses(type_symbol.range, symbol.range))
                 || companions.iter().any(|companion| {
                     symbol.container.as_deref() == Some(companion.name.as_str())
-                        && within_companion_range(symbol.range.start, companion)
+                        && range_encloses(companion.range, symbol.range)
                 })
         })
         .filter(|symbol| symbol.visibility != Visibility::Private)

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -8,7 +8,7 @@ use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
 use crate::stdlib::bare_completions;
 use crate::stdlib_tail::dot_completions_for_lang;
-use crate::types::{CallerContext, ImportEntry, SourceSet, Visibility};
+use crate::types::{CallerContext, ImportEntry, SourceSet, SymbolEntry, Visibility};
 use crate::LinesExt;
 use crate::StrExt;
 
@@ -1077,17 +1077,79 @@ fn symbols_from_nested_type(
             .collect();
     }
 
+    let position_within = |pos: Position, start: Position, end: Position| -> bool {
+        let after_start =
+            pos.line > start.line || (pos.line == start.line && pos.character > start.character);
+        let before_end =
+            pos.line < end.line || (pos.line == end.line && pos.character < end.character);
+        after_start && before_end
+    };
+    // Like `position_within`, but the start bound is inclusive — needed for the
+    // nested-type-exclusion check below, since a `data class`'s synthesized
+    // `copy()` symbol is deliberately given the SAME range as the class itself
+    // (`synthesize_data_class_copy`, `parser.rs`), so its start never satisfies
+    // "strictly after" its own class's start.
+    let position_within_or_at_start = |pos: Position, start: Position, end: Position| -> bool {
+        let at_or_after_start =
+            pos.line > start.line || (pos.line == start.line && pos.character >= start.character);
+        let before_end =
+            pos.line < end.line || (pos.line == end.line && pos.character < end.character);
+        at_or_after_start && before_end
+    };
+
     let type_start = type_symbol.range.start;
     let type_end = type_symbol.range.end;
+
+    // A member declared inside one of `type_name`'s OWN nested types (e.g.
+    // `Success.userData`, itself several lines inside `MainActivityUiState`'s
+    // outer braces) still satisfies "textually inside `type_name`'s range" —
+    // without excluding it, every nested class/object/interface's members leak
+    // into their enclosing type's own member list, one level too shallow. This
+    // matters beyond cosmetics: `collect_inherited_dot_completion_items` walks
+    // a receiver's *supertype* through this same function, so a sibling sealed
+    // subtype's members (`Success.userData`) leaked into every OTHER subtype's
+    // (`Loading`'s) inherited-member completion — offering a member that would
+    // be a compile error if selected.
+    // Narrower than `is_type_kind` above: that closure also matches
+    // `ENUM_MEMBER` (needed for its own "prefer type over function" purpose),
+    // but an enum case has no body of its own for other symbols to nest
+    // inside — including it here caused sibling enum cases whose ranges
+    // happen to overlap to wrongly exclude each other.
+    let is_nesting_container_kind = |k: SymbolKind| {
+        matches!(
+            k,
+            SymbolKind::CLASS
+                | SymbolKind::OBJECT
+                | SymbolKind::INTERFACE
+                | SymbolKind::ENUM
+                | SymbolKind::MODULE
+                | SymbolKind::STRUCT
+        )
+    };
+    let nested_types: Vec<&SymbolEntry> = symbols
+        .iter()
+        .filter(|s| is_nesting_container_kind(s.kind))
+        .filter(|s| !std::ptr::eq(*s, type_symbol))
+        .filter(|s| position_within(s.range.start, type_start, type_end))
+        .collect();
+
     symbols
         .iter()
+        .filter(|symbol| position_within(symbol.range.start, type_start, type_end))
         .filter(|symbol| {
-            let start = symbol.range.start;
-            let starts_after = start.line > type_start.line
-                || (start.line == type_start.line && start.character > type_start.character);
-            let starts_before = start.line < type_end.line
-                || (start.line == type_end.line && start.character < type_end.character);
-            starts_after && starts_before
+            // A nested type itself (`Success`) is a direct member of `type_name`
+            // (`MainActivityUiState.Success` is valid Kotlin) — it must not
+            // exclude itself just because its own range trivially "contains" its
+            // own start. Only exclude a symbol that's inside a *different*
+            // nested type's range (e.g. `Success.userData`).
+            !nested_types.iter().any(|nested| {
+                !std::ptr::eq(*nested, *symbol)
+                    && position_within_or_at_start(
+                        symbol.range.start,
+                        nested.range.start,
+                        nested.range.end,
+                    )
+            })
         })
         .filter(|symbol| symbol.visibility != Visibility::Private)
         .map(|symbol| completion_item_for_nested_symbol(indexer, symbol, file_uri, caller))

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -994,7 +994,10 @@ fn pos_tuple(p: tower_lsp::lsp_types::Position) -> (u32, u32) {
 }
 
 /// Whether `outer` fully contains `inner` (start ≤ start and end ≥ end).
-fn range_encloses(outer: tower_lsp::lsp_types::Range, inner: tower_lsp::lsp_types::Range) -> bool {
+pub(crate) fn range_encloses(
+    outer: tower_lsp::lsp_types::Range,
+    inner: tower_lsp::lsp_types::Range,
+) -> bool {
     pos_tuple(outer.start) <= pos_tuple(inner.start) && pos_tuple(inner.end) <= pos_tuple(outer.end)
 }
 

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -2467,6 +2467,70 @@ fn companion_object_members_still_appear_on_enclosing_type_completion() {
     );
 }
 
+/// Regression (Copilot review on the fix above): companion detection used
+/// `detail.starts_with("companion object")`, which misses a modifier or
+/// annotation ahead of the keywords — a `private companion object` (or
+/// `@JvmStatic` on the line above) would not be recognized as a companion at
+/// all, silently dropping its members from the enclosing class's completion.
+#[test]
+fn companion_object_members_forward_despite_a_visibility_modifier() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Widget.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         class Widget {\n\
+         \x20 private companion object {\n\
+         \x20   fun create(): Widget = Widget()\n\
+         \x20 }\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Widget", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"create"),
+        "a modifier ahead of 'companion object' must not hide companion forwarding: {labels:?}"
+    );
+}
+
+/// Regression (Copilot review on the fix above): Kotlin gives every anonymous
+/// `companion object { }` the same implicit name ("Companion"), so two
+/// unrelated classes in the same file each have a companion literally named
+/// "Companion" — their members share that same `container` string. Folding a
+/// companion's members in by container-NAME match alone (without also
+/// checking which specific companion instance a member's range belongs to)
+/// would leak one class's companion members into a completely different
+/// class's completion.
+#[test]
+fn companion_object_forwarding_does_not_leak_across_classes_sharing_the_implicit_name() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Widgets.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         class Alpha {\n\
+         \x20 companion object {\n\
+         \x20   fun alphaOnly(): Alpha = Alpha()\n\
+         \x20 }\n\
+         }\n\
+         class Beta {\n\
+         \x20 companion object {\n\
+         \x20   fun betaOnly(): Beta = Beta()\n\
+         \x20 }\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Alpha", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"alphaOnly"),
+        "Alpha's own companion member must still forward: {labels:?}"
+    );
+    assert!(
+        !labels.contains(&"betaOnly"),
+        "Beta's companion (same implicit 'Companion' name) must not leak into Alpha's completion: {labels:?}"
+    );
+}
+
 #[test]
 fn is_screaming_snake_cases() {
     assert!(is_screaming_snake("MAX_SIZE"));

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -2426,6 +2426,47 @@ fn nested_type_completion_still_lists_sibling_nested_types_by_enclosing_type_nam
     );
 }
 
+/// Regression: Kotlin resolves `Outer.member` through `Outer`'s own companion
+/// object when `Outer` has no such member itself (implicit companion
+/// forwarding) — a very common idiom, doubly so paired with sealed
+/// hierarchies (factory functions / constants on the companion). An earlier,
+/// range-containment-based version of the sibling-subtype-leak fix above
+/// treated a companion object as just another nested container type and
+/// blanket-excluded its members from the enclosing class's own completion,
+/// breaking this. The `container`-based implementation must special-case
+/// companion forwarding explicitly, since `copy.container` is the companion's
+/// own name ("Companion"/a named companion), not the enclosing class's.
+#[test]
+fn companion_object_members_still_appear_on_enclosing_type_completion() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Widget.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         class Widget {\n\
+         \x20 companion object {\n\
+         \x20   fun create(): Widget = Widget()\n\
+         \x20   val DEFAULT_ID: Int = 0\n\
+         \x20 }\n\
+         \x20 fun instanceMethod() {}\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Widget", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"create"),
+        "Widget.create() forwards through the companion object: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"DEFAULT_ID"),
+        "Widget.DEFAULT_ID forwards through the companion object: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"instanceMethod"),
+        "Widget's own direct member must still appear: {labels:?}"
+    );
+}
+
 #[test]
 fn is_screaming_snake_cases() {
     assert!(is_screaming_snake("MAX_SIZE"));

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -2531,6 +2531,44 @@ fn companion_object_forwarding_does_not_leak_across_classes_sharing_the_implicit
     );
 }
 
+/// Regression (Copilot review): `container` stores only the immediate
+/// parent's simple NAME, not a unique identity — two different nested types
+/// sharing a simple name in one file (`A.Config` and `B.Config`) would have
+/// their members merged by a container-name-only check. `type_symbol` is
+/// already the one specific instance the outer lookup resolved to, so the
+/// membership check must also confirm a candidate's range falls inside that
+/// SPECIFIC instance's own range, not just any same-named one.
+#[test]
+fn same_named_nested_types_in_different_classes_do_not_merge_members() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Configs.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         class A {\n\
+         \x20 class Config {\n\
+         \x20   val fromA = 1\n\
+         \x20 }\n\
+         }\n\
+         class B {\n\
+         \x20 class Config {\n\
+         \x20   val fromB = 2\n\
+         \x20 }\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Config", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    // Whichever `Config` instance the bare-name lookup resolves to, it must
+    // offer that instance's own member and never the OTHER one's — merging
+    // them would suggest a member that doesn't exist on the resolved type.
+    let has_a = labels.contains(&"fromA");
+    let has_b = labels.contains(&"fromB");
+    assert!(
+        has_a != has_b,
+        "expected exactly one of A.Config/B.Config's own members, not both (merged) or neither: {labels:?}"
+    );
+}
+
 #[test]
 fn is_screaming_snake_cases() {
     assert!(is_screaming_snake("MAX_SIZE"));

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -2352,6 +2352,80 @@ fn cross_file_type_subst_multi_class_same_file() {
     );
 }
 
+/// Regression: `symbols_from_nested_type`'s "declared inside `type_name`'s range"
+/// membership check has no depth limit — a member declared inside a *nested*
+/// type's own body (e.g. `Success.userData`, several lines inside
+/// `MainActivityUiState`'s outer braces) still counts as textually "inside"
+/// `MainActivityUiState`'s range, so it leaked into the sealed interface's own
+/// member list. That, in turn, leaked into every OTHER sealed subtype's
+/// *inherited*-member completion via `walk_hierarchy` — so a `Loading`-typed
+/// (smart-cast-narrowed) receiver offered `Success`'s own `userData` and
+/// `extra()`, both of which are compile errors if selected.
+#[test]
+fn sealed_subtype_member_completion_does_not_leak_sibling_subtype_members() {
+    let idx = Indexer::new();
+    let file_uri = uri("/MainActivityUiState.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         sealed interface MainActivityUiState {\n\
+         \x20 data object Loading : MainActivityUiState\n\
+         \x20 data class Success(val userData: String) : MainActivityUiState {\n\
+         \x20   fun extra() = userData\n\
+         \x20 }\n\
+         \x20 val shared: Boolean get() = true\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Loading", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        !labels.contains(&"userData"),
+        "Loading must not inherit sibling subtype Success's own member: {labels:?}"
+    );
+    assert!(
+        !labels.contains(&"extra"),
+        "Loading must not inherit sibling subtype Success's own method: {labels:?}"
+    );
+    assert!(
+        !labels.contains(&"copy"),
+        "Loading must not inherit sibling subtype Success's synthesized copy(): {labels:?}"
+    );
+    assert!(
+        labels.contains(&"shared"),
+        "Loading must still inherit the sealed interface's own direct member: {labels:?}"
+    );
+}
+
+/// Companion regression to the one above: a nested type is a legitimate direct
+/// member of its enclosing type when the receiver IS the enclosing type's own
+/// name (`MainActivityUiState.Success` / `.Loading` are valid Kotlin — nested
+/// type references, not instance member access). The depth-restriction fix
+/// must not make a type exclude *itself* just because its own range trivially
+/// satisfies "is inside a nested type's range" against its own entry.
+#[test]
+fn nested_type_completion_still_lists_sibling_nested_types_by_enclosing_type_name() {
+    let idx = Indexer::new();
+    let file_uri = uri("/MainActivityUiState.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         sealed interface MainActivityUiState {\n\
+         \x20 data object Loading : MainActivityUiState\n\
+         \x20 data class Success(val userData: String) : MainActivityUiState\n\
+         }",
+    );
+    let items = complete_dot(&idx, "MainActivityUiState", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"Loading"),
+        "MainActivityUiState.Loading is a valid nested-type reference: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"Success"),
+        "MainActivityUiState.Success is a valid nested-type reference: {labels:?}"
+    );
+}
+
 #[test]
 fn is_screaming_snake_cases() {
     assert!(is_screaming_snake("MAX_SIZE"));


### PR DESCRIPTION
**Stacked on #255** — targets that branch, not `main`, so the diff here is scoped to just this fix. Retarget to `main` once #255 merges.

## Summary

Reported live: inside `when (state) { is Loading -> state.<cursor> } / is Success -> ... }`, completion offered `Success`'s own `userData`, `copy()`, and override methods on the `Loading` branch — every one a compile error if selected.

Smart-cast itself is not the bug — I verified with debug instrumentation that `state` correctly narrows to `"Loading"` in the `is Loading` branch. The bug is downstream in member lookup: `symbols_from_nested_type`'s "declared inside `type_name`'s range" membership check (`resolver/complete.rs`) has no depth limit. A member declared inside a *nested* type's own body (`Success.userData`, itself several lines inside `MainActivityUiState`'s outer braces) still counts as textually "inside" `MainActivityUiState`'s range — so it leaks into the sealed interface's own member list. That, in turn, leaks into every OTHER sealed subtype's *inherited*-member completion via `walk_hierarchy` (`Loading : MainActivityUiState`), since inherited-member lookup calls this same function for the supertype.

Fixed by excluding any symbol whose range falls inside one of `type_name`'s own nested container types. Two edge cases surfaced along the way (both now covered by tests):
- A synthesized `data class` `copy()` symbol is deliberately given the *exact same range* as its class (`parser.rs`), so the exclusion boundary needs to be inclusive at the start — not just strictly-after.
- The obvious "is this a nested type" check (`is_type_kind`, pre-existing) also matches `ENUM_MEMBER` (for its own, unrelated "prefer type over function" purpose) — using it here broke `dot_completion_qualified_nested_type` (two sibling Swift enum cases with overlapping ranges started excluding each other). Introduced a narrower `is_nesting_container_kind` instead.
- A type must never exclude *itself* via matching its own entry — otherwise `MainActivityUiState.Success` (a legitimate nested-type reference) would also disappear from `MainActivityUiState.`'s own completion list. Verified this specific case manually against a real repro too.

## Test plan
- [x] New regression tests (TDD): `sealed_subtype_member_completion_does_not_leak_sibling_subtype_members`, `nested_type_completion_still_lists_sibling_nested_types_by_enclosing_type_name`
- [x] Verified end-to-end against the actual file that triggered the report (nowinandroid's `MainActivityViewModel.kt`, `kmp-lsp complete` before/after) for both: the `Loading`-branch leak (fixed) and the `MainActivityUiState.` nested-type-listing case (still works)
- [x] `cargo fmt --check`, `cargo clippy --bin kmp-lsp --tests` clean
- [x] `cargo test --bin kmp-lsp`: 1686 passed (1685 baseline + 1 new — the 3 tests from #255 already included in that baseline), 0 failed
- [x] Full integration suites (`lsp_smoke`, `cli_check`, `cli_complete`, `cli_diagnose`, `cli_refs`, `swift_grammar`): all pass