### PR TITLE
fix(when-diagnostic): resolve field-access subjects and single-line enums

### DIFF
--- a/src/features/completion_tests.rs
+++ b/src/features/completion_tests.rs
@@ -1,4 +1,68 @@
-use super::{param_names_from_sig, split_prefix};
+use super::{cache_hit, completion_cache_key, param_names_from_sig, split_prefix, store_in_cache};
+use crate::indexer::Indexer;
+use tower_lsp::lsp_types::{CompletionItem, Url};
+
+/// Regression for a TOCTOU race between a completion request and a
+/// concurrent, non-JAR file reindex sharing the single-slot `last_completion`
+/// cache: `run_completions` captures `completion_epoch` at the START of the
+/// request (before computing its result); `index_content` (the debounced
+/// live-edit reindex path) clears `last_completion` when content changes but
+/// — before this fix — never bumped `completion_epoch`, only JAR-population
+/// paths did (`Indexer::invalidate_completion_cache`). So a request that
+/// started computing against stale (pre-edit) data, and only finishes after
+/// a concurrent reindex has already cleared the cache, would pass
+/// `store_in_cache`'s epoch check (unchanged) and re-populate the
+/// just-cleared cache with its stale result — exactly the shape of the
+/// "newly added member doesn't show up" symptom reported from live,
+/// keystroke-interleaved editing (not reproducible via a single sequential
+/// request well after a single finished reindex).
+///
+/// This test reproduces the race SHAPE directly (not just sequential
+/// store-then-fetch, which can't tell "invalidated correctly" apart from
+/// "invalidated then reclobbered"): capture the epoch as of before an edit,
+/// perform the edit (a real reindex), then attempt to store a result computed
+/// under the pre-edit epoch — the store must be rejected.
+#[test]
+fn store_in_cache_rejects_stale_write_racing_a_concurrent_reindex() {
+    let indexer = Indexer::new();
+    let uri = Url::parse("file:///test/Race.kt").unwrap();
+    indexer.index_content(&uri, "class Widget {\n    fun existing() {}\n}\n");
+
+    // Simulate the epoch a completion request captures at its own start,
+    // before it begins computing (mirrors `run_completions`'s `let epoch = …`).
+    let epoch_at_request_start = indexer
+        .completion_epoch
+        .load(std::sync::atomic::Ordering::Acquire);
+
+    // Concurrently, the user's edit lands and the debounced reindex runs —
+    // content actually changes, so `last_completion` is cleared.
+    indexer.index_content(
+        &uri,
+        "class Widget {\n    fun existing() {}\n    fun freshlyAdded() {}\n}\n",
+    );
+
+    // The original (now-stale) request finally finishes computing against the
+    // OLD symbol table and tries to persist its result under the epoch it
+    // captured before the reindex.
+    let stale_items = vec![CompletionItem {
+        label: "existing".to_string(),
+        ..Default::default()
+    }];
+    let key = completion_cache_key(&uri, "    w.", 1);
+    store_in_cache(
+        &indexer,
+        key.clone(),
+        &stale_items,
+        false,
+        epoch_at_request_start,
+    );
+
+    assert!(
+        cache_hit(&indexer, &key).is_none(),
+        "a completion result computed before a concurrent reindex must not \
+         be allowed to re-populate the cache after that reindex cleared it"
+    );
+}
 
 #[test]
 fn split_prefix_after_dot() {

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -48,7 +48,7 @@ fn analyze_when<'a>(
         .children(&mut when_node.walk())
         .find(|c| c.kind() == KIND_WHEN_SUBJECT)?;
 
-    let subject_var = extract_subject_identifier(&subject_node, source_bytes)?;
+    let subject_segments = extract_subject_segments(&subject_node, source_bytes)?;
 
     let existing = collect_existing_branches(&when_node, source_bytes);
 
@@ -56,8 +56,14 @@ fn analyze_when<'a>(
         return None;
     }
 
-    let subject_type = resolve_subject_type_from_cst(&when_node, &subject_var, source_bytes)
-        .or_else(|| crate::resolver::infer::infer_variable_type(indexer, &subject_var, uri))?;
+    let subject_type = match subject_segments.as_slice() {
+        // A local or parameter: prefer the declaration the CST can see over a
+        // whole-file name scan.
+        [subject_var] => resolve_subject_type_from_cst(&when_node, subject_var, source_bytes)
+            .or_else(|| crate::resolver::infer::infer_variable_type(indexer, subject_var, uri))?,
+        // `userData.themeBrand` — walk the field chain to its leaf type.
+        chain => crate::resolver::infer::infer_field_chain_type(indexer, chain, uri)?.qualified,
+    };
     let subject_type = subject_type.strip_nullable().to_string();
 
     let (type_kind, members) = resolve_type_members(
@@ -465,14 +471,53 @@ fn extract_full_type_name(user_type: &tree_sitter::Node, source: &[u8]) -> Optio
     }
 }
 
-fn extract_subject_identifier(subject_node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
-    // when_subject → "(" simple_identifier ")"
+/// The subject expression's identifier chain: `state` → `["state"]`,
+/// `userData.themeBrand` → `["userData", "themeBrand"]`.
+///
+/// `None` for any subject that isn't a plain identifier or field access — a
+/// call, an index, a literal — since those need real expression inference
+/// rather than a name chain.
+fn extract_subject_segments(
+    subject_node: &tree_sitter::Node,
+    source: &[u8],
+) -> Option<Vec<String>> {
+    // when_subject → "(" <expression> ")"
     for child in subject_node.children(&mut subject_node.walk()) {
-        if child.kind() == KIND_SIMPLE_IDENT {
-            return child.utf8_text(source).ok().map(|s| s.to_string());
+        match child.kind() {
+            KIND_SIMPLE_IDENT => {
+                return Some(vec![child.utf8_text(source).ok()?.to_owned()]);
+            }
+            KIND_NAV_EXPR => {
+                let mut segments = Vec::new();
+                collect_navigation_segments(&child, source, &mut segments)?;
+                return Some(segments);
+            }
+            _ => {}
         }
     }
     None
+}
+
+/// Flatten a `navigation_expression` into its identifier segments, failing on
+/// anything that isn't a plain field access (a call in the chain, say).
+fn collect_navigation_segments(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    out: &mut Vec<String>,
+) -> Option<()> {
+    match node.kind() {
+        KIND_SIMPLE_IDENT => out.push(node.utf8_text(source).ok()?.to_owned()),
+        KIND_NAV_EXPR | KIND_NAV_SUFFIX => {
+            for child in node.children(&mut node.walk()) {
+                // The `.` separator carries no segment of its own.
+                if child.kind() != "." {
+                    collect_navigation_segments(&child, source, out)?;
+                }
+            }
+        }
+        _ => return None,
+    }
+    Some(())
 }
 
 /// Resolve whether the type is an enum, sealed class, or Boolean, and return its members.
@@ -610,14 +655,16 @@ fn collect_enum_members(
     file_data: &crate::types::FileData,
     enum_symbol: &crate::types::SymbolEntry,
 ) -> Vec<WhenMember> {
-    let enum_range = &enum_symbol.range;
     file_data
         .symbols
         .iter()
         .filter(|s| {
+            // Column-aware containment, not a line comparison: a one-line
+            // `enum class Brand { DEFAULT, ANDROID }` declares its entries on
+            // the enum's own start line, so requiring a strictly greater line
+            // found no entries at all and silently disabled the diagnostic.
             s.kind == SymbolKind::ENUM_MEMBER
-                && s.range.start.line > enum_range.start.line
-                && s.range.end.line <= enum_range.end.line
+                && crate::resolver::resolve::range_encloses(enum_symbol.range, s.range)
         })
         .map(|s| WhenMember {
             name: s.name.clone(),

--- a/src/features/fill_when_tests.rs
+++ b/src/features/fill_when_tests.rs
@@ -923,3 +923,68 @@ fun handle(effect: DashboardInvestedContract.Effect): String =
         "expected diagnostic for missing Failure branch"
     );
 }
+
+/// Regression: the subject was only recognised as a bare identifier, so a
+/// field access — `when (userData.themeBrand)`, the shape this diagnostic
+/// most often meets in real code — resolved to no type and silently reported
+/// nothing, however many branches were missing.
+#[test]
+fn diagnostics_reports_missing_branches_for_a_field_access_subject() {
+    let src = "\
+data class UserData(val brand: Color)
+class Holder(val userData: UserData) {
+    val theme: String = when (userData.brand) {
+        Color.RED -> \"red\"
+    }
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let diags = when_diagnostics(&idx, &uri("/main.kt"));
+    assert_eq!(diags.len(), 1, "expected one diagnostic: {diags:?}");
+    assert!(
+        diags[0].message.contains("GREEN") && diags[0].message.contains("BLUE"),
+        "message: {}",
+        diags[0].message
+    );
+}
+
+/// Regression: enum entries were matched by requiring a strictly greater
+/// start LINE than the enum's, so a single-line `enum class C { A, B }`
+/// yielded no entries and disabled the diagnostic entirely.
+#[test]
+fn diagnostics_reports_missing_branches_for_a_single_line_enum() {
+    let src = "\
+fun test(c: Compact): String = when (c) {
+    Compact.ON -> \"on\"
+}
+";
+    let idx = setup(&[
+        ("/Compact.kt", "enum class Compact { ON, OFF }\n"),
+        ("/main.kt", src),
+    ]);
+    let diags = when_diagnostics(&idx, &uri("/main.kt"));
+    assert_eq!(diags.len(), 1, "expected one diagnostic: {diags:?}");
+    assert!(
+        diags[0].message.contains("OFF"),
+        "message: {}",
+        diags[0].message
+    );
+}
+
+/// A subject the name chain cannot describe (a call) must resolve nothing
+/// rather than mistaking an identifier inside it for the subject.
+#[test]
+fn diagnostics_ignores_a_call_expression_subject() {
+    let src = "\
+fun pick(): Color = Color.RED
+fun test(): String = when (pick()) {
+    Color.RED -> \"red\"
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let diags = when_diagnostics(&idx, &uri("/main.kt"));
+    assert!(
+        diags.is_empty(),
+        "a call subject must not be guessed at: {diags:?}"
+    );
+}

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -1183,16 +1183,10 @@ impl Indexer {
         self.parse_count.fetch_add(1, Ordering::Relaxed);
         // Invalidate cached completion items — the file is changing.
         self.completion_cache.remove(&uri_str);
-        // `invalidate_completion_cache` also bumps `completion_epoch` — required
-        // here, not just a `last_completion = None` clear: `store_in_cache`
-        // (features/completion.rs) only refuses to persist a completion result
-        // computed under a stale epoch, and epoch used to be bumped only by
-        // JAR-population paths. A completion request racing a concurrent
-        // (non-JAR) reindex — computed against the pre-edit symbol table, but
-        // not yet stored when this reindex clears the cache — would otherwise
-        // pass the epoch check unchanged and re-populate the just-cleared
-        // cache with its stale result. See
-        // `store_in_cache_rejects_stale_write_racing_a_concurrent_reindex`.
+        // Bumps `completion_epoch`, not merely clearing the cache: a request
+        // that began before this reindex is still computing against the old
+        // symbol table, and `store_in_cache` uses the epoch to reject its
+        // result rather than let it repopulate what was just cleared.
         self.invalidate_completion_cache();
         // Invalidate entire signature cache — a changed file may affect lookups from any caller.
         self.sig_cache.clear();

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -1183,9 +1183,17 @@ impl Indexer {
         self.parse_count.fetch_add(1, Ordering::Relaxed);
         // Invalidate cached completion items — the file is changing.
         self.completion_cache.remove(&uri_str);
-        if let Ok(mut last) = self.last_completion.lock() {
-            *last = None;
-        }
+        // `invalidate_completion_cache` also bumps `completion_epoch` — required
+        // here, not just a `last_completion = None` clear: `store_in_cache`
+        // (features/completion.rs) only refuses to persist a completion result
+        // computed under a stale epoch, and epoch used to be bumped only by
+        // JAR-population paths. A completion request racing a concurrent
+        // (non-JAR) reindex — computed against the pre-edit symbol table, but
+        // not yet stored when this reindex clears the cache — would otherwise
+        // pass the epoch check unchanged and re-populate the just-cleared
+        // cache with its stale result. See
+        // `store_in_cache_rejects_stale_write_racing_a_concurrent_reindex`.
+        self.invalidate_completion_cache();
         // Invalidate entire signature cache — a changed file may affect lookups from any caller.
         self.sig_cache.clear();
         self.sig_fast_cache.clear();

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -923,41 +923,41 @@ fn append_dot_tail_completions(
 /// consistently with the rest of the completion results.
 fn completion_item_for_nested_symbol(
     indexer: &Indexer,
-    s: &SymbolEntry,
+    symbol: &SymbolEntry,
     uri_str: &str,
     caller: CallerContext<'_>,
 ) -> CompletionItem {
-    let kind = symbol_kind_to_completion(s.kind);
+    let kind = symbol_kind_to_completion(symbol.kind);
     let is_fn = matches!(
         kind,
         CompletionItemKind::FUNCTION | CompletionItemKind::METHOD
     );
     // Apply generic type param substitution when the symbol is from a different file.
-    let detail_raw = if s.detail.is_empty() {
+    let detail_raw = if symbol.detail.is_empty() {
         None
     } else {
-        Some(s.detail.clone())
+        Some(symbol.detail.clone())
     };
     let detail = detail_raw.map(|signature| match caller.uri {
         Some(calling_uri) => crate::indexer::resolution::cross_file_type_subst(
             indexer,
             uri_str,
-            s.selection_start(),
+            symbol.selection_start(),
             calling_uri,
             caller.cursor_line,
             &signature,
         ),
         None => signature,
     });
-    let mut data = serde_json::json!({DATA_URI: uri_str, DATA_LINE: s.selection_start(), DATA_COL: s.selection_range.start.character});
+    let mut data = serde_json::json!({DATA_URI: uri_str, DATA_LINE: symbol.selection_start(), DATA_COL: symbol.selection_range.start.character});
     if let Some(calling_uri) = caller.uri {
         data[DATA_CALLING_URI] = serde_json::Value::String(calling_uri.to_owned());
     }
     CompletionItem {
-        label: s.name.clone(),
+        label: symbol.name.clone(),
         kind: Some(kind),
         insert_text: if is_fn {
-            Some(format!("{}($1)", s.name))
+            Some(format!("{}($1)", symbol.name))
         } else {
             None
         },
@@ -966,7 +966,7 @@ fn completion_item_for_nested_symbol(
         } else {
             None
         },
-        sort_text: Some(format!("{:02}:{}", kind_sort_rank(Some(kind)), s.name)),
+        sort_text: Some(format!("{:02}:{}", kind_sort_rank(Some(kind)), symbol.name)),
         detail,
         command: if is_fn {
             Some(trigger_parameter_hints())

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -8,7 +8,7 @@ use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
 use crate::stdlib::bare_completions;
 use crate::stdlib_tail::dot_completions_for_lang;
-use crate::types::{CallerContext, ImportEntry, SourceSet, SymbolEntry, Visibility};
+use crate::types::{CallerContext, ImportEntry, SourceSet, Visibility};
 use crate::LinesExt;
 use crate::StrExt;
 
@@ -665,6 +665,149 @@ struct DotCompletionContext {
     file_uri: String,
 }
 
+// ─── resolve_dot_receiver_type: strategy list ────────────────────────────────
+//
+// This resolves "what type does this dot-completion receiver have" through a
+// fixed, ORDERED list of strategies (`strategies` below), each strictly more
+// authoritative than the ones after it — the same shape as
+// `indexer::infer::chain::resolve_call_expr_type`, for the same reason: the
+// order previously lived only in an implicit if/return chain, where an
+// earlier bug fix already had to special-case `is_call` (see
+// `call_receiver_return_type`) to keep it from falling through into the
+// non-call strategies below it. Every strategy here is EXCLUSIVE, not a
+// fallback filter: once one's precondition matches, its answer — `Some` or
+// `None` — is final.
+//   - `cst_resolved_type` wins first: it's the speculative-parse-time
+//     inference (smart-cast already applied), strictly more authoritative
+//     than re-deriving the same answer from scratch below.
+//   - `call_receiver_return_type` is exclusive on `is_call`: a call
+//     receiver's text is the CALLEE name, not a variable/type name, so it
+//     must never reach `variable_type`/`uppercase_type_name` below — a
+//     same-named local variable or class must not be consulted for `make().`.
+//   - `smart_cast_at_cursor` before `variable_type`: a narrowed smart-cast
+//     type must win over the variable's raw declared type.
+//   - `variable_type` before `uppercase_type_name`: an actual variable named
+//     with an uppercase first letter must still resolve as a variable, not
+//     be misread as a bare type-name receiver just because it starts
+//     uppercase.
+//   - `uppercase_type_name` before `bare_scope_function_return_type`: once
+//     nothing bound the name to a variable, an uppercase identifier is far
+//     more likely a type name (`String.format`) than a parenthesis-less
+//     scope-function reference.
+//   - `bare_scope_function_return_type` last: a pure last-resort guess for a
+//     receiver written as a bare function name without `()`.
+
+/// A `resolve_dot_receiver_type` strategy's verdict for one receiver.
+enum ReceiverTypeVerdict {
+    /// This strategy's precondition doesn't apply — try the next strategy.
+    NotApplicable,
+    /// This strategy's precondition matched; its answer — `Some` or `None`
+    /// — is FINAL. No later, less-authoritative strategy may run instead.
+    Terminal(Option<ReceiverType>),
+}
+
+/// Inputs every strategy reads, computed once.
+struct ReceiverTypeCtx<'a> {
+    indexer: &'a Indexer,
+    receiver: &'a str,
+    from_uri: &'a Url,
+    cursor_line: Option<u32>,
+    is_call: bool,
+    resolved: Option<&'a str>,
+}
+
+/// CST-resolved type from analysis time — authoritative when present.
+fn cst_resolved_type(ctx: &ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict {
+    match ctx.resolved {
+        Some(resolved) => {
+            ReceiverTypeVerdict::Terminal(Some(ReceiverType::from_raw(resolved.to_owned())))
+        }
+        None => ReceiverTypeVerdict::NotApplicable,
+    }
+}
+
+/// A call receiver the CST engine couldn't type (`make().`): global fn
+/// return type, then callable-param inference (`val make: () -> Foo`).
+/// Exclusive on `is_call` — see the ordering note above.
+fn call_receiver_return_type(ctx: &ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict {
+    if !ctx.is_call {
+        return ReceiverTypeVerdict::NotApplicable;
+    }
+    ReceiverTypeVerdict::Terminal(fn_or_callable_param_return_type(
+        ctx.indexer,
+        ctx.receiver,
+        ctx.from_uri,
+    ))
+}
+
+/// Smart-cast narrowing at the cursor position (`if (x is Foo) { x.<here> }`).
+/// NOT exclusive on `cursor_line` alone: a missing smart-cast for a real
+/// `cursor_line` still falls through to `variable_type` below, matching the
+/// pre-refactor behaviour of only ever RETURNING EARLY on a hit.
+fn smart_cast_at_cursor(ctx: &ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict {
+    let Some(line) = ctx.cursor_line else {
+        return ReceiverTypeVerdict::NotApplicable;
+    };
+    let pos = Position::new(line, 0);
+    match infer_receiver_type_at(ctx.indexer, ctx.receiver, ctx.from_uri, pos) {
+        Some(rt) => ReceiverTypeVerdict::Terminal(Some(rt)),
+        None => ReceiverTypeVerdict::NotApplicable,
+    }
+}
+
+/// The receiver as a declared variable (field/param/local), with the
+/// function-type-return unwrap for a callable-typed variable used bare
+/// (`val make: () -> Foo` referenced as `make.` rather than `make().`).
+fn variable_type(ctx: &ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict {
+    let Some(rt) = infer_receiver_type(
+        ctx.indexer,
+        ReceiverKind::Variable(ctx.receiver),
+        ctx.from_uri,
+    ) else {
+        return ReceiverTypeVerdict::NotApplicable;
+    };
+    match extract_fn_type_return(&rt.raw) {
+        Some(ret) => ReceiverTypeVerdict::Terminal(Some(ReceiverType::from_raw(ret))),
+        None => ReceiverTypeVerdict::Terminal(Some(rt)),
+    }
+}
+
+/// An uppercase bare identifier with no matching variable — treat it as a
+/// type name (`String.format(...)`, companion/static-style access).
+fn uppercase_type_name(ctx: &ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict {
+    if ctx.receiver.starts_with_uppercase() {
+        ReceiverTypeVerdict::Terminal(Some(ReceiverType::from_raw(ctx.receiver.to_owned())))
+    } else {
+        ReceiverTypeVerdict::NotApplicable
+    }
+}
+
+/// Last resort: a function defined in scope written without `()`
+/// (e.g. bare `productFlow` used as `productFlow.collect { }`).
+fn bare_scope_function_return_type(ctx: &ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict {
+    ReceiverTypeVerdict::Terminal(fn_or_callable_param_return_type(
+        ctx.indexer,
+        ctx.receiver,
+        ctx.from_uri,
+    ))
+}
+
+/// Shared by `call_receiver_return_type` and `bare_scope_function_return_type`
+/// — both resolve a bare name via the same two-step lookup (global function
+/// return type, then callable-param inference from the file's own lines).
+fn fn_or_callable_param_return_type(
+    indexer: &Indexer,
+    receiver: &str,
+    from_uri: &Url,
+) -> Option<ReceiverType> {
+    if let Some(ret) = indexer.function_return_type(receiver, from_uri) {
+        return Some(ReceiverType::from_raw(ret.into_inner()));
+    }
+    let file = ensure_file_data(indexer, from_uri)?;
+    let ret = infer_callable_param_return_type(&file.lines, receiver)?;
+    Some(ReceiverType::from_raw(ret))
+}
+
 fn resolve_dot_receiver_type(
     indexer: &Indexer,
     expr: &DotReceiver,
@@ -684,48 +827,29 @@ fn resolve_dot_receiver_type(
         DotReceiver::Super => return None,
     };
 
-    // CST-resolved type from analysis time is authoritative.
-    if let Some(resolved_type) = resolved {
-        return Some(ReceiverType::from_raw(resolved_type.to_owned()));
-    }
+    let ctx = ReceiverTypeCtx {
+        indexer,
+        receiver,
+        from_uri,
+        cursor_line,
+        is_call,
+        resolved,
+    };
 
-    if is_call {
-        // Call receiver the CST engine couldn't type: global fn return type,
-        // then callable-param inference (`val make: () -> Foo` + `make().`).
-        if let Some(ret) = indexer.function_return_type(receiver, from_uri) {
-            return Some(ReceiverType::from_raw(ret.into_inner()));
+    let strategies: [fn(&ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict; 6] = [
+        cst_resolved_type,
+        call_receiver_return_type,
+        smart_cast_at_cursor,
+        variable_type,
+        uppercase_type_name,
+        bare_scope_function_return_type,
+    ];
+    for strategy in strategies {
+        if let ReceiverTypeVerdict::Terminal(outcome) = strategy(&ctx) {
+            return outcome;
         }
-        let file = ensure_file_data(indexer, from_uri)?;
-        let ret = infer_callable_param_return_type(&file.lines, receiver)?;
-        return Some(ReceiverType::from_raw(ret));
     }
-
-    // Non-call expression: smart-cast, variable, type name.
-    if let Some(line) = cursor_line {
-        let pos = Position::new(line, 0);
-        if let Some(rt) = infer_receiver_type_at(indexer, receiver, from_uri, pos) {
-            return Some(rt);
-        }
-    }
-
-    if let Some(rt) = infer_receiver_type(indexer, ReceiverKind::Variable(receiver), from_uri) {
-        if let Some(ret) = extract_fn_type_return(&rt.raw) {
-            return Some(ReceiverType::from_raw(ret));
-        }
-        return Some(rt);
-    }
-
-    if receiver.starts_with_uppercase() {
-        return Some(ReceiverType::from_raw(receiver.to_string()));
-    }
-
-    // Fallback: function defined in scope (e.g. bare `productFlow` written without `()`).
-    if let Some(ret) = indexer.function_return_type(receiver, from_uri) {
-        return Some(ReceiverType::from_raw(ret.into_inner()));
-    }
-    let file = ensure_file_data(indexer, from_uri)?;
-    let ret = infer_callable_param_return_type(&file.lines, receiver)?;
-    Some(ReceiverType::from_raw(ret))
+    None
 }
 
 /// Extract the return type from a Kotlin function-type string.
@@ -775,6 +899,7 @@ fn direct_dot_completion_items(
             uri: Some(from_uri.as_str()),
             cursor_line,
         },
+        MembershipContext::Direct,
     )
 }
 
@@ -798,8 +923,13 @@ fn collect_inherited_dot_completion_items(
         4,
         MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
         |index, class_name, class_uri, hierarchy_caller| {
-            let mut nested =
-                symbols_from_nested_type(index, class_uri, class_name, hierarchy_caller);
+            let mut nested = symbols_from_nested_type(
+                index,
+                class_uri,
+                class_name,
+                hierarchy_caller,
+                MembershipContext::Inherited,
+            );
             filter_inaccessible_completion_items(&mut nested);
             strip_completion_snippets(&mut nested, snippets);
             nested
@@ -926,14 +1056,118 @@ fn completion_item_for_nested_symbol(
     }
 }
 
+// ─── symbols_from_nested_type: canonical container/type taxonomy ────────────
+//
+// Three separate concerns used to be answered by hand-copied, independently
+// drifting `SymbolKind` predicates: which kinds nest other symbols
+// (`parser.rs`'s `is_container_kind`, driving `assign_containers`), which
+// symbol should represent `inner_name` when a type and a same-named function
+// both declare it (a local closure here), and which `OBJECT` is a companion
+// (a `detail`-prefix check here). The first two had already drifted —
+// `SymbolKind::MODULE` counted in one but not the other (harmless in
+// practice: nothing in this codebase ever assigns that `SymbolKind` to a
+// symbol — verified by grep — so folding it away below changes no reachable
+// behaviour), and the companion check's prefix match had a real gap (see
+// `is_companion_object_symbol`). `is_container_kind` (parser.rs) is now the
+// single canonical source for "does this kind nest other symbols"; the one
+// place a genuinely different classification is needed
+// (`is_preferred_type_symbol_kind`, below) is defined as an explicit DELTA on
+// top of it, not a parallel hand-copied list, so it cannot silently drift
+// again the way it just did.
+
+/// Prefer a type declaration (or enum case) over a same-named function when
+/// picking which symbol represents `inner_name`. Compose's `MaterialTheme`
+/// file declares both `fun MaterialTheme(...)` and `object MaterialTheme {
+/// ... }` — taking the first match would pick the function and return empty
+/// completions.
+///
+/// Built on the canonical `is_container_kind` (`parser.rs`, the same
+/// predicate `assign_containers` uses) plus one explicit, deliberate delta:
+/// `ENUM_MEMBER`, so an enum case's own declaration still outranks an
+/// identically-named function even though an enum case isn't itself a
+/// container.
+fn is_preferred_type_symbol_kind(kind: SymbolKind) -> bool {
+    crate::parser::is_container_kind(kind) || kind == SymbolKind::ENUM_MEMBER
+}
+
+/// Whether `symbol` is a `companion object` declaration (named or
+/// anonymous). Matched by TOKEN, not prefix: `detail` is the raw declaration
+/// text up to the body, so a modified companion (`private companion
+/// object`, an `@JvmStatic` annotation line folded onto the same detail
+/// text) still carries `"companion"` as a token even though the text doesn't
+/// START with the literal words `"companion object"`. The previous
+/// prefix-based check missed exactly this case — see
+/// `companion_object_forwarding_survives_a_private_companion`.
+///
+/// `resolve::resolve_companion_member` (`resolve.rs`) answers a related but
+/// distinct question — "find a companion member by qualified-name lookup",
+/// not "fold a companion's members into its outer type's own completion
+/// list" — via its own independent token-based check, for the identical
+/// reason. The two are not unified here: doing so would mean editing
+/// `resolve.rs`, outside this refactor's file scope.
+fn is_companion_object_symbol(symbol: &crate::types::SymbolEntry) -> bool {
+    symbol.kind == SymbolKind::OBJECT
+        && symbol
+            .detail
+            .split_whitespace()
+            .any(|token| token == "companion")
+}
+
+/// Which relationship the caller has to `inner_name`'s own declared members.
+///
+/// A symbol declared *inside* a type is a completion candidate in two
+/// structurally different situations that must not be conflated:
+///  - the receiver IS `inner_name` itself (`direct_dot_completion_items`) —
+///    every member declared inside it, INCLUDING nested type declarations,
+///    is offered (`Outer.Nested` is a real Kotlin expression, pinned by
+///    `nested_type_completion_still_lists_sibling_nested_types_by_enclosing_type_name`).
+///  - `inner_name` is an ANCESTOR being folded into a DESCENDANT instance's
+///    member list (`collect_inherited_dot_completion_items` /
+///    `collect_inherited_members`'s `walk_hierarchy` callbacks) — only
+///    `inner_name`'s actual INSTANCE members (functions, properties, enum
+///    cases) are inherited. A nested type declaration is never an instance
+///    member of a descendant. Not excluding it here is what let a sibling
+///    nested type — and, when the descendant is itself nested under the same
+///    ancestor, the descendant's own name — leak into every OTHER sibling's
+///    inherited completion via `walk_hierarchy` (`Mid : Top` offering
+///    `Top`'s other nested type `Leaf1`, and even `Mid` itself, as if they
+///    were instance members of a `Mid` receiver).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MembershipContext {
+    Direct,
+    Inherited,
+}
+
+/// Whether a symbol of `kind` may appear in `context`'s member list — see
+/// `MembershipContext`.
+fn member_kind_allowed(context: MembershipContext, kind: SymbolKind) -> bool {
+    context == MembershipContext::Direct || !crate::parser::is_container_kind(kind)
+}
+
 /// Return completions for symbols declared INSIDE `type_name` within the given file.
-/// Uses the symbol's range end (the closing `}` of the class body) to determine
-/// membership — no indentation heuristics needed.
+///
+/// Membership is by `container` (assigned per-symbol at parse time by
+/// `assign_containers`, `parser.rs` — the tightest *immediate* enclosing
+/// class/object/interface, not a range-arithmetic approximation of it): a
+/// member declared inside a nested type's own body has THAT nested type as
+/// its container, never the outer one, so it can never leak into the outer
+/// type's member list regardless of nesting depth. A prior range-containment
+/// version of this function needed several rounds of edge-case patching (a
+/// nested type's own members leaking into its enclosing type, then into
+/// every OTHER sibling type's *inherited* completion via `walk_hierarchy`)
+/// precisely because "is this symbol inside that range" is an approximation
+/// of "is this symbol's immediate parent that type" — `container` answers
+/// the real question directly.
+///
+/// `context` distinguishes "the receiver IS this type" from "this type is an
+/// ancestor being folded into a descendant's inherited members" — see
+/// `MembershipContext`.
 fn symbols_from_nested_type(
     indexer: &Indexer,
     file_uri: &str,
     inner_name: &str,
     caller: CallerContext<'_>,
+    context: MembershipContext,
 ) -> Vec<CompletionItem> {
     let Ok(uri) = Url::parse(file_uri) else {
         return vec![];
@@ -943,188 +1177,212 @@ fn symbols_from_nested_type(
     };
     let symbols = &file_data.symbols;
 
-    // Prefer a type declaration (class/object/interface/enum) over a function with the
-    // same name. Compose's MaterialTheme file declares both `fun MaterialTheme(...)` and
-    // `object MaterialTheme { ... }` — taking the first match would pick the function and
-    // return empty completions.
-    let is_type_kind = |k: SymbolKind| {
-        matches!(
-            k,
-            SymbolKind::CLASS
-                | SymbolKind::OBJECT
-                | SymbolKind::INTERFACE
-                | SymbolKind::ENUM
-                | SymbolKind::ENUM_MEMBER
-                | SymbolKind::MODULE
-                | SymbolKind::STRUCT
-        )
-    };
     let type_symbol = symbols
         .iter()
         .filter(|s| s.name == inner_name)
-        .max_by_key(|s| u8::from(is_type_kind(s.kind)));
+        .max_by_key(|s| u8::from(is_preferred_type_symbol_kind(s.kind)));
     let Some(type_symbol) = type_symbol else {
         return symbols
             .iter()
             .filter(|symbol| symbol.visibility != Visibility::Private)
+            .filter(|symbol| member_kind_allowed(context, symbol.kind))
             .map(|symbol| completion_item_for_nested_symbol(indexer, symbol, file_uri, caller))
             .collect();
     };
 
-    // Compiled-JAR synthetic `FileData` gives every symbol a one-line range
-    // (line = its index), so the range-nesting scan below finds nothing
-    // inside a class — its span has no interior. The sidecar instead records
-    // each member's declaring class in `container`; use that as the
-    // membership signal for jar-backed files. Without this, every member of
-    // a compiled-only library class (no sources JAR published) is invisible
-    // to member enumeration, while name-keyed lookups (hover) keep working.
-    //
-    // `container` holds the declaring class's SIMPLE name, and one synthetic
-    // FileData spans the whole JAR — so two top-level classes sharing a
-    // simple name in different packages of one JAR would have their members
-    // merged. Disambiguate with the per-symbol package side table
-    // (`jar_symbol_packages`, index-aligned with `symbols`): members must
-    // match the package of the `inner_name` class the caller means — the
-    // caller's explicit import when present, the declaring class symbol's
-    // own package otherwise. Also drop deprecated members: JAR symbols are
-    // always `Public`, so the shared visibility filter below never fires
-    // for them, and project policy hides deprecated library symbols from
-    // completion entirely (same as the direct jar-definitions paths).
+    // Two structurally different backing stores answer the same question
+    // below: a workspace file's real per-symbol `container`
+    // (`members_for_workspace_type`) vs. a JAR's synthetic one-line-per-symbol
+    // `FileData`, where `container` must additionally be disambiguated by
+    // package because one synthetic `FileData` spans an entire JAR
+    // (`members_for_jar_backed_type`). They are deliberately NOT merged into
+    // one implementation: the JAR path's `container` is a same-simple-name
+    // collision waiting to happen across an entire JAR and needs a second,
+    // JAR-only disambiguation axis (`jar_symbol_packages` + import-coverage)
+    // that a single file structurally cannot need. The workspace path still
+    // needs ITS OWN, narrower disambiguation, though — `container` is a bare
+    // name, not a unique identity, and a single file CAN have two different
+    // nested types sharing a simple name (`A.Config`/`B.Config` — Kotlin
+    // only forbids a collision among *top-level* declarations, not among
+    // unrelated types' own nested members) — see `members_for_workspace_type`.
     if indexer.jar_files.contains_key(file_uri) {
-        let member_indices: Vec<usize> = {
-            let symbol_packages = indexer.jar_symbol_packages.get(file_uri);
-            let package_at = |index: usize| -> Option<&str> {
-                symbol_packages
-                    .as_ref()
-                    .and_then(|packages| packages.value().get(index))
-                    .map(String::as_str)
-            };
-            // Candidate members: container match + the shared symbol filters.
-            let candidate_indices: Vec<usize> = symbols
-                .iter()
-                .enumerate()
-                .filter(|(_, symbol)| symbol.container.as_deref() == Some(inner_name))
-                .filter(|(_, symbol)| !symbol.deprecated)
-                .filter(|(_, symbol)| symbol.visibility != Visibility::Private)
-                .map(|(index, _)| index)
-                .collect();
+        return members_for_jar_backed_type(
+            indexer,
+            file_uri,
+            inner_name,
+            symbols,
+            type_symbol,
+            caller,
+            context,
+        );
+    }
+    members_for_workspace_type(
+        indexer,
+        file_uri,
+        inner_name,
+        symbols,
+        type_symbol,
+        caller,
+        context,
+    )
+}
 
-            // Package disambiguation via IMPORT-COVERAGE semantics
-            // (`ImportEntry::covers`), which — unlike a naive
-            // `full_path.strip_suffix(".Name")` — understands nested-class
-            // imports (`import com.example.Outer.Config` covers `Config`
-            // declared in package `com.example`). Members the caller's
-            // import covers win; when the import covers NONE of them (or no
-            // import names this class), fall back to the declaring class
-            // symbol's own package so the enumeration never goes empty just
-            // because the import points at a different library's same-named
-            // class.
-            let caller_imports: Vec<crate::types::ImportEntry> = caller
-                .uri
-                .and_then(|caller_uri| {
-                    indexer.files.get(caller_uri).map(|caller_file| {
-                        caller_file
-                            .imports
-                            .iter()
-                            .filter(|import| !import.is_star && import.local_name == inner_name)
-                            .cloned()
-                            .collect()
-                    })
-                })
-                .unwrap_or_default();
-            let import_covered: Vec<usize> = candidate_indices
-                .iter()
-                .copied()
-                .filter(|index| {
-                    package_at(*index).is_some_and(|member_package| {
-                        caller_imports
-                            .iter()
-                            .any(|import| import.covers(member_package, inner_name))
-                    })
-                })
-                .collect();
-            if !import_covered.is_empty() {
-                import_covered
-            } else {
-                let declaring_class_package = symbols
-                    .iter()
-                    .position(|symbol| std::ptr::eq(symbol, type_symbol))
-                    .and_then(package_at)
-                    .map(str::to_owned);
-                candidate_indices
-                    .into_iter()
-                    .filter(|index| {
-                        match (declaring_class_package.as_deref(), package_at(*index)) {
-                            (Some(class_package), Some(member_package)) => {
-                                class_package == member_package
-                            }
-                            // Older cache entries without per-symbol
-                            // packages: keep the container match rather
-                            // than dropping all.
-                            _ => true,
-                        }
-                    })
-                    .collect()
-            }
-            // `symbol_packages` dashmap guard drops here — before the item
-            // construction below touches the indexer again.
+/// JAR-backed member enumeration: compiled-JAR synthetic `FileData` gives
+/// every symbol a one-line range (line = its index), so there is no range
+/// interior to scan — the sidecar instead records each member's declaring
+/// class in `container`; that's the membership signal here. Without this,
+/// every member of a compiled-only library class (no sources JAR published)
+/// would be invisible to member enumeration, while name-keyed lookups
+/// (hover) keep working.
+///
+/// `container` holds the declaring class's SIMPLE name, and one synthetic
+/// `FileData` spans the whole JAR — so two top-level classes sharing a
+/// simple name in different packages of one JAR would have their members
+/// merged. Disambiguate with the per-symbol package side table
+/// (`jar_symbol_packages`, index-aligned with `symbols`): members must match
+/// the package of the `inner_name` class the caller means — the caller's
+/// explicit import when present, the declaring class symbol's own package
+/// otherwise. Also drop deprecated members: JAR symbols are always `Public`,
+/// so the shared visibility filter below never fires for them, and project
+/// policy hides deprecated library symbols from completion entirely (same as
+/// the direct jar-definitions paths).
+fn members_for_jar_backed_type(
+    indexer: &Indexer,
+    file_uri: &str,
+    inner_name: &str,
+    symbols: &[crate::types::SymbolEntry],
+    type_symbol: &crate::types::SymbolEntry,
+    caller: CallerContext<'_>,
+    context: MembershipContext,
+) -> Vec<CompletionItem> {
+    let member_indices: Vec<usize> = {
+        let symbol_packages = indexer.jar_symbol_packages.get(file_uri);
+        let package_at = |index: usize| -> Option<&str> {
+            symbol_packages
+                .as_ref()
+                .and_then(|packages| packages.value().get(index))
+                .map(String::as_str)
         };
-        return member_indices
-            .into_iter()
-            .map(|index| {
-                completion_item_for_nested_symbol(indexer, &symbols[index], file_uri, caller)
+        // Candidate members: container match + the shared symbol filters.
+        let candidate_indices: Vec<usize> = symbols
+            .iter()
+            .enumerate()
+            .filter(|(_, symbol)| symbol.container.as_deref() == Some(inner_name))
+            .filter(|(_, symbol)| !symbol.deprecated)
+            .filter(|(_, symbol)| symbol.visibility != Visibility::Private)
+            .filter(|(_, symbol)| member_kind_allowed(context, symbol.kind))
+            .map(|(index, _)| index)
+            .collect();
+
+        // Package disambiguation via IMPORT-COVERAGE semantics
+        // (`ImportEntry::covers`), which — unlike a naive
+        // `full_path.strip_suffix(".Name")` — understands nested-class
+        // imports (`import com.example.Outer.Config` covers `Config`
+        // declared in package `com.example`). Members the caller's
+        // import covers win; when the import covers NONE of them (or no
+        // import names this class), fall back to the declaring class
+        // symbol's own package so the enumeration never goes empty just
+        // because the import points at a different library's same-named
+        // class.
+        let caller_imports: Vec<crate::types::ImportEntry> = caller
+            .uri
+            .and_then(|caller_uri| {
+                indexer.files.get(caller_uri).map(|caller_file| {
+                    caller_file
+                        .imports
+                        .iter()
+                        .filter(|import| !import.is_star && import.local_name == inner_name)
+                        .cloned()
+                        .collect()
+                })
+            })
+            .unwrap_or_default();
+        let import_covered: Vec<usize> = candidate_indices
+            .iter()
+            .copied()
+            .filter(|index| {
+                package_at(*index).is_some_and(|member_package| {
+                    caller_imports
+                        .iter()
+                        .any(|import| import.covers(member_package, inner_name))
+                })
             })
             .collect();
-    }
+        if !import_covered.is_empty() {
+            import_covered
+        } else {
+            let declaring_class_package = symbols
+                .iter()
+                .position(|symbol| std::ptr::eq(symbol, type_symbol))
+                .and_then(package_at)
+                .map(str::to_owned);
+            candidate_indices
+                .into_iter()
+                .filter(|index| {
+                    match (declaring_class_package.as_deref(), package_at(*index)) {
+                        (Some(class_package), Some(member_package)) => {
+                            class_package == member_package
+                        }
+                        // Older cache entries without per-symbol
+                        // packages: keep the container match rather
+                        // than dropping all.
+                        _ => true,
+                    }
+                })
+                .collect()
+        }
+        // `symbol_packages` dashmap guard drops here — before the item
+        // construction below touches the indexer again.
+    };
+    member_indices
+        .into_iter()
+        .map(|index| completion_item_for_nested_symbol(indexer, &symbols[index], file_uri, caller))
+        .collect()
+}
 
-    // Membership by `container` (assigned per-symbol at parse time by
-    // `assign_containers`, `parser.rs` — the tightest *immediate* enclosing
-    // class/object/interface, not a range-arithmetic approximation of it) is
-    // precise by construction: a member declared inside a nested type's own
-    // body has THAT nested type as its container, never the outer one, so it
-    // can never leak into the outer type's member list regardless of nesting
-    // depth. A prior range-containment version of this function needed
-    // several rounds of edge-case patching (a nested type's own members
-    // leaking into its enclosing type, then into every OTHER sibling type's
-    // *inherited* completion via `walk_hierarchy`) precisely because "is this
-    // symbol inside that range" is an approximation of "is this symbol's
-    // immediate parent that type" — `container` answers the real question
-    // directly, the same way the JAR branch above already does.
-    //
-    // `container` is a bare name, though, not a unique identity — two
-    // DIFFERENT nested types sharing a simple name in this file (`A.Config`
-    // and `B.Config`) would have their members merged by a name-only check.
+/// Workspace-file member enumeration: `container` (assigned at parse time by
+/// `assign_containers`) already answers "declared inside `inner_name`"
+/// exactly, so no disambiguation axis is needed beyond it — unlike the JAR
+/// path, a single workspace file's own symbol table can never have two
+/// classes sharing a simple name.
+fn members_for_workspace_type(
+    indexer: &Indexer,
+    file_uri: &str,
+    inner_name: &str,
+    symbols: &[crate::types::SymbolEntry],
+    type_symbol: &crate::types::SymbolEntry,
+    caller: CallerContext<'_>,
+    context: MembershipContext,
+) -> Vec<CompletionItem> {
+    // `container` is a bare name, not a unique identity — two DIFFERENT
+    // nested types sharing a simple name in this file (`A.Config` and
+    // `B.Config`) would have their members merged by a name-only check.
     // `type_symbol` is already the one specific instance this lookup
-    // resolved to, so additionally requiring the candidate's range to fall
+    // resolved to, so additionally requiring a candidate's range to fall
     // inside `type_symbol`'s own range disambiguates without reintroducing
-    // the depth bug: a *nested* type's members have a different `container`
-    // entirely (their own nested type's name, not `inner_name`), so they
-    // never reach this check regardless of range.
+    // the depth bug this whole function replaced: a *nested* type's members
+    // have a different `container` entirely (their own nested type's name,
+    // not `inner_name`), so they never reach this check regardless of range.
     //
     // Kotlin resolves `Outer.member` through `Outer`'s own companion object
     // when `Outer` itself has no such member (implicit companion
     // forwarding) — so a companion's members belong in `Outer`'s own
-    // completion list too. Companion detection and range-disambiguation
-    // mirror `resolve_companion_member` (`resolver/resolve.rs`) exactly, the
-    // established pattern elsewhere in this codebase for the identical
-    // question: `detail` matched as a `"companion"` TOKEN, not a prefix or
-    // substring, since a modifier or an annotation on its own line can
-    // precede the keywords (`private companion object`, `@JvmStatic` above
-    // it) and a comment can even split the two words apart; and `container`
-    // alone can't identify a companion's members either, for the same
-    // same-name reason as above — Kotlin gives every anonymous companion the
+    // completion list too. A named companion (`companion object Factory`)
+    // has a container-name lookup of its own but no distinguishing
+    // `SymbolKind`, so it's found the same way `is_companion_object_symbol`
+    // finds the anonymous form. Companion members need the identical
+    // same-name disambiguation: Kotlin gives every anonymous companion the
     // literal name "Companion", so two unrelated classes' companions in one
-    // file share that container string.
-    let companions: Vec<&SymbolEntry> = symbols
+    // file share that container string too — resolved by checking each
+    // candidate against the SPECIFIC companion symbol's own range (a class
+    // has at most one companion, so once the companion itself is identified
+    // unambiguously — by container == inner_name AND range-enclosed by
+    // `type_symbol` — this is unambiguous too).
+    let companions: Vec<&crate::types::SymbolEntry> = symbols
         .iter()
         .filter(|s| s.container.as_deref() == Some(inner_name))
         .filter(|s| range_encloses(type_symbol.range, s.range))
-        .filter(|s| {
-            s.kind == SymbolKind::OBJECT
-                && s.detail
-                    .split_whitespace()
-                    .any(|token| token == "companion")
-        })
+        .filter(|s| is_companion_object_symbol(s))
         .collect();
 
     symbols
@@ -1138,6 +1396,7 @@ fn symbols_from_nested_type(
                 })
         })
         .filter(|symbol| symbol.visibility != Visibility::Private)
+        .filter(|symbol| member_kind_allowed(context, symbol.kind))
         .map(|symbol| completion_item_for_nested_symbol(indexer, symbol, file_uri, caller))
         .collect()
 }
@@ -1833,7 +2092,13 @@ impl<'a> BareCompletionWalk<'a> {
             4,
             MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
             |index, class_name, ancestor_uri, hierarchy_caller| {
-                symbols_from_nested_type(index, ancestor_uri, class_name, hierarchy_caller)
+                symbols_from_nested_type(
+                    index,
+                    ancestor_uri,
+                    class_name,
+                    hierarchy_caller,
+                    MembershipContext::Inherited,
+                )
             },
         );
         for item in inherited {

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -8,7 +8,7 @@ use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
 use crate::stdlib::bare_completions;
 use crate::stdlib_tail::dot_completions_for_lang;
-use crate::types::{CallerContext, ImportEntry, SourceSet, Visibility};
+use crate::types::{CallerContext, ImportEntry, SourceSet, SymbolEntry, Visibility};
 use crate::LinesExt;
 use crate::StrExt;
 
@@ -665,136 +665,54 @@ struct DotCompletionContext {
     file_uri: String,
 }
 
-// ─── resolve_dot_receiver_type: strategy list ────────────────────────────────
-//
-// This resolves "what type does this dot-completion receiver have" through a
-// fixed, ORDERED list of strategies (`strategies` below), each strictly more
-// authoritative than the ones after it — the same shape as
-// `indexer::infer::chain::resolve_call_expr_type`, for the same reason: the
-// order previously lived only in an implicit if/return chain, where an
-// earlier bug fix already had to special-case `is_call` (see
-// `call_receiver_return_type`) to keep it from falling through into the
-// non-call strategies below it. Every strategy here is EXCLUSIVE, not a
-// fallback filter: once one's precondition matches, its answer — `Some` or
-// `None` — is final.
-//   - `cst_resolved_type` wins first: it's the speculative-parse-time
-//     inference (smart-cast already applied), strictly more authoritative
-//     than re-deriving the same answer from scratch below.
-//   - `call_receiver_return_type` is exclusive on `is_call`: a call
-//     receiver's text is the CALLEE name, not a variable/type name, so it
-//     must never reach `variable_type`/`uppercase_type_name` below — a
-//     same-named local variable or class must not be consulted for `make().`.
-//   - `smart_cast_at_cursor` before `variable_type`: a narrowed smart-cast
-//     type must win over the variable's raw declared type.
-//   - `variable_type` before `uppercase_type_name`: an actual variable named
-//     with an uppercase first letter must still resolve as a variable, not
-//     be misread as a bare type-name receiver just because it starts
-//     uppercase.
-//   - `uppercase_type_name` before `bare_scope_function_return_type`: once
-//     nothing bound the name to a variable, an uppercase identifier is far
-//     more likely a type name (`String.format`) than a parenthesis-less
-//     scope-function reference.
-//   - `bare_scope_function_return_type` last: a pure last-resort guess for a
-//     receiver written as a bare function name without `()`.
-
-/// A `resolve_dot_receiver_type` strategy's verdict for one receiver.
-enum ReceiverTypeVerdict {
-    /// This strategy's precondition doesn't apply — try the next strategy.
-    NotApplicable,
-    /// This strategy's precondition matched; its answer — `Some` or `None`
-    /// — is FINAL. No later, less-authoritative strategy may run instead.
-    Terminal(Option<ReceiverType>),
-}
-
-/// Inputs every strategy reads, computed once.
+/// Inputs shared by every fallback strategy below.
 struct ReceiverTypeCtx<'a> {
     indexer: &'a Indexer,
     receiver: &'a str,
     from_uri: &'a Url,
     cursor_line: Option<u32>,
-    is_call: bool,
-    resolved: Option<&'a str>,
 }
 
-/// CST-resolved type from analysis time — authoritative when present.
-fn cst_resolved_type(ctx: &ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict {
-    match ctx.resolved {
-        Some(resolved) => {
-            ReceiverTypeVerdict::Terminal(Some(ReceiverType::from_raw(resolved.to_owned())))
-        }
-        None => ReceiverTypeVerdict::NotApplicable,
-    }
+/// Smart-cast narrowing at the cursor (`if (x is Foo) { x.<here> }`), which
+/// must win over the variable's raw declared type below.
+fn smart_cast_at_cursor(ctx: &ReceiverTypeCtx<'_>) -> Option<ReceiverType> {
+    let pos = Position::new(ctx.cursor_line?, 0);
+    infer_receiver_type_at(ctx.indexer, ctx.receiver, ctx.from_uri, pos)
 }
 
-/// A call receiver the CST engine couldn't type (`make().`): global fn
-/// return type, then callable-param inference (`val make: () -> Foo`).
-/// Exclusive on `is_call` — see the ordering note above.
-fn call_receiver_return_type(ctx: &ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict {
-    if !ctx.is_call {
-        return ReceiverTypeVerdict::NotApplicable;
-    }
-    ReceiverTypeVerdict::Terminal(fn_or_callable_param_return_type(
-        ctx.indexer,
-        ctx.receiver,
-        ctx.from_uri,
-    ))
-}
-
-/// Smart-cast narrowing at the cursor position (`if (x is Foo) { x.<here> }`).
-/// NOT exclusive on `cursor_line` alone: a missing smart-cast for a real
-/// `cursor_line` still falls through to `variable_type` below, matching the
-/// pre-refactor behaviour of only ever RETURNING EARLY on a hit.
-fn smart_cast_at_cursor(ctx: &ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict {
-    let Some(line) = ctx.cursor_line else {
-        return ReceiverTypeVerdict::NotApplicable;
-    };
-    let pos = Position::new(line, 0);
-    match infer_receiver_type_at(ctx.indexer, ctx.receiver, ctx.from_uri, pos) {
-        Some(rt) => ReceiverTypeVerdict::Terminal(Some(rt)),
-        None => ReceiverTypeVerdict::NotApplicable,
-    }
-}
-
-/// The receiver as a declared variable (field/param/local), with the
-/// function-type-return unwrap for a callable-typed variable used bare
-/// (`val make: () -> Foo` referenced as `make.` rather than `make().`).
-fn variable_type(ctx: &ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict {
-    let Some(rt) = infer_receiver_type(
+/// The receiver as a declared variable (field/param/local), unwrapping a
+/// callable-typed variable used bare (`val make: () -> Foo` as `make.`).
+///
+/// Ahead of `uppercase_type_name`: a variable whose name happens to start
+/// uppercase is still a variable, not a type-name receiver.
+fn variable_type(ctx: &ReceiverTypeCtx<'_>) -> Option<ReceiverType> {
+    let resolved = infer_receiver_type(
         ctx.indexer,
         ReceiverKind::Variable(ctx.receiver),
         ctx.from_uri,
-    ) else {
-        return ReceiverTypeVerdict::NotApplicable;
-    };
-    match extract_fn_type_return(&rt.raw) {
-        Some(ret) => ReceiverTypeVerdict::Terminal(Some(ReceiverType::from_raw(ret))),
-        None => ReceiverTypeVerdict::Terminal(Some(rt)),
+    )?;
+    match extract_fn_type_return(&resolved.raw) {
+        Some(ret) => Some(ReceiverType::from_raw(ret)),
+        None => Some(resolved),
     }
 }
 
-/// An uppercase bare identifier with no matching variable — treat it as a
-/// type name (`String.format(...)`, companion/static-style access).
-fn uppercase_type_name(ctx: &ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict {
-    if ctx.receiver.starts_with_uppercase() {
-        ReceiverTypeVerdict::Terminal(Some(ReceiverType::from_raw(ctx.receiver.to_owned())))
-    } else {
-        ReceiverTypeVerdict::NotApplicable
-    }
+/// An uppercase identifier nothing bound to a variable — far more likely a
+/// type name (`String.format`) than the parenthesis-less function below.
+fn uppercase_type_name(ctx: &ReceiverTypeCtx<'_>) -> Option<ReceiverType> {
+    ctx.receiver
+        .starts_with_uppercase()
+        .then(|| ReceiverType::from_raw(ctx.receiver.to_owned()))
 }
 
-/// Last resort: a function defined in scope written without `()`
-/// (e.g. bare `productFlow` used as `productFlow.collect { }`).
-fn bare_scope_function_return_type(ctx: &ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict {
-    ReceiverTypeVerdict::Terminal(fn_or_callable_param_return_type(
-        ctx.indexer,
-        ctx.receiver,
-        ctx.from_uri,
-    ))
+/// Last resort: a function in scope written without `()`
+/// (bare `productFlow` used as `productFlow.collect { }`).
+fn bare_scope_function_return_type(ctx: &ReceiverTypeCtx<'_>) -> Option<ReceiverType> {
+    fn_or_callable_param_return_type(ctx.indexer, ctx.receiver, ctx.from_uri)
 }
 
-/// Shared by `call_receiver_return_type` and `bare_scope_function_return_type`
-/// — both resolve a bare name via the same two-step lookup (global function
-/// return type, then callable-param inference from the file's own lines).
+/// Resolve a bare name to a return type: global function first, then
+/// callable-param inference from the file's own lines.
 fn fn_or_callable_param_return_type(
     indexer: &Indexer,
     receiver: &str,
@@ -827,29 +745,33 @@ fn resolve_dot_receiver_type(
         DotReceiver::Super => return None,
     };
 
+    // Speculative-parse-time inference (smart-cast already applied) beats
+    // re-deriving the same answer from scratch.
+    if let Some(resolved) = resolved {
+        return Some(ReceiverType::from_raw(resolved.to_owned()));
+    }
+    // A call receiver's text is the CALLEE name, so it resolves one way only:
+    // consulting the fallbacks below would match a same-named variable or
+    // class that has nothing to do with `make().`.
+    if is_call {
+        return fn_or_callable_param_return_type(indexer, receiver, from_uri);
+    }
+
     let ctx = ReceiverTypeCtx {
         indexer,
         receiver,
         from_uri,
         cursor_line,
-        is_call,
-        resolved,
     };
-
-    let strategies: [fn(&ReceiverTypeCtx<'_>) -> ReceiverTypeVerdict; 6] = [
-        cst_resolved_type,
-        call_receiver_return_type,
+    // Ordered most- to least-authoritative; first match wins. Each entry
+    // documents why it outranks the next.
+    let fallbacks: [fn(&ReceiverTypeCtx<'_>) -> Option<ReceiverType>; 4] = [
         smart_cast_at_cursor,
         variable_type,
         uppercase_type_name,
         bare_scope_function_return_type,
     ];
-    for strategy in strategies {
-        if let ReceiverTypeVerdict::Terminal(outcome) = strategy(&ctx) {
-            return outcome;
-        }
-    }
-    None
+    fallbacks.iter().find_map(|strategy| strategy(&ctx))
 }
 
 /// Extract the return type from a Kotlin function-type string.
@@ -1001,7 +923,7 @@ fn append_dot_tail_completions(
 /// consistently with the rest of the completion results.
 fn completion_item_for_nested_symbol(
     indexer: &Indexer,
-    s: &crate::types::SymbolEntry,
+    s: &SymbolEntry,
     uri_str: &str,
     caller: CallerContext<'_>,
 ) -> CompletionItem {
@@ -1056,112 +978,39 @@ fn completion_item_for_nested_symbol(
     }
 }
 
-// ─── symbols_from_nested_type: canonical container/type taxonomy ────────────
-//
-// Three separate concerns used to be answered by hand-copied, independently
-// drifting `SymbolKind` predicates: which kinds nest other symbols
-// (`parser.rs`'s `is_container_kind`, driving `assign_containers`), which
-// symbol should represent `inner_name` when a type and a same-named function
-// both declare it (a local closure here), and which `OBJECT` is a companion
-// (a `detail`-prefix check here). The first two had already drifted —
-// `SymbolKind::MODULE` counted in one but not the other (harmless in
-// practice: nothing in this codebase ever assigns that `SymbolKind` to a
-// symbol — verified by grep — so folding it away below changes no reachable
-// behaviour), and the companion check's prefix match had a real gap (see
-// `is_companion_object_symbol`). `is_container_kind` (parser.rs) is now the
-// single canonical source for "does this kind nest other symbols"; the one
-// place a genuinely different classification is needed
-// (`is_preferred_type_symbol_kind`, below) is defined as an explicit DELTA on
-// top of it, not a parallel hand-copied list, so it cannot silently drift
-// again the way it just did.
-
-/// Prefer a type declaration (or enum case) over a same-named function when
-/// picking which symbol represents `inner_name`. Compose's `MaterialTheme`
-/// file declares both `fun MaterialTheme(...)` and `object MaterialTheme {
-/// ... }` — taking the first match would pick the function and return empty
-/// completions.
+/// Which symbol represents `inner_name` when several share that name.
 ///
-/// Built on the canonical `is_container_kind` (`parser.rs`, the same
-/// predicate `assign_containers` uses) plus one explicit, deliberate delta:
-/// `ENUM_MEMBER`, so an enum case's own declaration still outranks an
-/// identically-named function even though an enum case isn't itself a
-/// container.
+/// A type declaration (or enum case) outranks a same-named function: Compose's
+/// `MaterialTheme` file declares both `fun MaterialTheme(...)` and `object
+/// MaterialTheme { … }`, and picking the function returns no members at all.
+///
+/// `is_container_kind` (`parser.rs`) is the canonical "does this kind nest
+/// other symbols" predicate — the same one `assign_containers` uses to
+/// populate the `container` field this module reads back. `ENUM_MEMBER` is
+/// the deliberate delta: an enum case nests nothing, but its declaration
+/// should still outrank an identically-named function.
 fn is_preferred_type_symbol_kind(kind: SymbolKind) -> bool {
     crate::parser::is_container_kind(kind) || kind == SymbolKind::ENUM_MEMBER
 }
 
-/// Whether `symbol` is a `companion object` declaration (named or
-/// anonymous). Matched by TOKEN, not prefix: `detail` is the raw declaration
-/// text up to the body, so a modified companion (`private companion
-/// object`, an `@JvmStatic` annotation line folded onto the same detail
-/// text) still carries `"companion"` as a token even though the text doesn't
-/// START with the literal words `"companion object"`. The previous
-/// prefix-based check missed exactly this case — see
-/// `companion_object_forwarding_survives_a_private_companion`.
-///
-/// `resolve::resolve_companion_member` (`resolve.rs`) answers a related but
-/// distinct question — "find a companion member by qualified-name lookup",
-/// not "fold a companion's members into its outer type's own completion
-/// list" — via its own independent token-based check, for the identical
-/// reason. The two are not unified here: doing so would mean editing
-/// `resolve.rs`, outside this refactor's file scope.
-fn is_companion_object_symbol(symbol: &crate::types::SymbolEntry) -> bool {
-    symbol.kind == SymbolKind::OBJECT
-        && symbol
-            .detail
-            .split_whitespace()
-            .any(|token| token == "companion")
-}
-
-/// Which relationship the caller has to `inner_name`'s own declared members.
-///
-/// A symbol declared *inside* a type is a completion candidate in two
-/// structurally different situations that must not be conflated:
-///  - the receiver IS `inner_name` itself (`direct_dot_completion_items`) —
-///    every member declared inside it, INCLUDING nested type declarations,
-///    is offered (`Outer.Nested` is a real Kotlin expression, pinned by
-///    `nested_type_completion_still_lists_sibling_nested_types_by_enclosing_type_name`).
-///  - `inner_name` is an ANCESTOR being folded into a DESCENDANT instance's
-///    member list (`collect_inherited_dot_completion_items` /
-///    `collect_inherited_members`'s `walk_hierarchy` callbacks) — only
-///    `inner_name`'s actual INSTANCE members (functions, properties, enum
-///    cases) are inherited. A nested type declaration is never an instance
-///    member of a descendant. Not excluding it here is what let a sibling
-///    nested type — and, when the descendant is itself nested under the same
-///    ancestor, the descendant's own name — leak into every OTHER sibling's
-///    inherited completion via `walk_hierarchy` (`Mid : Top` offering
-///    `Top`'s other nested type `Leaf1`, and even `Mid` itself, as if they
-///    were instance members of a `Mid` receiver).
+/// How the caller reached `inner_name`'s members, which decides whether
+/// nested type declarations belong in the result.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum MembershipContext {
+    /// The receiver IS `inner_name`. `Outer.Nested` is a real Kotlin
+    /// expression, so nested types are offered alongside instance members.
     Direct,
+    /// `inner_name` is an ancestor whose members are folded into a
+    /// descendant instance (`walk_hierarchy`). Only instance members are
+    /// inherited — a nested type declaration never is.
     Inherited,
 }
 
-/// Whether a symbol of `kind` may appear in `context`'s member list — see
-/// `MembershipContext`.
 fn member_kind_allowed(context: MembershipContext, kind: SymbolKind) -> bool {
     context == MembershipContext::Direct || !crate::parser::is_container_kind(kind)
 }
 
-/// Return completions for symbols declared INSIDE `type_name` within the given file.
-///
-/// Membership is by `container` (assigned per-symbol at parse time by
-/// `assign_containers`, `parser.rs` — the tightest *immediate* enclosing
-/// class/object/interface, not a range-arithmetic approximation of it): a
-/// member declared inside a nested type's own body has THAT nested type as
-/// its container, never the outer one, so it can never leak into the outer
-/// type's member list regardless of nesting depth. A prior range-containment
-/// version of this function needed several rounds of edge-case patching (a
-/// nested type's own members leaking into its enclosing type, then into
-/// every OTHER sibling type's *inherited* completion via `walk_hierarchy`)
-/// precisely because "is this symbol inside that range" is an approximation
-/// of "is this symbol's immediate parent that type" — `container` answers
-/// the real question directly.
-///
-/// `context` distinguishes "the receiver IS this type" from "this type is an
-/// ancestor being folded into a descendant's inherited members" — see
-/// `MembershipContext`.
+/// Completions for the members of `inner_name`, as declared in `file_uri`.
 fn symbols_from_nested_type(
     indexer: &Indexer,
     file_uri: &str,
@@ -1190,21 +1039,10 @@ fn symbols_from_nested_type(
             .collect();
     };
 
-    // Two structurally different backing stores answer the same question
-    // below: a workspace file's real per-symbol `container`
-    // (`members_for_workspace_type`) vs. a JAR's synthetic one-line-per-symbol
-    // `FileData`, where `container` must additionally be disambiguated by
-    // package because one synthetic `FileData` spans an entire JAR
-    // (`members_for_jar_backed_type`). They are deliberately NOT merged into
-    // one implementation: the JAR path's `container` is a same-simple-name
-    // collision waiting to happen across an entire JAR and needs a second,
-    // JAR-only disambiguation axis (`jar_symbol_packages` + import-coverage)
-    // that a single file structurally cannot need. The workspace path still
-    // needs ITS OWN, narrower disambiguation, though — `container` is a bare
-    // name, not a unique identity, and a single file CAN have two different
-    // nested types sharing a simple name (`A.Config`/`B.Config` — Kotlin
-    // only forbids a collision among *top-level* declarations, not among
-    // unrelated types' own nested members) — see `members_for_workspace_type`.
+    // A JAR's synthetic `FileData` spans the whole archive and gives every
+    // symbol a one-line range, so it needs a package axis the per-file
+    // workspace path has no equivalent of — hence two implementations rather
+    // than one with a dead parameter.
     if indexer.jar_files.contains_key(file_uri) {
         return members_for_jar_backed_type(
             indexer,
@@ -1216,42 +1054,27 @@ fn symbols_from_nested_type(
             context,
         );
     }
-    members_for_workspace_type(
-        indexer,
-        file_uri,
-        inner_name,
-        symbols,
-        type_symbol,
-        caller,
-        context,
-    )
+    members_for_workspace_type(indexer, file_uri, symbols, type_symbol, caller, context)
 }
 
-/// JAR-backed member enumeration: compiled-JAR synthetic `FileData` gives
-/// every symbol a one-line range (line = its index), so there is no range
-/// interior to scan — the sidecar instead records each member's declaring
-/// class in `container`; that's the membership signal here. Without this,
-/// every member of a compiled-only library class (no sources JAR published)
-/// would be invisible to member enumeration, while name-keyed lookups
-/// (hover) keep working.
+/// JAR-backed member enumeration, keyed on `container` alone: a synthetic
+/// `FileData` gives every symbol a one-line range, leaving no interior to
+/// scan, so [`is_declared_in`]'s range check cannot apply here.
 ///
-/// `container` holds the declaring class's SIMPLE name, and one synthetic
-/// `FileData` spans the whole JAR — so two top-level classes sharing a
-/// simple name in different packages of one JAR would have their members
-/// merged. Disambiguate with the per-symbol package side table
-/// (`jar_symbol_packages`, index-aligned with `symbols`): members must match
-/// the package of the `inner_name` class the caller means — the caller's
-/// explicit import when present, the declaring class symbol's own package
-/// otherwise. Also drop deprecated members: JAR symbols are always `Public`,
-/// so the shared visibility filter below never fires for them, and project
-/// policy hides deprecated library symbols from completion entirely (same as
-/// the direct jar-definitions paths).
+/// That costs the identity `is_declared_in` gets from ranges — one synthetic
+/// `FileData` spans a whole JAR, where two same-named classes in different
+/// packages really do occur — so package is the disambiguator instead, taken
+/// from the caller's import when one names this class and the declaring
+/// class's own package otherwise.
+///
+/// Deprecated members are dropped here rather than by the shared filter:
+/// JAR symbols are always `Public`, so visibility never hides them.
 fn members_for_jar_backed_type(
     indexer: &Indexer,
     file_uri: &str,
     inner_name: &str,
-    symbols: &[crate::types::SymbolEntry],
-    type_symbol: &crate::types::SymbolEntry,
+    symbols: &[SymbolEntry],
+    type_symbol: &SymbolEntry,
     caller: CallerContext<'_>,
     context: MembershipContext,
 ) -> Vec<CompletionItem> {
@@ -1340,65 +1163,48 @@ fn members_for_jar_backed_type(
         .collect()
 }
 
-/// Workspace-file member enumeration: `container` (assigned at parse time by
-/// `assign_containers`) already answers "declared inside `inner_name`"
-/// exactly, so no disambiguation axis is needed beyond it — unlike the JAR
-/// path, a single workspace file's own symbol table can never have two
-/// classes sharing a simple name.
+/// Workspace-file member enumeration, keyed on each symbol's own
+/// `container` — see [`is_declared_in`].
 fn members_for_workspace_type(
     indexer: &Indexer,
     file_uri: &str,
-    inner_name: &str,
-    symbols: &[crate::types::SymbolEntry],
-    type_symbol: &crate::types::SymbolEntry,
+    symbols: &[SymbolEntry],
+    type_symbol: &SymbolEntry,
     caller: CallerContext<'_>,
     context: MembershipContext,
 ) -> Vec<CompletionItem> {
-    // `container` is a bare name, not a unique identity — two DIFFERENT
-    // nested types sharing a simple name in this file (`A.Config` and
-    // `B.Config`) would have their members merged by a name-only check.
-    // `type_symbol` is already the one specific instance this lookup
-    // resolved to, so additionally requiring a candidate's range to fall
-    // inside `type_symbol`'s own range disambiguates without reintroducing
-    // the depth bug this whole function replaced: a *nested* type's members
-    // have a different `container` entirely (their own nested type's name,
-    // not `inner_name`), so they never reach this check regardless of range.
-    //
-    // Kotlin resolves `Outer.member` through `Outer`'s own companion object
-    // when `Outer` itself has no such member (implicit companion
-    // forwarding) — so a companion's members belong in `Outer`'s own
-    // completion list too. A named companion (`companion object Factory`)
-    // has a container-name lookup of its own but no distinguishing
-    // `SymbolKind`, so it's found the same way `is_companion_object_symbol`
-    // finds the anonymous form. Companion members need the identical
-    // same-name disambiguation: Kotlin gives every anonymous companion the
-    // literal name "Companion", so two unrelated classes' companions in one
-    // file share that container string too — resolved by checking each
-    // candidate against the SPECIFIC companion symbol's own range (a class
-    // has at most one companion, so once the companion itself is identified
-    // unambiguously — by container == inner_name AND range-enclosed by
-    // `type_symbol` — this is unambiguous too).
-    let companions: Vec<&crate::types::SymbolEntry> = symbols
+    // Kotlin resolves `Outer.member` through `Outer`'s companion when `Outer`
+    // has no such member itself, so the companion's members join `Outer`'s own.
+    let companions: Vec<&SymbolEntry> = symbols
         .iter()
-        .filter(|s| s.container.as_deref() == Some(inner_name))
-        .filter(|s| range_encloses(type_symbol.range, s.range))
-        .filter(|s| is_companion_object_symbol(s))
+        .filter(|symbol| symbol.is_companion_object() && is_declared_in(symbol, type_symbol))
         .collect();
 
     symbols
         .iter()
         .filter(|symbol| {
-            (symbol.container.as_deref() == Some(inner_name)
-                && range_encloses(type_symbol.range, symbol.range))
-                || companions.iter().any(|companion| {
-                    symbol.container.as_deref() == Some(companion.name.as_str())
-                        && range_encloses(companion.range, symbol.range)
-                })
+            is_declared_in(symbol, type_symbol)
+                || companions
+                    .iter()
+                    .any(|companion| is_declared_in(symbol, companion))
         })
         .filter(|symbol| symbol.visibility != Visibility::Private)
         .filter(|symbol| member_kind_allowed(context, symbol.kind))
         .map(|symbol| completion_item_for_nested_symbol(indexer, symbol, file_uri, caller))
         .collect()
+}
+
+/// Whether `symbol` is declared directly inside `parent`.
+///
+/// `container` names the immediate parent, so nesting depth is handled for
+/// free — a member of a nested type carries that nested type's name, never the
+/// outer one. But a name is not an identity: one file may declare two nested
+/// types sharing a simple name (`A.Config` and `B.Config`), and Kotlin gives
+/// every anonymous companion the same implicit name `Companion`. The range
+/// check pins the match to this specific `parent` declaration.
+fn is_declared_in(symbol: &SymbolEntry, parent: &SymbolEntry) -> bool {
+    symbol.container.as_deref() == Some(parent.name.as_str())
+        && range_encloses(parent.range, symbol.range)
 }
 
 /// Sort rank for completion item kinds: lower = appears earlier.

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -166,14 +166,16 @@ pub(crate) fn infer_field_chain_type(
 }
 
 /// Like [`infer_receiver_type`] but checks smart-cast narrowing at the given
-/// position first.  If the variable is inside a `when (var) { is Type -> }`
-/// branch or an `if (var is Type)` block, returns the narrowed type.
+/// position first.  If the variable is inside a `when (var)` branch or an
+/// `if (var is Type)` block, returns the narrowed type.
 pub(crate) fn infer_receiver_type_at(
     indexer: &Indexer,
     name: &str,
     uri: &Url,
     position: Position,
 ) -> Option<ReceiverType> {
+    use super::infer_lines::SmartCast;
+
     // Try smart cast narrowing first when lines are available.
     let lines = indexer
         .live_lines
@@ -181,14 +183,39 @@ pub(crate) fn infer_receiver_type_at(
         .map(|ll| (*ll).clone())
         .or_else(|| indexer.files.get(uri.as_str()).map(|d| d.lines.clone()));
     if let Some(lines) = lines {
-        if let Some(narrowed) =
-            super::infer_lines::smart_cast_type_at_line(&lines, name, position.line)
-        {
+        let narrowed =
+            match super::infer_lines::smart_cast_type_at_line(&lines, name, position.line) {
+                Some(SmartCast::TypeTest(type_name)) => Some(type_name),
+                // Only an object's own name is also a type; an enum entry or a
+                // constant matches by value and leaves the subject's type alone.
+                Some(SmartCast::ObjectEquality(label)) => {
+                    names_object_declaration(indexer, &label).then_some(label)
+                }
+                None => None,
+            };
+        if let Some(narrowed) = narrowed {
             return Some(ReceiverType::from_raw(narrowed));
         }
     }
     // Fallback to normal inference
     infer_receiver_type(indexer, ReceiverKind::Variable(name), uri)
+}
+
+/// Whether `label` (possibly qualified, e.g. `Ui.Loading`) names an `object`
+/// declaration.
+fn names_object_declaration(indexer: &Indexer, label: &str) -> bool {
+    let simple_name = label.rsplit('.').next().unwrap_or(label);
+    indexer
+        .lookup_definitions(simple_name)
+        .into_iter()
+        .any(|location| {
+            crate::resolver::ensure_file_data(indexer, &location.uri).is_some_and(|file_data| {
+                file_data.symbols.iter().any(|symbol| {
+                    symbol.selection_range == location.range
+                        && symbol.kind == tower_lsp::lsp_types::SymbolKind::OBJECT
+                })
+            })
+        })
 }
 
 /// Scan the current file's lines for a type annotation on `var_name` and return

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -189,7 +189,7 @@ pub(crate) fn infer_receiver_type_at(
                 // Only an object's own name is also a type; an enum entry or a
                 // constant matches by value and leaves the subject's type alone.
                 Some(SmartCast::ObjectEquality(label)) => {
-                    names_object_declaration(indexer, &label).then_some(label)
+                    names_object_declaration(indexer, &label, uri).then_some(label)
                 }
                 None => None,
             };
@@ -201,18 +201,21 @@ pub(crate) fn infer_receiver_type_at(
     infer_receiver_type(indexer, ReceiverKind::Variable(name), uri)
 }
 
-/// Whether `label` (possibly qualified, e.g. `Ui.Loading`) names an `object`
-/// declaration.
-fn names_object_declaration(indexer: &Indexer, label: &str) -> bool {
-    let simple_name = label.rsplit('.').next().unwrap_or(label);
-    indexer
-        .lookup_definitions(simple_name)
+/// Whether the qualified `label` (e.g. `Ui.Loading`) names an `object`
+/// declaration as seen from `from_uri`.
+///
+/// Resolved through `resolve_type_index_only`, which honours the file's own
+/// imports and package, rather than by scanning every definition sharing the
+/// simple name: an unrelated `object Idle` in another package would otherwise
+/// validate an enum entry named `Idle` and narrow the subject to a type it
+/// has nothing to do with.
+fn names_object_declaration(indexer: &Indexer, label: &str, from_uri: &Url) -> bool {
+    super::resolve::resolve_type_index_only(indexer, label, from_uri)
         .into_iter()
         .any(|location| {
-            crate::resolver::ensure_file_data(indexer, &location.uri).is_some_and(|file_data| {
+            ensure_file_data(indexer, &location.uri).is_some_and(|file_data| {
                 file_data.symbols.iter().any(|symbol| {
-                    symbol.selection_range == location.range
-                        && symbol.kind == tower_lsp::lsp_types::SymbolKind::OBJECT
+                    symbol.selection_range == location.range && symbol.kind == SymbolKind::OBJECT
                 })
             })
         })

--- a/src/resolver/infer_lines.rs
+++ b/src/resolver/infer_lines.rs
@@ -773,27 +773,41 @@ fn if_is_smart_cast(lines: &[String], var_name: &str, line_idx: usize) -> Option
 
 /// Read what a `when` branch narrows its subject to.
 ///
-/// `is Foo ->` is a type test. A bare `Foo ->` / `Ui.Foo ->` is equality
-/// against a declaration — the idiomatic form for matching a `data object`,
-/// and the reason this exists — which narrows only when that declaration is
-/// an object, hence the separate variant for the caller to confirm.
+/// `is Foo ->` is a type test. `Ui.Foo ->` is equality against a declaration —
+/// the idiomatic form for matching a `data object`, and the reason this
+/// exists — which narrows only when that declaration is an object, hence the
+/// separate variant for the caller to confirm.
+///
+/// The equality form requires a QUALIFIED label (`Ui.Foo`, not a bare `Foo`).
+/// This scan reads one line at a time with no idea whether it sits in a `when`
+/// at all, and a lambda parameter is written the same way a branch label is:
+///
+/// ```text
+///     items.forEach {
+///         Element ->            // a parameter, not a branch
+/// ```
+///
+/// A lambda parameter is always a simple identifier, never dotted, so the dot
+/// tells the two apart structurally rather than by guessing at conventions.
+/// The cost is that a bare `Foo ->` branch (legal when `Foo` is imported)
+/// doesn't narrow; separating those needs the CST, not a smarter line scan.
 fn extract_when_branch_narrowing(trimmed: &str) -> Option<SmartCast> {
     if trimmed.starts_with("is ") {
         return extract_is_type_from_when_branch(trimmed).map(SmartCast::TypeTest);
     }
     let arrow = trimmed.find("->")?;
     let label = trimmed[..arrow].trim();
-    // A single dotted identifier only: `else`, a call, a range, a literal, or
-    // a comma-separated label list narrows nothing usable.
-    let is_dotted_identifier = !label.is_empty()
-        && label != "else"
-        && label.split('.').all(|segment| {
-            !segment.is_empty() && segment.chars().all(|c| c.is_alphanumeric() || c == '_')
-        });
-    if !is_dotted_identifier {
-        return None;
-    }
-    if !label.rsplit('.').next()?.chars().next()?.is_uppercase() {
+    // One qualified identifier only: `else`, a call, a range, a literal, or a
+    // comma-separated label list narrows nothing usable.
+    let (qualifier, name) = label.rsplit_once('.')?;
+    let is_qualified_identifier = !qualifier.is_empty()
+        && qualifier
+            .split('.')
+            .chain(std::iter::once(name))
+            .all(|segment| {
+                !segment.is_empty() && segment.chars().all(|c| c.is_alphanumeric() || c == '_')
+            });
+    if !is_qualified_identifier || !name.chars().next()?.is_uppercase() {
         return None;
     }
     Some(SmartCast::ObjectEquality(label.to_owned()))

--- a/src/resolver/infer_lines.rs
+++ b/src/resolver/infer_lines.rs
@@ -630,45 +630,52 @@ pub(crate) fn find_declaration_range_in_lines(lines: &[String], name: &str) -> O
 /// Maximum lines to scan backward for `when(subject)` or `if (x is T)`.
 const SMART_CAST_SCAN_LINES: usize = 30;
 
+/// What a branch narrows its subject to, and how much the caller must verify.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SmartCast {
+    /// `is Foo ->` or `if (x is Foo)`. A type test, so `Foo` is a type by
+    /// construction and the narrowing needs no further checking.
+    TypeTest(String),
+    /// `Foo ->` / `Ui.Foo ->`: equality against a declaration. Kotlin narrows
+    /// here only when the label is an `object`, since matching one proves the
+    /// subject's type. An enum entry or `const val` names no type, so the
+    /// caller must confirm the label before using it.
+    ObjectEquality(String),
+}
+
 /// Detect smart cast narrowing at a given line position.
 ///
-/// Handles two patterns:
-/// 1. `when (var) { is Type -> ... }` — cursor inside the `is Type` branch
-/// 2. `if (var is Type)` / `else if (var is Type)` — cursor inside that block
-///
-/// Returns the narrowed type name (e.g. `"Event.OnSomethingClick"`) or `None`.
+/// Handles three patterns:
+/// 1. `when (var) { is Type -> … }` — cursor inside the `is Type` branch
+/// 2. `when (var) { Obj -> … }` — cursor inside an object-equality branch
+/// 3. `if (var is Type)` / `else if (var is Type)` — cursor inside that block
 pub(crate) fn smart_cast_type_at_line(
     lines: &[String],
     var_name: &str,
     line: u32,
-) -> Option<String> {
+) -> Option<SmartCast> {
     let line_idx = line as usize;
     if line_idx >= lines.len() {
         return None;
     }
 
-    // Strategy 1: `when (var)` block — find `is Type` on current or preceding branch line
-    if let Some(type_name) = when_branch_smart_cast(lines, var_name, line_idx) {
-        return Some(type_name);
-    }
-
-    // Strategy 2: `if (var is Type)` block
-    if_is_smart_cast(lines, var_name, line_idx)
+    when_branch_smart_cast(lines, var_name, line_idx)
+        .or_else(|| if_is_smart_cast(lines, var_name, line_idx).map(SmartCast::TypeTest))
 }
 
-/// Check if cursor is inside a `when (var_name)` block and extract the `is Type` from
-/// the enclosing branch.
+/// Check if cursor is inside a `when (var_name)` block and read the narrowing
+/// from the enclosing branch.
 ///
 /// Handles nested when: scans backward through multiple when levels, matching each
-/// `is X ->` branch to its nearest enclosing `when (subject)`.
-fn when_branch_smart_cast(lines: &[String], var_name: &str, line_idx: usize) -> Option<String> {
+/// branch to its nearest enclosing `when (subject)`.
+fn when_branch_smart_cast(lines: &[String], var_name: &str, line_idx: usize) -> Option<SmartCast> {
     let start = line_idx.saturating_sub(SMART_CAST_SCAN_LINES);
 
     // Track brace depth while scanning backward from cursor.
     // depth=0 at cursor. Opening `{` going backward means we exit a scope (depth-=1),
     // closing `}` means we enter a nested scope (depth+=1).
     let mut depth: i32 = 0;
-    let mut branch_type: Option<String> = None;
+    let mut branch: Option<SmartCast> = None;
 
     for i in (start..=line_idx).rev() {
         let trimmed = lines[i].trim();
@@ -686,14 +693,14 @@ fn when_branch_smart_cast(lines: &[String], var_name: &str, line_idx: usize) -> 
             break;
         }
 
-        // If we haven't found our branch yet, look for `is Type ->`
-        if branch_type.is_none() {
-            if let Some(type_name) = extract_is_type_from_when_branch(trimmed) {
-                branch_type = Some(type_name);
+        // If we haven't found our branch yet, look for one.
+        if branch.is_none() {
+            if let Some(narrowing) = extract_when_branch_narrowing(trimmed) {
+                branch = Some(narrowing);
                 continue;
             }
-            // Stop at `else ->` or other non-`is` branch boundaries.
-            if trimmed.contains(" ->") && !trimmed.starts_with("is ") {
+            // Stop at `else ->` or any other branch that narrows nothing.
+            if trimmed.contains(" ->") {
                 break;
             }
             // Stop if we hit a closing brace without finding a branch
@@ -708,17 +715,14 @@ fn when_branch_smart_cast(lines: &[String], var_name: &str, line_idx: usize) -> 
         // relative to where we found the branch, or the when is on a line that decreases
         // depth further).
         if is_when_subject(trimmed, var_name) {
-            return branch_type;
+            return branch;
         }
         // If we find a `when (something_else)` that doesn't match our var, this branch
         // belongs to that inner when — our var isn't narrowed by it. Reset and keep looking.
         if trimmed.contains("when") && trimmed.contains('(') {
-            branch_type = None;
             // This line may also be a branch for an outer when:
             // e.g. `is Banner -> when (inner) {`
-            if let Some(type_name) = extract_is_type_from_when_branch(trimmed) {
-                branch_type = Some(type_name);
-            }
+            branch = extract_when_branch_narrowing(trimmed);
         }
     }
     None
@@ -765,6 +769,34 @@ fn if_is_smart_cast(lines: &[String], var_name: &str, line_idx: usize) -> Option
         }
     }
     None
+}
+
+/// Read what a `when` branch narrows its subject to.
+///
+/// `is Foo ->` is a type test. A bare `Foo ->` / `Ui.Foo ->` is equality
+/// against a declaration — the idiomatic form for matching a `data object`,
+/// and the reason this exists — which narrows only when that declaration is
+/// an object, hence the separate variant for the caller to confirm.
+fn extract_when_branch_narrowing(trimmed: &str) -> Option<SmartCast> {
+    if trimmed.starts_with("is ") {
+        return extract_is_type_from_when_branch(trimmed).map(SmartCast::TypeTest);
+    }
+    let arrow = trimmed.find("->")?;
+    let label = trimmed[..arrow].trim();
+    // A single dotted identifier only: `else`, a call, a range, a literal, or
+    // a comma-separated label list narrows nothing usable.
+    let is_dotted_identifier = !label.is_empty()
+        && label != "else"
+        && label.split('.').all(|segment| {
+            !segment.is_empty() && segment.chars().all(|c| c.is_alphanumeric() || c == '_')
+        });
+    if !is_dotted_identifier {
+        return None;
+    }
+    if !label.rsplit('.').next()?.chars().next()?.is_uppercase() {
+        return None;
+    }
+    Some(SmartCast::ObjectEquality(label.to_owned()))
 }
 
 /// Extract `Type` from a when-branch line like `is Event.OnClick ->` or `is Event.OnClick ->`

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -23,7 +23,7 @@ use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
 
-use tower_lsp::lsp_types::{Location, SymbolKind, Url};
+use tower_lsp::lsp_types::{Location, Url};
 
 use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
@@ -1005,10 +1005,7 @@ pub(crate) fn range_encloses(
 ///
 /// `Foo.member` with `Foo` a class name (not a variable) can only ever reach a
 /// companion-object member in Kotlin — never an instance member of `Foo`, even
-/// when one happens to share the name. The companion is identified by its
-/// `detail`, which always starts with the literal `"companion object"` keywords
-/// (set by [`crate::parser::extract_detail`] for both the named and the
-/// synthesized-anonymous form — see [`crate::parser::extract_anonymous_companion_objects`]).
+/// when one happens to share the name.
 fn resolve_companion_member(
     indexer: &Indexer,
     name: &str,
@@ -1032,19 +1029,11 @@ fn resolve_companion_member(
     else {
         return vec![];
     };
-    let Some(companion) = file_data.symbols.iter().find(|symbol| {
-        // `kind == OBJECT` already restricts this to object declarations; among
-        // those, the companion is the one carrying the `companion` soft-keyword.
-        // Match it as a token rather than a prefix so leading modifiers or an
-        // annotation line (`private companion object`, `@JvmStatic\ncompanion
-        // object`) don't hide it.
-        symbol.kind == SymbolKind::OBJECT
-            && symbol
-                .detail
-                .split_whitespace()
-                .any(|token| token == "companion")
-            && range_encloses(class_range, symbol.range)
-    }) else {
+    let Some(companion) = file_data
+        .symbols
+        .iter()
+        .find(|symbol| symbol.is_companion_object() && range_encloses(class_range, symbol.range))
+    else {
         return vec![];
     };
     file_data

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -2758,7 +2758,10 @@ fn smart_cast_when_branch() {
 
     // Line 3 is inside `is Event.OnClick` branch
     let result = infer_lines::smart_cast_type_at_line(&lines, "event", 3);
-    assert_eq!(result.as_deref(), Some("Event.OnClick"));
+    assert_eq!(
+        result,
+        Some(infer_lines::SmartCast::TypeTest("Event.OnClick".to_owned()))
+    );
 }
 
 #[test]
@@ -2776,7 +2779,10 @@ fn smart_cast_when_branch_same_line() {
 
     // Cursor on the branch line itself
     let result = infer_lines::smart_cast_type_at_line(&lines, "event", 2);
-    assert_eq!(result.as_deref(), Some("Event.OnClick"));
+    assert_eq!(
+        result,
+        Some(infer_lines::SmartCast::TypeTest("Event.OnClick".to_owned()))
+    );
 }
 
 #[test]
@@ -2793,7 +2799,10 @@ fn smart_cast_if_is() {
     .collect();
 
     let result = infer_lines::smart_cast_type_at_line(&lines, "event", 2);
-    assert_eq!(result.as_deref(), Some("Event.OnInput"));
+    assert_eq!(
+        result,
+        Some(infer_lines::SmartCast::TypeTest("Event.OnInput".to_owned()))
+    );
 }
 
 #[test]
@@ -2853,7 +2862,10 @@ fn smart_cast_if_does_not_leak_from_closed_nested_block() {
     .collect();
 
     let result = infer_lines::smart_cast_type_at_line(&lines, "event", 5);
-    assert_eq!(result.as_deref(), Some("Event.OnInput"));
+    assert_eq!(
+        result,
+        Some(infer_lines::SmartCast::TypeTest("Event.OnInput".to_owned()))
+    );
 }
 
 #[test]
@@ -2887,7 +2899,12 @@ fn smart_cast_if_preserves_generic_types_with_commas() {
     .collect();
 
     let result = infer_lines::smart_cast_type_at_line(&lines, "value", 2);
-    assert_eq!(result.as_deref(), Some("Map<String, List<Int>>"));
+    assert_eq!(
+        result,
+        Some(infer_lines::SmartCast::TypeTest(
+            "Map<String, List<Int>>".to_owned()
+        ))
+    );
 }
 #[test]
 fn smart_cast_nested_when_on_same_line() {
@@ -2908,11 +2925,19 @@ fn smart_cast_nested_when_on_same_line() {
 
     // event.events on line 4 should be narrowed to SalespointInputEvent.OnCloseClick
     let result = infer_lines::smart_cast_type_at_line(&lines, "event.events", 4);
-    assert_eq!(result.as_deref(), Some("SalespointInputEvent.OnCloseClick"),);
+    assert_eq!(
+        result,
+        Some(infer_lines::SmartCast::TypeTest(
+            "SalespointInputEvent.OnCloseClick".to_owned()
+        )),
+    );
 
     // event on line 4 should be narrowed to Banner (from outer when)
     let result2 = infer_lines::smart_cast_type_at_line(&lines, "event", 4);
-    assert_eq!(result2.as_deref(), Some("Banner"));
+    assert_eq!(
+        result2,
+        Some(infer_lines::SmartCast::TypeTest("Banner".to_owned()))
+    );
 }
 
 // ── Completion ordering ────────────────────────────────────────────────────
@@ -5804,5 +5829,68 @@ fn same_named_nested_types_in_different_classes_do_not_merge_members() {
     assert!(
         has_a != has_b,
         "expected exactly one of A.Config/B.Config's own members, not both (merged) or neither: {labels:?}"
+    );
+}
+
+/// Regression: matching a `data object` in a `when` is written as equality
+/// (`Loading ->`), not a type test (`is Loading ->`) — the idiomatic form,
+/// since an object has exactly one instance. Only `is` branches narrowed, so
+/// the subject kept its sealed-interface type and the object's own members
+/// were missing from completion.
+#[test]
+fn when_equality_branch_on_an_object_narrows_the_subject() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Ui.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         sealed interface Ui {\n\
+         \x20 data object Loading : Ui {\n\
+         \x20   val progress = 0\n\
+         \x20 }\n\
+         \x20 data class Ready(val value: Int) : Ui\n\
+         }\n\
+         fun render(state: Ui) {\n\
+         \x20 when (state) {\n\
+         \x20   Ui.Loading -> state.\n\
+         \x20   else -> {}\n\
+         \x20 }\n\
+         }",
+    );
+    let items = complete_dot(&idx, "state", &file_uri, false, Some(9));
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"progress"),
+        "an object-equality branch must narrow to that object: {labels:?}"
+    );
+}
+
+/// An enum entry is a value, not a type, so `Color.RED ->` must NOT narrow —
+/// treating the label as a type would resolve to the entry (which has no
+/// members) and blank the completion list instead of offering the enum's own.
+#[test]
+fn when_equality_branch_on_an_enum_entry_does_not_narrow() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Color.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         enum class Color {\n\
+         \x20 RED, GREEN;\n\
+         \x20 fun describe(): String = name\n\
+         }\n\
+         fun pick(color: Color) {\n\
+         \x20 when (color) {\n\
+         \x20   Color.RED -> color.\n\
+         \x20   else -> {}\n\
+         \x20 }\n\
+         }",
+    );
+    let items = complete_dot(&idx, "color", &file_uri, false, Some(7));
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"describe"),
+        "must still offer Color's own members; narrowing to the entry (which \
+         has none) would blank the list: {labels:?}"
     );
 }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -5894,3 +5894,75 @@ fn when_equality_branch_on_an_enum_entry_does_not_narrow() {
          has none) would blank the list: {labels:?}"
     );
 }
+
+/// Regression: the backward line scan has no idea whether it is inside a
+/// `when`, and a lambda parameter on its own line looks exactly like a branch
+/// label. Accepting a bare `Element ->` let an unrelated object's members be
+/// offered for a receiver the branch never narrowed — worse than not narrowing
+/// at all. Only a qualified label is accepted, since a lambda parameter is
+/// always a simple identifier.
+#[test]
+fn a_lambda_parameter_is_not_mistaken_for_a_when_branch_label() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Scan.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         object Element { fun unrelatedMember() {} }\n\
+         sealed interface Ui\n\
+         object Busy : Ui { fun busyOnly() {} }\n\
+         fun render(state: Ui) {\n\
+         \x20 when (state) {\n\
+         \x20   is Busy -> {\n\
+         \x20     listOf(1).forEach {\n\
+         \x20       Element ->\n\
+         \x20       state.\n\
+         \x20     }\n\
+         \x20   }\n\
+         \x20 }\n\
+         }",
+    );
+    let items = complete_dot(&idx, "state", &file_uri, false, Some(9));
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        !labels.contains(&"unrelatedMember"),
+        "a lambda parameter must not narrow the subject to that name: {labels:?}"
+    );
+}
+
+/// Regression: confirming the branch label names an object must respect the
+/// file's own imports and package. Scanning every definition sharing the
+/// simple name let an unrelated `object Idle` in another package validate an
+/// enum entry named `Idle`, narrowing the subject to a type it has nothing to
+/// do with and blanking the completion list.
+#[test]
+fn an_unrelated_same_named_object_does_not_validate_an_enum_entry_branch() {
+    let idx = Indexer::new();
+    let other_uri = uri("/other/Idle.kt");
+    let app_uri = uri("/app/Conn.kt");
+    idx.index_content(
+        &other_uri,
+        "package other\nobject Idle { fun unrelatedMember() {} }\n",
+    );
+    idx.index_content(
+        &app_uri,
+        "package app\n\
+         enum class Conn {\n\
+         \x20 Idle,\n\
+         \x20 Active;\n\
+         \x20 fun describe(): String = name\n\
+         }\n\
+         fun show(conn: Conn) {\n\
+         \x20 when (conn) {\n\
+         \x20   Conn.Idle -> conn.\n\
+         \x20   else -> {}\n\
+         \x20 }\n\
+         }",
+    );
+    let items = complete_dot(&idx, "conn", &app_uri, false, Some(8));
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"describe"),
+        "an unrelated same-named object must not validate an enum entry: {labels:?}"
+    );
+}

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -2548,6 +2548,32 @@ fn companion_object_forwarding_survives_a_private_companion() {
     );
 }
 
+/// Regression: `detail` is raw declaration text, so a comment sitting between
+/// the modifiers and the keywords lands in it. Testing for a lone `companion`
+/// token therefore classified `private /* companion */ object Registry` as a
+/// companion, forwarding an ordinary nested object's members onto the
+/// enclosing type. The two keywords must be adjacent.
+#[test]
+fn a_comment_mentioning_companion_does_not_make_an_object_a_companion() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Registry.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         class Host {\n\
+         \x20 private /* companion */ object Registry {\n\
+         \x20   fun registryOnly(): Int = 1\n\
+         \x20 }\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Host", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        !labels.contains(&"registryOnly"),
+        "a plain nested object's members must not forward onto the enclosing type: {labels:?}"
+    );
+}
+
 /// Regression: Kotlin gives every anonymous `companion object { }` the same
 /// implicit name ("Companion"), so two unrelated classes in the same file
 /// each have a companion literally named "Companion" — their members share

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -2426,6 +2426,56 @@ fn nested_type_completion_still_lists_sibling_nested_types_by_enclosing_type_nam
     );
 }
 
+/// Pre-existing bug in the same problem family as the two regressions above,
+/// found (not yet fixed) during the review that led to the container-based
+/// rewrite, and fixed here as a natural consequence of the
+/// `MembershipContext` split: `symbols_from_nested_type` used to answer
+/// "what does `inner_name` declare" identically whether the caller meant
+/// "the receiver IS `inner_name`" or "`inner_name` is an ancestor being
+/// folded into a DESCENDANT's inherited members" (`collect_inherited_dot_completion_items`'s
+/// `walk_hierarchy` callback). A nested type declaration IS a legitimate
+/// direct member of its own enclosing type (`Top.Leaf1` — see the test
+/// above) but is NEVER an inherited instance member of a descendant
+/// (`mid.Leaf1` isn't valid Kotlin) — so when `Mid` (itself nested inside
+/// `Top`, a common sealed-hierarchy shape) inherits `Top`'s members via
+/// `walk_hierarchy`, `Top`'s own nested-type declarations — its sibling
+/// `Leaf1`, and even `Mid` itself — leaked into `Mid`'s own inherited
+/// completion list as if they were instance members.
+#[test]
+fn sibling_nested_type_does_not_leak_into_inherited_completion() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Top.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         sealed class Top {\n\
+         \x20 class Mid : Top() {\n\
+         \x20   fun midMethod() {}\n\
+         \x20 }\n\
+         \x20 class Leaf1 : Top()\n\
+         \x20 fun topMethod() {}\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Mid", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"midMethod"),
+        "Mid's own direct member must still appear: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"topMethod"),
+        "Mid must still inherit Top's own instance member: {labels:?}"
+    );
+    assert!(
+        !labels.contains(&"Leaf1"),
+        "a sibling nested type must not leak into Mid's inherited completion: {labels:?}"
+    );
+    assert!(
+        !labels.contains(&"Mid"),
+        "Mid must not leak into its own inherited completion via its enclosing type: {labels:?}"
+    );
+}
+
 /// Regression: Kotlin resolves `Outer.member` through `Outer`'s own companion
 /// object when `Outer` has no such member itself (implicit companion
 /// forwarding) — a very common idiom, doubly so paired with sealed
@@ -2467,40 +2517,44 @@ fn companion_object_members_still_appear_on_enclosing_type_completion() {
     );
 }
 
-/// Regression (Copilot review on the fix above): companion detection used
-/// `detail.starts_with("companion object")`, which misses a modifier or
-/// annotation ahead of the keywords — a `private companion object` (or
-/// `@JvmStatic` on the line above) would not be recognized as a companion at
-/// all, silently dropping its members from the enclosing class's completion.
+/// Regression found by the container-based rewrite's own review: the
+/// companion-object detection in `symbols_from_nested_type` matched by
+/// PREFIX (`detail.starts_with("companion object")`), so a modified
+/// companion — `private companion object`, or any other leading modifier —
+/// never matched, and its members silently stopped forwarding to the
+/// enclosing type's own completion. `resolve::resolve_companion_member`
+/// (`resolve.rs`) had already fixed the identical gap for its own,
+/// independent companion lookup via a token-based match (see
+/// `resolve_qualified_class_name_prefers_private_companion_member`);
+/// `is_companion_object_symbol` applies the same fix here.
 #[test]
-fn companion_object_members_forward_despite_a_visibility_modifier() {
+fn companion_object_forwarding_survives_a_private_companion() {
     let idx = Indexer::new();
-    let file_uri = uri("/Widget.kt");
+    let file_uri = uri("/Widget2.kt");
     idx.index_content(
         &file_uri,
         "package app\n\
-         class Widget {\n\
+         class Widget2 {\n\
          \x20 private companion object {\n\
-         \x20   fun create(): Widget = Widget()\n\
+         \x20   fun create(): Widget2 = Widget2()\n\
          \x20 }\n\
          }",
     );
-    let items = complete_dot(&idx, "Widget", &file_uri, false, None);
+    let items = complete_dot(&idx, "Widget2", &file_uri, false, None);
     let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
     assert!(
         labels.contains(&"create"),
-        "a modifier ahead of 'companion object' must not hide companion forwarding: {labels:?}"
+        "a private companion's create() must still forward: {labels:?}"
     );
 }
 
-/// Regression (Copilot review on the fix above): Kotlin gives every anonymous
-/// `companion object { }` the same implicit name ("Companion"), so two
-/// unrelated classes in the same file each have a companion literally named
-/// "Companion" — their members share that same `container` string. Folding a
-/// companion's members in by container-NAME match alone (without also
-/// checking which specific companion instance a member's range belongs to)
-/// would leak one class's companion members into a completely different
-/// class's completion.
+/// Regression: Kotlin gives every anonymous `companion object { }` the same
+/// implicit name ("Companion"), so two unrelated classes in the same file
+/// each have a companion literally named "Companion" — their members share
+/// that same `container` string. Folding a companion's members in by
+/// container-NAME match alone (without also checking which specific
+/// companion instance a member's range belongs to) would leak one class's
+/// companion members into a completely different class's completion.
 #[test]
 fn companion_object_forwarding_does_not_leak_across_classes_sharing_the_implicit_name() {
     let idx = Indexer::new();
@@ -2528,44 +2582,6 @@ fn companion_object_forwarding_does_not_leak_across_classes_sharing_the_implicit
     assert!(
         !labels.contains(&"betaOnly"),
         "Beta's companion (same implicit 'Companion' name) must not leak into Alpha's completion: {labels:?}"
-    );
-}
-
-/// Regression (Copilot review): `container` stores only the immediate
-/// parent's simple NAME, not a unique identity — two different nested types
-/// sharing a simple name in one file (`A.Config` and `B.Config`) would have
-/// their members merged by a container-name-only check. `type_symbol` is
-/// already the one specific instance the outer lookup resolved to, so the
-/// membership check must also confirm a candidate's range falls inside that
-/// SPECIFIC instance's own range, not just any same-named one.
-#[test]
-fn same_named_nested_types_in_different_classes_do_not_merge_members() {
-    let idx = Indexer::new();
-    let file_uri = uri("/Configs.kt");
-    idx.index_content(
-        &file_uri,
-        "package app\n\
-         class A {\n\
-         \x20 class Config {\n\
-         \x20   val fromA = 1\n\
-         \x20 }\n\
-         }\n\
-         class B {\n\
-         \x20 class Config {\n\
-         \x20   val fromB = 2\n\
-         \x20 }\n\
-         }",
-    );
-    let items = complete_dot(&idx, "Config", &file_uri, false, None);
-    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
-    // Whichever `Config` instance the bare-name lookup resolves to, it must
-    // offer that instance's own member and never the OTHER one's — merging
-    // them would suggest a member that doesn't exist on the resolved type.
-    let has_a = labels.contains(&"fromA");
-    let has_b = labels.contains(&"fromB");
-    assert!(
-        has_a != has_b,
-        "expected exactly one of A.Config/B.Config's own members, not both (merged) or neither: {labels:?}"
     );
 }
 
@@ -5726,4 +5742,41 @@ fn receiver_provides_member_false_for_unrelated_name() {
         "package androidx.compose.ui\nobject Modifier",
     );
     assert!(!receiver_provides_member(&idx, "Modifier", "notAMember"));
+}
+
+/// Regression: `container` stores only the immediate parent's simple NAME,
+/// not a unique identity — two different nested types sharing a simple name
+/// in one file (`A.Config`/`B.Config`) are valid Kotlin (Kotlin only forbids
+/// a name collision among *top-level* declarations in one file, not among
+/// unrelated types' own nested members) and would have their members merged
+/// by a container-name-only check. `type_symbol` is already the one specific
+/// instance the outer lookup resolved to, so `members_for_workspace_type`
+/// must also confirm a candidate's range falls inside that SPECIFIC
+/// instance's own range, not just any same-named one.
+#[test]
+fn same_named_nested_types_in_different_classes_do_not_merge_members() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Configs.kt");
+    idx.index_content(
+        &file_uri,
+        "package app\n\
+         class A {\n\
+         \x20 class Config {\n\
+         \x20   val fromA = 1\n\
+         \x20 }\n\
+         }\n\
+         class B {\n\
+         \x20 class Config {\n\
+         \x20   val fromB = 2\n\
+         \x20 }\n\
+         }",
+    );
+    let items = complete_dot(&idx, "Config", &file_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    let has_a = labels.contains(&"fromA");
+    let has_b = labels.contains(&"fromB");
+    assert!(
+        has_a != has_b,
+        "expected exactly one of A.Config/B.Config's own members, not both (merged) or neither: {labels:?}"
+    );
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -272,6 +272,22 @@ impl SymbolEntry {
         self.selection_range.start.line
     }
 
+    /// Whether this is a `companion object` declaration, named
+    /// (`companion object Factory`) or anonymous (synthesized under the
+    /// implicit name `Companion` — see `parser::extract_anonymous_companion_objects`).
+    ///
+    /// `kind` alone can't tell one apart from a plain `object`; the
+    /// `companion` soft-keyword survives only in `detail`, the raw
+    /// declaration text. Matched as a whitespace-delimited token, since
+    /// modifiers and annotations may precede it (`private companion object`).
+    pub(crate) fn is_companion_object(&self) -> bool {
+        self.kind == SymbolKind::OBJECT
+            && self
+                .detail
+                .split_whitespace()
+                .any(|token| token == "companion")
+    }
+
     /// Generic type parameter names extracted from the CST at parse time.
     /// e.g. `class Foo<T, U>` → `["T", "U"]`. Empty slice for non-generic symbols.
     pub(crate) fn type_params(&self) -> &[String] {

--- a/src/types.rs
+++ b/src/types.rs
@@ -278,14 +278,19 @@ impl SymbolEntry {
     ///
     /// `kind` alone can't tell one apart from a plain `object`; the
     /// `companion` soft-keyword survives only in `detail`, the raw
-    /// declaration text. Matched as a whitespace-delimited token, since
-    /// modifiers and annotations may precede it (`private companion object`).
+    /// declaration text — which may carry modifiers, annotations, and
+    /// comments alongside the keywords. Matching the two keywords as
+    /// *adjacent* tokens accepts every real form (`private companion
+    /// object`, `companion object Factory`) while rejecting a comment that
+    /// merely mentions the word (`private /* companion */ object Registry`).
     pub(crate) fn is_companion_object(&self) -> bool {
-        self.kind == SymbolKind::OBJECT
-            && self
-                .detail
-                .split_whitespace()
-                .any(|token| token == "companion")
+        if self.kind != SymbolKind::OBJECT {
+            return false;
+        }
+        let tokens: Vec<&str> = self.detail.split_whitespace().collect();
+        tokens
+            .windows(2)
+            .any(|pair| pair[0] == "companion" && pair[1] == "object")
     }
 
     /// Generic type parameter names extracted from the CST at parse time.

--- a/src/workspace/file_change_handler_tests.rs
+++ b/src/workspace/file_change_handler_tests.rs
@@ -112,3 +112,65 @@ async fn retype_cycle_indexer_state_supports_diagnostics() {
         "step3: expected diagnostic after retype — indexer state is stale"
     );
 }
+
+/// A member added to a nested type by a live buffer edit must reach dot
+/// completion once the debounce settles. Covers the full async pipeline
+/// (didChange → debounce → index_content → member enumeration), which the
+/// unit-level completion tests bypass by indexing synchronously.
+#[tokio::test]
+async fn live_added_nested_val_reaches_member_completion() {
+    use tower_lsp::lsp_types::Position;
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();
+    let file_path = tmp.path().join("Ui.kt");
+
+    let indexer = Arc::new(Indexer::new());
+    indexer.workspace_root.set(tmp.path().to_path_buf());
+    let mut handler = FileChangeHandler::new(Arc::clone(&indexer), None);
+    let uri = Url::parse(&format!("file://{}", file_path.display())).unwrap();
+
+    let before = concat!(
+        "package app\n",
+        "sealed interface MainActivityUiState {\n",
+        "    data object Loading : MainActivityUiState {\n",
+        "    }\n",
+        "}\n",
+        "fun use(state: MainActivityUiState) {\n",
+        "    when (state) {\n",
+        "        is Loading -> state.\n",
+        "    }\n",
+        "}\n",
+    );
+    let after = concat!(
+        "package app\n",
+        "sealed interface MainActivityUiState {\n",
+        "    data object Loading : MainActivityUiState {\n",
+        "        val zload = test()\n",
+        "    }\n",
+        "}\n",
+        "fun use(state: MainActivityUiState) {\n",
+        "    when (state) {\n",
+        "        is Loading -> state.\n",
+        "    }\n",
+        "}\n",
+    );
+
+    std::fs::write(&file_path, before).unwrap();
+    handler
+        .handle_file_changed(uri.clone(), change(before))
+        .await;
+    handler.wait_for_pending_reindex(&uri).await;
+
+    handler
+        .handle_file_changed(uri.clone(), change(after))
+        .await;
+    handler.wait_for_pending_reindex(&uri).await;
+
+    // `is Loading -> state.` is line 8 (0-based) in `after`, col after the dot.
+    let line = 8u32;
+    let col = "        is Loading -> state.".len() as u32;
+    let (items, _) = indexer.completions(&uri, Position::new(line, col), false);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(labels.contains(&"zload"), "zload missing: {labels:?}");
+}


### PR DESCRIPTION
**Stacked on #257** — targets that branch so the diff here stays scoped. Retarget to `main` once #257 merges.

## Summary

Reported from live testing against nowinandroid: deleting a branch from

```kotlin
override val shouldUseAndroidTheme: Boolean = when (userData.themeBrand) {
    ThemeBrand.DEFAULT -> false
    ThemeBrand.ANDROID -> true
}
```

produced no diagnostic, no matter how many branches were missing. Two independent causes, each enough on its own to silence it:

1. **Field-access subjects were unresolvable.** `extract_subject_identifier` accepted only a bare `simple_identifier`, so `when (userData.themeBrand)` yielded no subject and `analyze_when` returned before ever checking exhaustiveness. Only a plain local worked. It now flattens a `navigation_expression` into its segments and resolves the chain via `infer_field_chain_type` — which already does exactly this for the nullable-dot-call diagnostic, so the capability existed and simply wasn't reached from here. Single identifiers keep their existing CST-then-name-scan path.

2. **Single-line enums yielded no members.** `collect_enum_members` required an entry's start *line* to be strictly greater than the enum's, so `enum class Compact { ON, OFF }` collected nothing. Replaced with column-aware `range_encloses`, which handles both layouts.

Sealed hierarchies were unaffected throughout and still behave identically.

## Test plan
- [x] Verified end-to-end on the reported shape: both `when (userData.themeBrand)` and `when (userData.darkThemeConfig)` now report their missing branches
- [x] New regression tests: `diagnostics_reports_missing_branches_for_a_field_access_subject`, `diagnostics_reports_missing_branches_for_a_single_line_enum` — both confirmed failing against the pre-fix code
- [x] `diagnostics_ignores_a_call_expression_subject` guards the new navigation walk against picking an identifier out of a call subject (passes before and after — it protects the change, it doesn't pin a fix)
- [x] `cargo test --bin kmp-lsp`: 1701 passed, 0 failed
- [x] All integration suites pass; `cargo fmt --check` and `cargo clippy --bin kmp-lsp --tests` clean, zero warnings