### PR TITLE
fix(stack-overflow): bound all hand-rolled recursive CST descents

### DIFF
--- a/src/cli/tokens.rs
+++ b/src/cli/tokens.rs
@@ -268,6 +268,17 @@ pub(crate) fn dump_tree(file: &Path) -> Result<(), String> {
 }
 
 fn print_node(node: tree_sitter::Node<'_>, source: &[u8], depth: usize) {
+    // See `crate::util::MAX_CST_DESCENT_DEPTH`: bail rather than overflow the
+    // stack on a pathologically deep tree (huge chained expression, or
+    // ERROR-recovery on a huge malformed file).
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        println!(
+            "{}… (truncated: depth limit {} reached)",
+            "  ".repeat(depth),
+            crate::util::MAX_CST_DESCENT_DEPTH
+        );
+        return;
+    }
     let indent = "  ".repeat(depth);
     let start = node.start_position();
     let end = node.end_position();

--- a/src/features/call_arg_diagnostics.rs
+++ b/src/features/call_arg_diagnostics.rs
@@ -89,7 +89,7 @@ fn collect_call_nodes(
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("collect_call_nodes", node);
+        crate::util::report_cst_depth_exceeded!("collect_call_nodes", node);
         return;
     }
 

--- a/src/features/call_arg_diagnostics.rs
+++ b/src/features/call_arg_diagnostics.rs
@@ -89,6 +89,7 @@ fn collect_call_nodes(
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("collect_call_nodes", node);
         return;
     }
 

--- a/src/features/call_arg_diagnostics.rs
+++ b/src/features/call_arg_diagnostics.rs
@@ -54,6 +54,7 @@ pub(crate) fn call_arg_diagnostics(indexer: &Indexer, uri: &Url, doc: &LiveDoc) 
         &mut diagnostics,
         &mut stats,
         &mut sig_cache,
+        0,
     );
     log::debug!(
         "call_arg_diagnostics: {} call_expr nodes, {} skipped(lambda), {} skipped(scope), {} resolved ({} cache hits), {}ms",
@@ -73,6 +74,7 @@ struct DiagStats {
     resolve_ms: u128,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_call_nodes(
     node: tree_sitter::Node,
     bytes: &[u8],
@@ -81,7 +83,15 @@ fn collect_call_nodes(
     diagnostics: &mut Vec<Diagnostic>,
     stats: &mut DiagStats,
     sig_cache: &mut std::collections::HashMap<(String, Option<String>), Resolution<Signature>>,
+    depth: usize,
 ) {
+    // See `crate::util::MAX_CST_DESCENT_DEPTH`: bail rather than overflow the
+    // stack on a pathologically deep tree (huge chained expression, or
+    // ERROR-recovery on a huge malformed file).
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return;
+    }
+
     if node.kind() == KIND_CALL_EXPR {
         if let Some(diag) = check_call_args(&node, bytes, indexer, uri, stats, sig_cache) {
             diagnostics.push(diag);
@@ -99,6 +109,7 @@ fn collect_call_nodes(
                 diagnostics,
                 stats,
                 sig_cache,
+                depth + 1,
             );
             if !cursor.goto_next_sibling() {
                 break;

--- a/src/features/call_arg_diagnostics_tests.rs
+++ b/src/features/call_arg_diagnostics_tests.rs
@@ -1647,3 +1647,24 @@ fn swift_overloaded_explicit_init_suppresses_diagnostic() {
         "ambiguous between two init arities — must suppress: {diags:?}"
     );
 }
+
+/// Regression: `collect_call_nodes` recurses over every CST node
+/// unconditionally, with no depth guard. A long chain of `+` — perfectly
+/// valid Kotlin, no malformed/ERROR-recovery input needed — parses as a
+/// deeply left-nested `binary_expression` tree, and before
+/// `MAX_CST_DESCENT_DEPTH` was added this overflowed an 8 MiB stack
+/// (Linux's real main-thread default). This drives `call_arg_diagnostics`
+/// — the production entry point — several times past the old crash
+/// threshold; without the guard this aborts the whole test process rather
+/// than failing an assertion.
+#[test]
+fn call_arg_diagnostics_survives_a_pathologically_deep_expression() {
+    let n = 5_000; // several times MAX_CST_DESCENT_DEPTH (512)
+    let mut src = String::from("fun f() {\n    val x = 1");
+    for _ in 0..n {
+        src.push_str("+1");
+    }
+    src.push_str("\n}\n");
+    let (uri, idx, src) = setup(&[("/a.kt", &src)]);
+    let _ = run_diagnostics(&idx, &uri, &src);
+}

--- a/src/features/definition.rs
+++ b/src/features/definition.rs
@@ -33,11 +33,19 @@ pub(crate) fn locs_to_opt_response(locs: Vec<Location>) -> Option<GotoDefinition
 
 // ─── rg fallback ─────────────────────────────────────────────────────────────
 
+/// Throttle counter for the join-panic warning below — see
+/// [`crate::util::throttled_warn`]. This is the last-resort fallback on the
+/// goto-definition path: a panic here silently degrades "no definition
+/// found" from an rg miss to an unwound task, which looks identical to the
+/// caller.
+static RG_RESOLVE_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 async fn rg_resolve(index: &impl SearchAccess, uri: &Url, name: &str) -> Vec<Location> {
     let name_clone = name.to_string();
     let file_path = uri.to_file_path().ok();
     let (root_opt, source_roots, matcher) = index.rg_scope_for_path(file_path.as_deref());
-    tokio::task::spawn_blocking(move || {
+    let join_result = tokio::task::spawn_blocking(move || {
         rg::rg_find_definition(
             &name_clone,
             root_opt.as_deref(),
@@ -45,8 +53,19 @@ async fn rg_resolve(index: &impl SearchAccess, uri: &Url, name: &str) -> Vec<Loc
             matcher.as_deref(),
         )
     })
-    .await
-    .unwrap_or_default()
+    .await;
+    if let Err(ref e) = join_result {
+        crate::util::throttled_warn(&RG_RESOLVE_JOIN_FAILURES, 5, || {
+            crate::util::join_failure_message(
+                &format!(
+                    "running the rg goto-definition fallback for `{name}` from {}",
+                    uri.path()
+                ),
+                e,
+            )
+        });
+    }
+    join_result.unwrap_or_default()
 }
 
 // ─── Super helpers ────────────────────────────────────────────────────────────

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -207,6 +207,7 @@ fn collect_when_nodes(
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("collect_when_nodes", node);
         return;
     }
 
@@ -522,6 +523,7 @@ fn collect_navigation_segments(
     depth: usize,
 ) -> Option<()> {
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("collect_navigation_segments", *node);
         return None;
     }
     match node.kind() {

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -207,7 +207,7 @@ fn collect_when_nodes(
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("collect_when_nodes", node);
+        crate::util::report_cst_depth_exceeded!("collect_when_nodes", node);
         return;
     }
 
@@ -523,7 +523,7 @@ fn collect_navigation_segments(
     depth: usize,
 ) -> Option<()> {
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("collect_navigation_segments", *node);
+        crate::util::report_cst_depth_exceeded!("collect_navigation_segments", *node);
         return None;
     }
     match node.kind() {

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -177,6 +177,7 @@ pub(crate) fn when_diagnostics(indexer: &Indexer, uri: &Url) -> Vec<Diagnostic> 
         &mut diagnostics,
         &mut sealed_cache,
         &mut type_members_cache,
+        0,
     );
     let elapsed = diag_start.elapsed();
     if elapsed.as_millis() > 50 {
@@ -191,6 +192,7 @@ pub(crate) fn when_diagnostics(indexer: &Indexer, uri: &Url) -> Vec<Diagnostic> 
     diagnostics
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_when_nodes(
     node: tree_sitter::Node,
     source: &[u8],
@@ -199,7 +201,15 @@ fn collect_when_nodes(
     diagnostics: &mut Vec<Diagnostic>,
     sealed_cache: &mut SealedMembersCache,
     type_members_cache: &mut TypeMembersCache,
+    depth: usize,
 ) {
+    // See `crate::util::MAX_CST_DESCENT_DEPTH`: bail rather than overflow the
+    // stack on a pathologically deep tree (huge chained expression, or
+    // ERROR-recovery on a huge malformed file).
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return;
+    }
+
     if node.kind() == KIND_WHEN_EXPR {
         // Emit a warning whenever a `when` over a sealed class or enum is missing
         // branches and has no `else`.  This applies to both expression-form and
@@ -239,6 +249,7 @@ fn collect_when_nodes(
                 diagnostics,
                 sealed_cache,
                 type_members_cache,
+                depth + 1,
             );
             if !cursor.goto_next_sibling() {
                 break;
@@ -489,7 +500,7 @@ fn extract_subject_segments(
             }
             KIND_NAV_EXPR => {
                 let mut segments = Vec::new();
-                collect_navigation_segments(&child, source, &mut segments)?;
+                collect_navigation_segments(&child, source, &mut segments, 0)?;
                 return Some(segments);
             }
             _ => {}
@@ -500,18 +511,26 @@ fn extract_subject_segments(
 
 /// Flatten a `navigation_expression` into its identifier segments, failing on
 /// anything that isn't a plain field access (a call in the chain, say).
+///
+/// Kind-bounded (only descends through `KIND_NAV_EXPR`/`KIND_NAV_SUFFIX`), but
+/// an arbitrarily long `a.b.c.d…` chain is still an arbitrarily deep
+/// recursion — `depth` caps it. See `crate::util::MAX_CST_DESCENT_DEPTH`.
 fn collect_navigation_segments(
     node: &tree_sitter::Node,
     source: &[u8],
     out: &mut Vec<String>,
+    depth: usize,
 ) -> Option<()> {
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return None;
+    }
     match node.kind() {
         KIND_SIMPLE_IDENT => out.push(node.utf8_text(source).ok()?.to_owned()),
         KIND_NAV_EXPR | KIND_NAV_SUFFIX => {
             for child in node.children(&mut node.walk()) {
                 // The `.` separator carries no segment of its own.
                 if child.kind() != "." {
-                    collect_navigation_segments(&child, source, out)?;
+                    collect_navigation_segments(&child, source, out, depth + 1)?;
                 }
             }
         }

--- a/src/features/fill_when_tests.rs
+++ b/src/features/fill_when_tests.rs
@@ -988,3 +988,30 @@ fun test(): String = when (pick()) {
         "a call subject must not be guessed at: {diags:?}"
     );
 }
+
+/// Regression: `collect_navigation_segments` only descends through
+/// navigation-expression node kinds, so it bails immediately on anything
+/// else — but a long, entirely ordinary field-access chain (`a.b.c.d…`)
+/// never leaves those kinds, so its recursion depth is unbounded in the
+/// length of the chain. Before `MAX_CST_DESCENT_DEPTH` was added, a subject
+/// chain of tens of thousands of segments overflowed an 8 MiB stack
+/// (matching Linux's real main-thread default) — no malformed/ERROR-recovery
+/// input needed, just an ordinary (if absurd) `when (a.b.c…)`.  This runs
+/// `when_diagnostics` — the production entry point — end to end on a chain
+/// several times past the old crash threshold; without the guard this
+/// aborts the whole test process rather than failing an assertion.
+#[test]
+fn diagnostics_survives_a_pathologically_deep_when_subject_chain() {
+    let n = 5_000; // several times MAX_CST_DESCENT_DEPTH (512)
+    let mut chain = String::from("a");
+    for i in 0..n {
+        chain.push_str(&format!(".b{i}"));
+    }
+    let src = format!(
+        "fun test(a: Any) {{\n    when ({chain}) {{\n        Color.RED -> \"red\"\n    }}\n}}\n"
+    );
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", &src)]);
+    // Must return (not overflow the stack) — the specific result doesn't
+    // matter since the subject type can never resolve.
+    let _ = when_diagnostics(&idx, &uri("/main.kt"));
+}

--- a/src/features/implementation.rs
+++ b/src/features/implementation.rs
@@ -19,6 +19,15 @@ use crate::indexer::{classify_cursor, Indexer, SymbolRole};
 use crate::rg;
 use crate::types::FileData;
 
+/// Throttle counters for the join-panic warnings below — see
+/// [`crate::util::throttled_warn`]. A panic here means goto-implementation
+/// silently returns "no implementations", indistinguishable from a genuine
+/// zero-implementors result.
+static RG_FIND_IMPLEMENTORS_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static RG_FIND_METHOD_OVERRIDES_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 /// Find implementations for the symbol at `position` — CST-resolved first
 /// (works from a CALL SITE via the receiver's type, not just the declaration
 /// line), falling back to the existing name+line path.
@@ -82,7 +91,7 @@ async fn find_type_implementations(
         let file_path = uri.to_file_path().ok();
         let (root_opt, source_roots, matcher) = index.rg_scope_for_path(file_path.as_deref());
         let word_clone = type_name.to_string();
-        let rg_impls = tokio::task::spawn_blocking(move || {
+        let join_result = tokio::task::spawn_blocking(move || {
             rg::rg_find_implementors(
                 &word_clone,
                 root_opt.as_deref(),
@@ -90,8 +99,19 @@ async fn find_type_implementations(
                 matcher.as_deref(),
             )
         })
-        .await
-        .unwrap_or_default();
+        .await;
+        if let Err(ref e) = join_result {
+            crate::util::throttled_warn(&RG_FIND_IMPLEMENTORS_JOIN_FAILURES, 5, || {
+                crate::util::join_failure_message(
+                    &format!(
+                        "running the rg goto-implementation fallback for `{type_name}` from {}",
+                        uri.path()
+                    ),
+                    e,
+                )
+            });
+        }
+        let rg_impls = join_result.unwrap_or_default();
         if !rg_impls.is_empty() {
             return locs_to_opt_response(rg_impls);
         }
@@ -228,7 +248,7 @@ async fn find_method_implementations(
         let (root_opt, source_roots, matcher) = index.rg_scope_for_path(file_path.as_deref());
         let method = method_name.to_string();
         let class = declaring_class.to_string();
-        let rg_locs = tokio::task::spawn_blocking(move || {
+        let join_result = tokio::task::spawn_blocking(move || {
             rg::rg_find_method_overrides(
                 &method,
                 &class,
@@ -237,8 +257,20 @@ async fn find_method_implementations(
                 matcher.as_deref(),
             )
         })
-        .await
-        .unwrap_or_default();
+        .await;
+        if let Err(ref e) = join_result {
+            crate::util::throttled_warn(&RG_FIND_METHOD_OVERRIDES_JOIN_FAILURES, 5, || {
+                crate::util::join_failure_message(
+                    &format!(
+                        "running the rg override-search fallback for `{method_name}` in \
+                         `{declaring_class}` from {}",
+                        uri.path()
+                    ),
+                    e,
+                )
+            });
+        }
+        let rg_locs = join_result.unwrap_or_default();
         return locs_to_opt_response(rg_locs);
     }
 

--- a/src/features/missing_import_diagnostics.rs
+++ b/src/features/missing_import_diagnostics.rs
@@ -108,7 +108,16 @@ fn collect_candidates(
     type_params: &HashSet<String>,
     receivers: &[String],
     out: &mut Vec<Candidate>,
+    depth: usize,
 ) {
+    // A pathological input (a single expression with tens of thousands of
+    // chained tokens, or ERROR-recovery on a huge malformed file) can nest
+    // far deeper than any real Kotlin syntax — bail rather than overflow the
+    // stack. See `crate::util::MAX_CST_DESCENT_DEPTH`.
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return;
+    }
+
     let kind = node.kind();
 
     // Don't descend into import/package declarations — their identifiers aren't uses.
@@ -212,7 +221,7 @@ fn collect_candidates(
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_candidates(child, src, active, active_receivers, out);
+        collect_candidates(child, src, active, active_receivers, out, depth + 1);
     }
 }
 
@@ -237,6 +246,7 @@ pub(crate) fn collect_missing_import_flags(
         &HashSet::new(),
         &[],
         &mut candidates,
+        0,
     );
 
     // `importable` / `in-scope` are per-name; only the receiver check is per-occurrence,

--- a/src/features/missing_import_diagnostics.rs
+++ b/src/features/missing_import_diagnostics.rs
@@ -115,7 +115,7 @@ fn collect_candidates(
     // far deeper than any real Kotlin syntax — bail rather than overflow the
     // stack. See `crate::util::MAX_CST_DESCENT_DEPTH`.
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("collect_candidates", node);
+        crate::util::report_cst_depth_exceeded!("collect_candidates", node);
         return;
     }
 

--- a/src/features/missing_import_diagnostics.rs
+++ b/src/features/missing_import_diagnostics.rs
@@ -115,6 +115,7 @@ fn collect_candidates(
     // far deeper than any real Kotlin syntax — bail rather than overflow the
     // stack. See `crate::util::MAX_CST_DESCENT_DEPTH`.
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("collect_candidates", node);
         return;
     }
 

--- a/src/features/missing_import_diagnostics_tests.rs
+++ b/src/features/missing_import_diagnostics_tests.rs
@@ -242,3 +242,24 @@ fn no_import_action_for_an_unrelated_diagnostic() {
         "must not fire for diagnostics that aren't ours: {actions:?}"
     );
 }
+
+/// Regression: `collect_candidates` recurses over every CST node
+/// unconditionally, with no depth guard. A long chain of `+` — perfectly
+/// valid Kotlin, no malformed/ERROR-recovery input needed — parses as a
+/// deeply left-nested `binary_expression` tree, and before
+/// `MAX_CST_DESCENT_DEPTH` was added this overflowed an 8 MiB stack
+/// (Linux's real main-thread default). This drives
+/// `missing_import_diagnostics` — the production entry point — several
+/// times past the old crash threshold; without the guard this aborts the
+/// whole test process rather than failing an assertion.
+#[test]
+fn missing_import_diagnostics_survives_a_pathologically_deep_expression() {
+    let n = 5_000; // several times MAX_CST_DESCENT_DEPTH (512)
+    let mut src = String::from("package app\nfun f() {\n    val x = 1");
+    for _ in 0..n {
+        src.push_str("+1");
+    }
+    src.push_str("\n}\n");
+    let (uri, idx, src) = setup(&[("/a.kt", &src)]);
+    let _ = run_diagnostics(&idx, &uri, &src);
+}

--- a/src/features/nullable_call_diagnostics.rs
+++ b/src/features/nullable_call_diagnostics.rs
@@ -51,7 +51,14 @@ pub(crate) fn nullable_dot_call_diagnostics(
     //     them — `s.let { }` on a nullable `s` is never flagged.
     let bytes = &doc.bytes;
     let mut diagnostics = Vec::new();
-    collect_nav_nodes(doc.tree.root_node(), bytes, indexer, uri, &mut diagnostics);
+    collect_nav_nodes(
+        doc.tree.root_node(),
+        bytes,
+        indexer,
+        uri,
+        &mut diagnostics,
+        0,
+    );
     diagnostics
 }
 
@@ -61,7 +68,15 @@ fn collect_nav_nodes(
     indexer: &Indexer,
     uri: &Url,
     diagnostics: &mut Vec<Diagnostic>,
+    depth: usize,
 ) {
+    // See `crate::util::MAX_CST_DESCENT_DEPTH`: bail rather than overflow the
+    // stack on a pathologically deep tree (huge chained expression, or
+    // ERROR-recovery on a huge malformed file).
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return;
+    }
+
     if node.kind() == KIND_NAV_EXPR {
         if let Some(diag) = check_nullable_dot_call(&node, bytes, indexer, uri) {
             diagnostics.push(diag);
@@ -71,7 +86,7 @@ fn collect_nav_nodes(
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
         loop {
-            collect_nav_nodes(cursor.node(), bytes, indexer, uri, diagnostics);
+            collect_nav_nodes(cursor.node(), bytes, indexer, uri, diagnostics, depth + 1);
             if !cursor.goto_next_sibling() {
                 break;
             }
@@ -206,6 +221,20 @@ fn resolve_receiver(
 ///
 /// `holder.repo` → `["holder", "repo"]`; `getFoo().bar` → `None`.
 fn pure_field_chain(node: &tree_sitter::Node, bytes: &[u8]) -> Option<Vec<String>> {
+    pure_field_chain_at(node, bytes, 0)
+}
+
+fn pure_field_chain_at(
+    node: &tree_sitter::Node,
+    bytes: &[u8],
+    depth: usize,
+) -> Option<Vec<String>> {
+    // Kind-bounded (only descends through KIND_NAV_EXPR), but an arbitrarily
+    // long `a.b.c.d…` field-access chain is still an arbitrarily deep
+    // recursion — cap it. See `crate::util::MAX_CST_DESCENT_DEPTH`.
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return None;
+    }
     match node.kind() {
         KIND_SIMPLE_IDENT => Some(vec![node.utf8_text_owned(bytes)?]),
         KIND_NAV_EXPR => {
@@ -221,7 +250,7 @@ fn pure_field_chain(node: &tree_sitter::Node, bytes: &[u8]) -> Option<Vec<String
                 return None;
             }
             let field = suffix.first_child_of_kind(KIND_SIMPLE_IDENT)?;
-            let mut chain = pure_field_chain(&receiver, bytes)?;
+            let mut chain = pure_field_chain_at(&receiver, bytes, depth + 1)?;
             chain.push(field.utf8_text_owned(bytes)?);
             Some(chain)
         }

--- a/src/features/nullable_call_diagnostics.rs
+++ b/src/features/nullable_call_diagnostics.rs
@@ -74,6 +74,7 @@ fn collect_nav_nodes(
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("collect_nav_nodes", node);
         return;
     }
 
@@ -233,6 +234,7 @@ fn pure_field_chain_at(
     // long `a.b.c.d…` field-access chain is still an arbitrarily deep
     // recursion — cap it. See `crate::util::MAX_CST_DESCENT_DEPTH`.
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("pure_field_chain_at", *node);
         return None;
     }
     match node.kind() {

--- a/src/features/nullable_call_diagnostics.rs
+++ b/src/features/nullable_call_diagnostics.rs
@@ -74,7 +74,7 @@ fn collect_nav_nodes(
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("collect_nav_nodes", node);
+        crate::util::report_cst_depth_exceeded!("collect_nav_nodes", node);
         return;
     }
 
@@ -234,7 +234,7 @@ fn pure_field_chain_at(
     // long `a.b.c.d…` field-access chain is still an arbitrarily deep
     // recursion — cap it. See `crate::util::MAX_CST_DESCENT_DEPTH`.
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("pure_field_chain_at", *node);
+        crate::util::report_cst_depth_exceeded!("pure_field_chain_at", *node);
         return None;
     }
     match node.kind() {

--- a/src/features/nullable_call_diagnostics_tests.rs
+++ b/src/features/nullable_call_diagnostics_tests.rs
@@ -544,3 +544,24 @@ fn direct_nested_field_chain_member_resolves_despite_same_named_decoy() {
     );
     assert!(diagnostics[0].message.contains("tabCzech"));
 }
+
+/// Regression: `collect_nav_nodes` recurses over every CST node
+/// unconditionally, and `pure_field_chain` recurses through an arbitrarily
+/// long field-access chain — neither had a depth guard. Before
+/// `MAX_CST_DESCENT_DEPTH` was added, a long `a.b.c.d…` chain (ordinary
+/// Kotlin, no malformed input needed) overflowed an 8 MiB stack (Linux's
+/// real main-thread default). This drives `nullable_dot_call_diagnostics`
+/// — the production entry point — several times past the old crash
+/// threshold; without the guard this aborts the whole test process rather
+/// than failing an assertion.
+#[test]
+fn nullable_diagnostics_survives_a_pathologically_deep_field_chain() {
+    let n = 5_000; // several times MAX_CST_DESCENT_DEPTH (512)
+    let mut chain = String::from("a");
+    for i in 0..n {
+        chain.push_str(&format!(".b{i}"));
+    }
+    let src = format!("fun f(a: Any) {{\n    {chain}\n}}\n");
+    let (uri, idx, src) = setup(&[("/a.kt", &src)]);
+    let _ = run_diagnostics(&idx, &uri, &src);
+}

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -422,6 +422,13 @@ fn reference_matches_parent_class(
 
 // ─── rg search ────────────────────────────────────────────────────────────────
 
+/// Throttle counter for the join-panic warning below — see
+/// [`crate::util::throttled_warn`]. A panic here means "find references"
+/// silently returns an empty list, indistinguishable from a genuine
+/// zero-references result.
+static RG_LOCATIONS_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 async fn rg_locations(
     search: &ReferenceSearch,
     index: &(impl SymbolIndex + ScopeQuery + SearchAccess + Send + Sync),
@@ -475,7 +482,7 @@ async fn rg_locations(
         (vec![], vec![])
     };
     let request = search.clone();
-    tokio::task::spawn_blocking(move || {
+    let join_result = tokio::task::spawn_blocking(move || {
         let rg_req = RgSearchRequest::new(
             &request.name,
             request.parent_class.as_deref(),
@@ -504,8 +511,24 @@ async fn rg_locations(
         };
         crate::rg::rg_find_references(&rg_req, matcher.as_deref())
     })
-    .await
-    .unwrap_or_default()
+    .await;
+    let join_result = match join_result {
+        Ok(locs) => Ok(locs),
+        Err(e) => {
+            crate::util::throttled_warn(&RG_LOCATIONS_JOIN_FAILURES, 5, || {
+                crate::util::join_failure_message(
+                    &format!(
+                        "running the rg find-references fallback for `{}` from {}",
+                        search.name,
+                        search.uri.path()
+                    ),
+                    &e,
+                )
+            });
+            Err(e)
+        }
+    };
+    join_result.unwrap_or_default()
 }
 
 // ─── In-memory current-file injection ─────────────────────────────────────────

--- a/src/features/unused_import_diagnostics.rs
+++ b/src/features/unused_import_diagnostics.rs
@@ -194,7 +194,7 @@ pub(crate) fn collect_unused_import_flags(doc: &LiveDoc) -> Vec<UnusedImportFlag
 /// reference token found inside comment-leaf text, skipping the import/package
 /// headers themselves. Deliberately unstructured — see the module doc for why.
 fn collect_used_identifier_texts<'a>(node: Node<'a>, bytes: &'a [u8], out: &mut HashSet<&'a str>) {
-    collect_used_identifier_texts_inner(node, bytes, false, false, out);
+    collect_used_identifier_texts_inner(node, bytes, false, false, out, 0);
 }
 
 /// `in_declaration_header` suppresses identifier-text collection while inside
@@ -214,7 +214,16 @@ fn collect_used_identifier_texts_inner<'a>(
     in_declaration_header: bool,
     parent_has_error: bool,
     out: &mut HashSet<&'a str>,
+    depth: usize,
 ) {
+    // This walks every node in the file, so ERROR recovery on a huge
+    // malformed buffer nests it far deeper than real syntax ever does — bail
+    // rather than overflow the stack. See `crate::util::MAX_CST_DESCENT_DEPTH`.
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded!("collect_used_identifier_texts_inner", node);
+        return;
+    }
+
     let kind = node.kind();
     let in_declaration_header =
         in_declaration_header || kind == KIND_IMPORT_HEADER || kind == KIND_PACKAGE_HEADER;
@@ -276,6 +285,7 @@ fn collect_used_identifier_texts_inner<'a>(
             in_declaration_header,
             this_has_error,
             out,
+            depth + 1,
         );
     }
 }

--- a/src/features/unused_import_diagnostics_tests.rs
+++ b/src/features/unused_import_diagnostics_tests.rs
@@ -270,3 +270,21 @@ fn offers_a_remove_import_quickfix_for_a_flagged_diagnostic() {
         "must delete the whole line including its newline"
     );
 }
+
+#[test]
+fn unused_import_diagnostics_survives_a_pathologically_deep_expression() {
+    let n = 60_000; // ~100x MAX_CST_DESCENT_DEPTH (512)
+    let mut source =
+        String::from("package app\n\nimport com.example.lib.Unused\n\nfun f() {\n    val x = 1");
+    for _ in 0..n {
+        source.push_str("+1");
+    }
+    source.push_str("\n}\n");
+
+    let handle = std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024) // match Linux's default main-thread stack
+        .spawn(move || run_diagnostics(&source).len())
+        .unwrap();
+    // A stack overflow aborts the process rather than failing this join.
+    handle.join().expect("must not overflow the stack");
+}

--- a/src/features/workspace_symbols.rs
+++ b/src/features/workspace_symbols.rs
@@ -14,6 +14,11 @@ use super::traits::{SearchAccess, SymbolIndex};
 /// Maximum results returned from the index scan.
 const WORKSPACE_SYMBOL_CAP: usize = 512;
 
+/// Throttle counter for [`collect_index_symbols`]'s URI-parse warning — see
+/// [`crate::util::throttled_warn`].
+static INDEXED_FILE_URI_PARSE_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 /// Timeout for the rg cold-start fallback.
 ///
 /// Note: this bounds how long `compute_workspace_symbols` *awaits* the
@@ -58,6 +63,19 @@ fn collect_index_symbols(
     let mut f = |uri_str: &str, data: &Arc<FileData>| {
         index_populated = true;
         let Some(uri) = parse_uri(uri_str) else {
+            // `uri_str` is a key of `Indexer::files`/`jar_files`, always
+            // inserted as `Url::to_string()` of a URI this process produced
+            // (or a `Url::from_file_path` round-trip for the same). Neither
+            // parse should ever fail here — a hit means the key is
+            // corrupted, and every symbol in this file silently drops out
+            // of workspace-symbol search.
+            crate::util::throttled_warn(&INDEXED_FILE_URI_PARSE_FAILURES, 5, || {
+                format!(
+                    "workspace_symbols: indexed file key {uri_str:?} is not a valid URI or file \
+                     path — its {} symbol(s) are excluded from every workspace-symbol search",
+                    data.symbols.len(),
+                )
+            });
             return true;
         };
         for symbol in &data.symbols {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -954,6 +954,8 @@ impl Indexer {
             } else {
                 JarPhase::Unavailable
             };
+        } else {
+            crate::indexer::jar_phase::report_jar_phase_lock_poisoned("Indexer::clear_jar_index");
         }
     }
 

--- a/src/indexer/cst_folding.rs
+++ b/src/indexer/cst_folding.rs
@@ -53,6 +53,7 @@ fn collect_folds_at(node: tree_sitter::Node, out: &mut Vec<FoldingRange>, depth:
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("collect_folds_at", node);
         return;
     }
 

--- a/src/indexer/cst_folding.rs
+++ b/src/indexer/cst_folding.rs
@@ -53,7 +53,7 @@ fn collect_folds_at(node: tree_sitter::Node, out: &mut Vec<FoldingRange>, depth:
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("collect_folds_at", node);
+        crate::util::report_cst_depth_exceeded!("collect_folds_at", node);
         return;
     }
 

--- a/src/indexer/cst_folding.rs
+++ b/src/indexer/cst_folding.rs
@@ -45,6 +45,17 @@ pub(crate) fn cst_folding_ranges(indexer: &Indexer, uri: &Url) -> Option<Vec<Fol
 }
 
 fn collect_folds(node: tree_sitter::Node, out: &mut Vec<FoldingRange>) {
+    collect_folds_at(node, out, 0);
+}
+
+fn collect_folds_at(node: tree_sitter::Node, out: &mut Vec<FoldingRange>, depth: usize) {
+    // See `crate::util::MAX_CST_DESCENT_DEPTH`: bail rather than overflow the
+    // stack on a pathologically deep tree (huge chained expression, or
+    // ERROR-recovery on a huge malformed file).
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return;
+    }
+
     let kind = node.kind();
 
     if REGION_KINDS.contains(&kind) {
@@ -114,8 +125,50 @@ fn collect_folds(node: tree_sitter::Node, out: &mut Vec<FoldingRange>) {
             }
             i = j;
         } else {
-            collect_folds(child, out);
+            collect_folds_at(child, out, depth + 1);
             i += 1;
         }
+    }
+}
+
+#[cfg(test)]
+mod depth_guard_tests {
+    //! Regression coverage for the `MAX_CST_DESCENT_DEPTH` guard added to
+    //! `collect_folds`. Before the guard, a long chain of `+` (perfectly
+    //! valid Kotlin — no malformed/ERROR-recovery input needed) parses as a
+    //! deeply left-nested `binary_expression` tree, and `collect_folds`'s
+    //! unconditional full-tree recursion overflowed an 8 MiB stack (matching
+    //! Linux's real main-thread default) at ~10-20k chained terms in a debug
+    //! build. This test proves the guard actually stops the descent — run on
+    //! a thread with that same 8 MiB stack, well past the old crash
+    //! threshold, and it must both survive and terminate promptly.
+    use tree_sitter::Parser;
+
+    #[test]
+    fn collect_folds_does_not_overflow_on_a_pathologically_deep_chain() {
+        let n = 200_000; // ~3x the old debug-build crash threshold
+        let mut src = String::with_capacity(n * 2 + 32);
+        src.push_str("fun f() { val x = 1");
+        for _ in 0..n {
+            src.push_str("+1");
+        }
+        src.push_str("\n}\n");
+
+        let handle = std::thread::Builder::new()
+            .stack_size(8 * 1024 * 1024) // match Linux's default main-thread stack
+            .spawn(move || {
+                let mut parser = Parser::new();
+                parser
+                    .set_language(&tree_sitter_kotlin::language())
+                    .unwrap();
+                let tree = parser.parse(&src, None).unwrap();
+                let mut out = Vec::new();
+                super::collect_folds(tree.root_node(), &mut out);
+                out.len()
+            })
+            .unwrap();
+        // If this doesn't overflow, `join` returns normally (a stack overflow
+        // aborts the whole process rather than failing this join).
+        handle.join().expect("must not overflow the stack");
     }
 }

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -39,7 +39,7 @@ pub(super) fn collect_nav_segments<'a>(
     bytes: &[u8],
 ) -> Vec<NavSegment<'a>> {
     let mut segments = Vec::new();
-    collect_nav_segments_recursive(node, bytes, &mut segments);
+    collect_nav_segments_recursive(node, bytes, &mut segments, 0);
     segments
 }
 
@@ -47,9 +47,20 @@ fn collect_nav_segments_recursive<'a>(
     node: tree_sitter::Node<'a>,
     bytes: &[u8],
     segments: &mut Vec<NavSegment<'a>>,
+    depth: usize,
 ) {
     if node.kind() != KIND_NAV_EXPR {
         // Base case: not a navigation expression
+        segments.push(NavSegment::Root(node));
+        return;
+    }
+
+    // Kind-bounded (only ever descends through KIND_NAV_EXPR/KIND_CALL_EXPR),
+    // but an arbitrarily long `a.b.c.d…` / `a.let{}.let{}…` chain is still an
+    // arbitrarily deep recursion — cap it rather than overflow the stack.
+    // See `crate::util::MAX_CST_DESCENT_DEPTH`. Treat the cut point as an
+    // opaque root, same as the ordinary non-nav-expression base case above.
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
         segments.push(NavSegment::Root(node));
         return;
     }
@@ -58,13 +69,13 @@ fn collect_nav_segments_recursive<'a>(
     if let Some(left) = node.named_child(0) {
         match left.kind() {
             k if k == KIND_NAV_EXPR => {
-                collect_nav_segments_recursive(left, bytes, segments);
+                collect_nav_segments_recursive(left, bytes, segments, depth + 1);
             }
             k if k == KIND_CALL_EXPR => {
                 // Intermediate call expression (e.g. `a.let { }.let { }`)
                 // Recurse into its callee to get the chain up to that point
                 if let Some(inner_callee) = left.child(0) {
-                    collect_nav_segments_recursive(inner_callee, bytes, segments);
+                    collect_nav_segments_recursive(inner_callee, bytes, segments, depth + 1);
                 }
                 segments.push(NavSegment::CallExpr(left));
             }

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -61,7 +61,7 @@ fn collect_nav_segments_recursive<'a>(
     // See `crate::util::MAX_CST_DESCENT_DEPTH`. Treat the cut point as an
     // opaque root, same as the ordinary non-nav-expression base case above.
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("collect_nav_segments_recursive", node);
+        crate::util::report_cst_depth_exceeded!("collect_nav_segments_recursive", node);
         segments.push(NavSegment::Root(node));
         return;
     }
@@ -335,7 +335,7 @@ fn resolve_callee_chain_at_depth(
     depth: usize,
 ) -> Option<(String, String)> {
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("resolve_callee_chain_at_depth", callee);
+        crate::util::report_cst_depth_exceeded!("resolve_callee_chain_at_depth", callee);
         return None;
     }
     match callee.kind() {

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -61,6 +61,7 @@ fn collect_nav_segments_recursive<'a>(
     // See `crate::util::MAX_CST_DESCENT_DEPTH`. Treat the cut point as an
     // opaque root, same as the ordinary non-nav-expression base case above.
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("collect_nav_segments_recursive", node);
         segments.push(NavSegment::Root(node));
         return;
     }

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -313,6 +313,31 @@ pub(super) fn resolve_callee_chain(
     deps: &impl InferDeps,
     uri: &Url,
 ) -> Option<(String, String)> {
+    resolve_callee_chain_at_depth(callee, bytes, deps, uri, 0)
+}
+
+/// Depth-guarded implementation of [`resolve_callee_chain`].
+///
+/// The `KIND_CALL_EXPR` arm below recurses into `callee.child(0)` to unwrap
+/// nested call expressions (`items.mapNotNull(::transform) { it }` nests as
+/// `outer_call(inner_call(receiver.method, args), call_suffix{lambda})`) —
+/// a hand-rolled recursive CST descent with no depth guard, the same pattern
+/// `MAX_CST_DESCENT_DEPTH` already covers for `collect_nav_segments_recursive`
+/// in this file and `infer_expr_type_at_depth`. A pathologically long chain
+/// of nested/curried calls (`x()()()()…`) recurses one frame per call with
+/// no cap. Bail out (not error) past the cap, same trade-off every other
+/// capped walker makes.
+fn resolve_callee_chain_at_depth(
+    callee: tree_sitter::Node<'_>,
+    bytes: &[u8],
+    deps: &impl InferDeps,
+    uri: &Url,
+    depth: usize,
+) -> Option<(String, String)> {
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("resolve_callee_chain_at_depth", callee);
+        return None;
+    }
     match callee.kind() {
         k if k == KIND_NAV_EXPR => {
             let segments = collect_nav_segments(callee, bytes);
@@ -355,7 +380,7 @@ pub(super) fn resolve_callee_chain(
         // so `items.mapNotNull(::transform) { it }` still resolves `items`'s type.
         k if k == KIND_CALL_EXPR => {
             let inner_callee = callee.child(0)?;
-            resolve_callee_chain(inner_callee, bytes, deps, uri)
+            resolve_callee_chain_at_depth(inner_callee, bytes, deps, uri, depth + 1)
         }
         _ => None,
     }

--- a/src/indexer/infer/expr_type.rs
+++ b/src/indexer/infer/expr_type.rs
@@ -57,6 +57,34 @@ pub(crate) fn infer_expr_type(
     deps: &impl InferDeps,
     uri: &Url,
 ) -> Option<String> {
+    infer_expr_type_at_depth(node, bytes, deps, uri, 0)
+}
+
+/// Depth-guarded implementation of [`infer_expr_type`].
+///
+/// `infer_expr_type` and its helpers (`infer_navigation_expr_type`,
+/// `infer_if_expr_type`, `infer_range_expr_type`, `infer_arithmetic_expr_type`,
+/// `infer_parenthesized_expr_type`) form a hand-rolled recursive descent over
+/// the expression tree — the same pattern `MAX_CST_DESCENT_DEPTH` was
+/// introduced for elsewhere (`indexer::infer::chain::collect_nav_segments`,
+/// `indexer::cst_folding`, the `features::*_diagnostics` walkers). This one
+/// was missed by that sweep: a pathologically long `a.b.c.d…` navigation
+/// chain, `((((…))))` parenthesization, or `1+1+1+…` arithmetic chain — all
+/// syntactically valid, no malformed input required — recurses one frame per
+/// segment with no cap, reachable from `inlay_hints` and
+/// `infer_variable_type_from_cst` (the CST fallback `InferDeps::find_var_type`
+/// uses). Bail out (not error) past the cap, same trade-off every other
+/// capped walker makes.
+fn infer_expr_type_at_depth(
+    node: Node<'_>,
+    bytes: &[u8],
+    deps: &impl InferDeps,
+    uri: &Url,
+    depth: usize,
+) -> Option<String> {
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return None;
+    }
     match node.kind() {
         KIND_INTEGER_LITERAL => Some("Int".to_owned()),
         KIND_LONG_LITERAL => Some("Long".to_owned()),
@@ -69,7 +97,7 @@ pub(crate) fn infer_expr_type(
             infer_ident_type(node, bytes, deps, uri)
         }
         k if k == KIND_THIS_EXPR => infer_this_expr_type(node, bytes, deps, uri),
-        k if k == KIND_NAV_EXPR => infer_navigation_expr_type(node, bytes, deps, uri),
+        k if k == KIND_NAV_EXPR => infer_navigation_expr_type(node, bytes, deps, uri, depth),
         k if k == KIND_CALL_EXPR => infer_call_expr_type(node, bytes, deps, uri),
         k if k == KIND_CHECK_EXPR
             || k == KIND_COMPARISON_EXPR
@@ -79,12 +107,14 @@ pub(crate) fn infer_expr_type(
             Some("Boolean".to_owned())
         }
         k if k == KIND_PREFIX_EXPR => infer_prefix_expr_type(node, bytes),
-        k if k == KIND_IF_EXPR => infer_if_expr_type(node, bytes, deps, uri),
-        k if k == KIND_RANGE_EXPR => infer_range_expr_type(node, bytes, deps, uri),
+        k if k == KIND_IF_EXPR => infer_if_expr_type(node, bytes, deps, uri, depth),
+        k if k == KIND_RANGE_EXPR => infer_range_expr_type(node, bytes, deps, uri, depth),
         k if k == KIND_ADDITIVE_EXPR || k == KIND_MULTIPLICATIVE_EXPR => {
-            infer_arithmetic_expr_type(node, bytes, deps, uri)
+            infer_arithmetic_expr_type(node, bytes, deps, uri, depth)
         }
-        k if k == KIND_PARENTHESIZED_EXPR => infer_parenthesized_expr_type(node, bytes, deps, uri),
+        k if k == KIND_PARENTHESIZED_EXPR => {
+            infer_parenthesized_expr_type(node, bytes, deps, uri, depth)
+        }
         _ => None,
     }
 }
@@ -175,10 +205,11 @@ fn infer_navigation_expr_type(
     bytes: &[u8],
     deps: &impl InferDeps,
     uri: &Url,
+    depth: usize,
 ) -> Option<String> {
     let receiver = nav_receiver_node(node)?;
     let member = nav_member_ident(node)?.utf8_text_owned(bytes)?;
-    let receiver_type = infer_expr_type(receiver, bytes, deps, uri)?;
+    let receiver_type = infer_expr_type_at_depth(receiver, bytes, deps, uri, depth + 1)?;
 
     if nav_is_call_callee(node) {
         // The two-step `find_fun_return_type_reachable` → `find_fun_return_type` replicates
@@ -264,6 +295,7 @@ fn infer_if_expr_type<D: InferDeps>(
     bytes: &[u8],
     deps: &D,
     uri: &Url,
+    depth: usize,
 ) -> Option<String> {
     node.first_child_of_kind(KIND_ELSE)?;
 
@@ -272,8 +304,8 @@ fn infer_if_expr_type<D: InferDeps>(
         .into_iter();
     let then_expr = bodies.next()?.child(0)?;
     let else_expr = bodies.next()?.child(0)?;
-    let then_type = infer_expr_type(then_expr, bytes, deps, uri)?;
-    let else_type = infer_expr_type(else_expr, bytes, deps, uri)?;
+    let then_type = infer_expr_type_at_depth(then_expr, bytes, deps, uri, depth + 1)?;
+    let else_type = infer_expr_type_at_depth(else_expr, bytes, deps, uri, depth + 1)?;
     (then_type == else_type).then_some(then_type)
 }
 
@@ -284,12 +316,13 @@ fn infer_range_expr_type<D: InferDeps>(
     bytes: &[u8],
     deps: &D,
     uri: &Url,
+    depth: usize,
 ) -> Option<String> {
     let lhs = node.child(0)?;
     let rhs_idx = node.child_count().checked_sub(1)?;
     let rhs = node.child(rhs_idx)?;
-    let lhs_ty = infer_expr_type(lhs, bytes, deps, uri)?;
-    let rhs_ty = infer_expr_type(rhs, bytes, deps, uri)?;
+    let lhs_ty = infer_expr_type_at_depth(lhs, bytes, deps, uri, depth + 1)?;
+    let rhs_ty = infer_expr_type_at_depth(rhs, bytes, deps, uri, depth + 1)?;
     match (lhs_ty.as_str(), rhs_ty.as_str()) {
         ("Int", "Int") => Some("IntRange".to_owned()),
         ("Long", "Long") | ("Int", "Long") | ("Long", "Int") => Some("LongRange".to_owned()),
@@ -306,9 +339,10 @@ fn infer_parenthesized_expr_type<D: InferDeps>(
     bytes: &[u8],
     deps: &D,
     uri: &Url,
+    depth: usize,
 ) -> Option<String> {
     let inner = node.named_child(0)?;
-    infer_expr_type(inner, bytes, deps, uri)
+    infer_expr_type_at_depth(inner, bytes, deps, uri, depth + 1)
 }
 
 /// Numeric rank for Kotlin's arithmetic operand-promotion, highest wins
@@ -343,15 +377,16 @@ fn infer_arithmetic_expr_type<D: InferDeps>(
     bytes: &[u8],
     deps: &D,
     uri: &Url,
+    depth: usize,
 ) -> Option<String> {
     let lhs = node.child(0)?;
     let op = node.child(1)?.utf8_text(bytes).ok()?;
     let rhs = node.child(2)?;
-    let lhs_ty = infer_expr_type(lhs, bytes, deps, uri)?;
+    let lhs_ty = infer_expr_type_at_depth(lhs, bytes, deps, uri, depth + 1)?;
     if op == "+" && lhs_ty == "String" {
         return Some("String".to_owned());
     }
-    let rhs_ty = infer_expr_type(rhs, bytes, deps, uri)?;
+    let rhs_ty = infer_expr_type_at_depth(rhs, bytes, deps, uri, depth + 1)?;
     let lhs_rank = numeric_rank(&lhs_ty)?;
     let rhs_rank = numeric_rank(&rhs_ty)?;
     // Kotlin has no same-rank arithmetic overload for `Byte`/`Short`: unlike

--- a/src/indexer/infer/expr_type.rs
+++ b/src/indexer/infer/expr_type.rs
@@ -83,6 +83,7 @@ fn infer_expr_type_at_depth(
     depth: usize,
 ) -> Option<String> {
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("infer_expr_type_at_depth", node);
         return None;
     }
     match node.kind() {

--- a/src/indexer/infer/expr_type.rs
+++ b/src/indexer/infer/expr_type.rs
@@ -83,7 +83,7 @@ fn infer_expr_type_at_depth(
     depth: usize,
 ) -> Option<String> {
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("infer_expr_type_at_depth", node);
+        crate::util::report_cst_depth_exceeded!("infer_expr_type_at_depth", node);
         return None;
     }
     match node.kind() {

--- a/src/indexer/infer/expr_type_tests.rs
+++ b/src/indexer/infer/expr_type_tests.rs
@@ -511,3 +511,49 @@ fn unknown_identifier_returns_none() {
         None
     );
 }
+
+// ─── recursion-depth guard ──────────────────────────────────────────────────
+
+/// Regression: `infer_expr_type` (via `infer_parenthesized_expr_type`,
+/// `infer_navigation_expr_type`, `infer_arithmetic_expr_type`, …) recurses
+/// over the expression tree with no depth guard. A pathologically deep,
+/// perfectly valid parenthesization (`((((…42…))))`) — no malformed/
+/// ERROR-recovery input needed — parses as a deeply nested
+/// `parenthesized_expression` tree and, before `MAX_CST_DESCENT_DEPTH` was
+/// threaded through this module, stack-overflowed a few thousand levels in
+/// (the same vulnerability class already fixed for
+/// `indexer::infer::chain::collect_nav_segments`, `indexer::cst_folding`,
+/// and the `features::*_diagnostics` walkers — this call graph was missed
+/// by that sweep). This drives `infer_expr_type` — reachable from
+/// `inlay_hints` and `InferDeps::find_var_type`'s CST fallback — several
+/// times past `MAX_CST_DESCENT_DEPTH` (512); without the guard this aborts
+/// the whole test process rather than failing an assertion.
+#[test]
+fn infer_expr_type_survives_a_pathologically_deep_parenthesization() {
+    let n = 5_000; // several times MAX_CST_DESCENT_DEPTH (512)
+    let mut src = String::new();
+    for _ in 0..n {
+        src.push('(');
+    }
+    src.push_str("42");
+    for _ in 0..n {
+        src.push(')');
+    }
+    // Past the cap the walk simply bails (returns `None`) — same trade-off
+    // every other capped walker makes — so no specific value is asserted,
+    // only that inference runs to completion without crashing.
+    let _ = infer(&src);
+}
+
+/// Same regression, via a deeply nested navigation chain (`a.b.c.d…`)
+/// instead of parenthesization — exercises `infer_navigation_expr_type`'s
+/// receiver recursion specifically.
+#[test]
+fn infer_expr_type_survives_a_pathologically_deep_navigation_chain() {
+    let n = 5_000; // several times MAX_CST_DESCENT_DEPTH (512)
+    let mut src = String::from("a");
+    for _ in 0..n {
+        src.push_str(".b");
+    }
+    let _ = infer(&src);
+}

--- a/src/indexer/jar_phase.rs
+++ b/src/indexer/jar_phase.rs
@@ -36,3 +36,29 @@ impl JarPhase {
         matches!(self, JarPhase::Pending | JarPhase::InProgress)
     }
 }
+
+/// Whether `Indexer::jar_phase`'s poisoning has already been reported this
+/// process. `std::sync::Mutex` poisons on any panic while the lock is held,
+/// and every `if let Ok(mut phase) = jar_phase.lock()` transition site in
+/// `indexer.rs`/`scan_handler.rs` currently has no `else` — once poisoned,
+/// each becomes a permanent silent no-op, and the JAR-indexing state machine
+/// (Pending → InProgress → Ready/Failed) freezes wherever it was, with hover
+/// and completion never learning why JAR symbols stopped updating. Gated to
+/// fire once (not per call site, not per throttle count) since every hit
+/// after the first describes the exact same poisoning.
+static JAR_PHASE_POISON_REPORTED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Report that `jar_phase.lock()` returned `Err` (poisoned) at `site`. See
+/// [`JAR_PHASE_POISON_REPORTED`] for why this only ever logs once.
+pub(crate) fn report_jar_phase_lock_poisoned(site: &str) {
+    if JAR_PHASE_POISON_REPORTED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        return;
+    }
+    log::warn!(
+        "jar_phase mutex is poisoned (first observed in {site}) — a prior JAR-phase update \
+         panicked while holding the lock. Every future phase transition will silently no-op \
+         from here on, freezing JAR-derived hover/completion at whatever phase they were in \
+         when this fired."
+    );
+}

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -17,6 +17,11 @@ use super::Indexer;
 use crate::types::SymbolEntry;
 use crate::StrExt;
 
+/// Throttle counter for [`Indexer::jar_declaration_scope`]'s side-table
+/// misalignment warning — see [`crate::util::throttled_warn`].
+static JAR_SYMBOL_PACKAGES_MISALIGNED: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 impl Indexer {
     /// Returns true if `name` has at least one definition location inside `uri`.
     pub(crate) fn is_declared_in(&self, uri: &Url, name: &str) -> bool {
@@ -76,10 +81,31 @@ impl Indexer {
                 .jar_symbol_packages
                 .get(uri_str)
                 .and_then(|packages| {
-                    packages
+                    let entry = packages
                         .get(symbol_index)
                         .filter(|p| !p.is_empty())
-                        .cloned()
+                        .cloned();
+                    // `jar_symbol_packages` is populated index-aligned with the jar's
+                    // `FileData.symbols` (synthetic line number == symbol index) —
+                    // see `jar.rs`'s population comment. A missing map entry for
+                    // `uri_str` is a legitimate fallback (pre-v8 sidecars never
+                    // recorded per-symbol packages at all), but an in-bounds map
+                    // whose vector is too short for `symbol_index` means the two
+                    // "index-aligned" collections drifted apart — the same class of
+                    // bug already caused `padding` to vanish from chained-call
+                    // completion once (see the population-site comment).
+                    if entry.is_none() && symbol_index >= packages.len() {
+                        crate::util::throttled_warn(&JAR_SYMBOL_PACKAGES_MISALIGNED, 5, || {
+                            format!(
+                                "jar_symbol_packages misaligned for {uri_str}: symbol index \
+                                 {symbol_index} out of bounds (side table has {} entries) — \
+                                 falling back to the per-jar inferred package, which can be \
+                                 wrong for a multi-package jar",
+                                packages.len(),
+                            )
+                        });
+                    }
+                    entry
                 })
                 .or_else(|| {
                     self.jar_files

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -17,6 +17,11 @@ use tower_lsp::lsp_types::*;
 /// Maximum number of file-read failures to log before suppressing further warnings.
 const MAX_READ_FAILURES_LOGGED: usize = 5;
 
+/// Throttle counter for the priority-indexing join-panic warning below —
+/// see [`crate::util::throttled_warn`].
+static PRIORITY_INDEX_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 use crate::indexer::{
     cache::{cache_entry_to_file_result, save_cache, try_load_cache, write_status_file},
     discover::{find_source_files, warm_discover_files},
@@ -746,14 +751,25 @@ impl Indexer {
                 let idx_c = Arc::clone(&self);
                 let uri_c = uri.clone();
                 let cont_c = content.clone();
-                let supers: Vec<String> = tokio::task::spawn_blocking(move || {
+                let join_result = tokio::task::spawn_blocking(move || {
                     idx_c
                         .index_content(&uri_c, &cont_c)
                         .map(|d| d.supers.iter().map(|(_, n, _)| n.clone()).collect())
                         .unwrap_or_default()
                 })
-                .await
-                .unwrap_or_default();
+                .await;
+                if let Err(ref e) = join_result {
+                    crate::util::throttled_warn(&PRIORITY_INDEX_JOIN_FAILURES, 5, || {
+                        crate::util::join_failure_message(
+                            &format!(
+                                "priority-indexing {} to seed its supertypes",
+                                path.display()
+                            ),
+                            e,
+                        )
+                    });
+                }
+                let supers: Vec<String> = join_result.unwrap_or_default();
                 // Expand priority set to include supertypes so cross-class navigation
                 // (super, override resolution) works before the full scan completes.
                 if !supers.is_empty() {
@@ -778,10 +794,22 @@ impl Indexer {
                     if path.exists() {
                         if let Ok(content) = tokio::fs::read_to_string(&path).await {
                             if let Ok(uri) = Url::from_file_path(&path) {
-                                let _ = tokio::task::spawn_blocking(move || {
+                                let join_result = tokio::task::spawn_blocking(move || {
                                     idx.index_content(&uri, &content)
                                 })
                                 .await;
+                                if let Err(ref e) = join_result {
+                                    crate::util::throttled_warn(
+                                        &PRIORITY_INDEX_JOIN_FAILURES,
+                                        5,
+                                        || {
+                                            crate::util::join_failure_message(
+                                                &format!("priority-indexing {}", path.display()),
+                                                e,
+                                            )
+                                        },
+                                    );
+                                }
                             }
                         }
                     }

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -20,6 +20,11 @@ use super::{
     Resolver, MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
 };
 
+/// Throttle counter for [`members_for_jar_backed_type`]'s `jar_symbol_packages`
+/// side-table misalignment warning — see [`crate::util::throttled_warn`].
+static JAR_SYMBOL_PACKAGES_MISALIGNED: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 // ─── CompletionItem.data JSON keys ───────────────────────────────────────────
 
 /// Symbol definition URI.
@@ -1081,10 +1086,30 @@ fn members_for_jar_backed_type(
     let member_indices: Vec<usize> = {
         let symbol_packages = indexer.jar_symbol_packages.get(file_uri);
         let package_at = |index: usize| -> Option<&str> {
-            symbol_packages
-                .as_ref()
-                .and_then(|packages| packages.value().get(index))
-                .map(String::as_str)
+            let packages = symbol_packages.as_ref()?;
+            let values = packages.value();
+            let result = values.get(index).map(String::as_str);
+            // `jar_symbol_packages` is populated index-aligned with `symbols`
+            // (see the population-site comment in `jar.rs`). The map entry
+            // for this `file_uri` existing but being too short for `index`
+            // means the two collections drifted apart — the same class of
+            // bug that already made an explicitly-imported `padding` vanish
+            // from chained-call completion once. A missing map entry
+            // entirely is the legitimate pre-v8-sidecar case and isn't
+            // logged.
+            if result.is_none() && index >= values.len() {
+                crate::util::throttled_warn(&JAR_SYMBOL_PACKAGES_MISALIGNED, 5, || {
+                    format!(
+                        "jar_symbol_packages misaligned for {file_uri}: symbol index {index} out \
+                         of bounds (side table has {} entries) — member package disambiguation \
+                         for `{inner_name}` completion falls back to the declaring class's own \
+                         package, which can pick the wrong same-named class in a multi-package \
+                         jar",
+                        values.len(),
+                    )
+                });
+            }
+            result
         };
         // Candidate members: container match + the shared symbol filters.
         let candidate_indices: Vec<usize> = symbols

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -451,10 +451,60 @@ pub(crate) fn infer_variable_type_from_cst(
     var_name: &str,
     uri: &Url,
 ) -> Option<String> {
+    // Cycle guard — see `ResolutionInFlight`. Inferring a variable's type
+    // infers its initializer, which resolves the identifiers inside it, which
+    // infers *their* variables. A self- or mutually-referential initializer
+    // closes that into a loop with no natural end.
+    let _guard = ResolutionInFlight::enter(uri, var_name)?;
     let doc = indexer.live_doc_or_parse(uri)?;
     let bytes = doc.bytes.as_slice();
     let init = find_prop_initializer(doc.tree.root_node(), bytes, var_name)?;
     crate::indexer::infer_expr_type(init, bytes, indexer, uri)
+}
+
+thread_local! {
+    /// Variables whose type inference is currently on the stack, per thread.
+    static RESOLVING_VARIABLES: std::cell::RefCell<std::collections::HashSet<(String, String)>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+}
+
+/// Breaks reference cycles in variable-type inference by refusing to re-enter
+/// a resolution that is already in flight.
+///
+/// A depth cap cannot solve this. The loop runs
+/// `infer_expr_type` → `infer_ident_type` → `infer_variable_type_from_cst` →
+/// `infer_expr_type`, and `infer_expr_type` is a public entry point that
+/// restarts its depth counter at zero on every lap, so the counter never
+/// climbs. This was not theoretical: it aborted the server in normal editing
+/// with a 65,127-frame stack overflow, and the resulting core dump shows that
+/// exact four-frame cycle repeating to exhaustion.
+///
+/// Keyed on `(uri, var_name)` — the full identity of the query. Re-entering
+/// the *same* variable in the *same* file cannot produce an answer the outer
+/// call is not already computing, so returning `None` loses nothing; a
+/// different variable or file is unaffected and resolves normally.
+struct ResolutionInFlight {
+    key: (String, String),
+}
+
+impl ResolutionInFlight {
+    /// Claims `(uri, var_name)`, or returns `None` if it is already being
+    /// resolved further up the stack — the cycle case.
+    fn enter(uri: &Url, var_name: &str) -> Option<Self> {
+        let key = (uri.as_str().to_owned(), var_name.to_owned());
+        let claimed = RESOLVING_VARIABLES.with(|set| set.borrow_mut().insert(key.clone()));
+        if !claimed {
+            crate::util::report_resolution_cycle("infer_variable_type_from_cst", var_name, uri);
+            return None;
+        }
+        Some(ResolutionInFlight { key })
+    }
+}
+
+impl Drop for ResolutionInFlight {
+    fn drop(&mut self) {
+        RESOLVING_VARIABLES.with(|set| set.borrow_mut().remove(&self.key));
+    }
 }
 
 /// Depth-first search for the initializer expression of `val/var <var_name> = …`.

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -475,14 +475,13 @@ thread_local! {
 /// `infer_expr_type` → `infer_ident_type` → `infer_variable_type_from_cst` →
 /// `infer_expr_type`, and `infer_expr_type` is a public entry point that
 /// restarts its depth counter at zero on every lap, so the counter never
-/// climbs. This was not theoretical: it aborted the server in normal editing
-/// with a 65,127-frame stack overflow, and the resulting core dump shows that
-/// exact four-frame cycle repeating to exhaustion.
+/// climbs. Only remembering what is already in flight terminates it.
 ///
-/// Keyed on `(uri, var_name)` — the full identity of the query. Re-entering
-/// the *same* variable in the *same* file cannot produce an answer the outer
-/// call is not already computing, so returning `None` loses nothing; a
-/// different variable or file is unaffected and resolves normally.
+/// Keyed on `(uri, var_name)` because that is what the resolution itself keys
+/// on — [`find_prop_initializer`] searches a file by name — so re-entering the
+/// same key cannot produce an answer the outer call is not already computing,
+/// and returning `None` loses nothing. A resolution that became scope-aware
+/// would need a correspondingly finer key here.
 struct ResolutionInFlight {
     key: (String, String),
 }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -458,7 +458,7 @@ pub(crate) fn infer_variable_type_from_cst(
     let _guard = ResolutionInFlight::enter(uri, var_name)?;
     let doc = indexer.live_doc_or_parse(uri)?;
     let bytes = doc.bytes.as_slice();
-    let init = find_prop_initializer(doc.tree.root_node(), bytes, var_name)?;
+    let init = find_prop_initializer(doc.tree.root_node(), bytes, var_name, 0)?;
     crate::indexer::infer_expr_type(init, bytes, indexer, uri)
 }
 
@@ -512,8 +512,17 @@ fn find_prop_initializer<'a>(
     node: tree_sitter::Node<'a>,
     bytes: &[u8],
     var_name: &str,
+    depth: usize,
 ) -> Option<tree_sitter::Node<'a>> {
     use crate::queries::{KIND_EQ, KIND_PROP_DECL};
+    // A name that is never declared makes this search the whole file, so a
+    // pathological input reaches its full depth here rather than returning
+    // early — bail rather than overflow the stack. See
+    // `crate::util::MAX_CST_DESCENT_DEPTH`.
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded!("find_prop_initializer", node);
+        return None;
+    }
     if node.kind() == KIND_PROP_DECL && prop_decl_name(node, bytes).as_deref() == Some(var_name) {
         let mut cursor = node.walk();
         let mut past_eq = false;
@@ -530,7 +539,7 @@ fn find_prop_initializer<'a>(
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        if let Some(found) = find_prop_initializer(child, bytes, var_name) {
+        if let Some(found) = find_prop_initializer(child, bytes, var_name, depth + 1) {
             return Some(found);
         }
     }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -5998,3 +5998,30 @@ fn mutually_referential_initializers_do_not_recurse_forever() {
     idx.store_live_tree(&file_uri, src);
     let _ = crate::resolver::infer::infer_variable_type_from_cst(&idx, "a", &file_uri);
 }
+
+/// A name that is never declared makes `find_prop_initializer` search the
+/// whole file rather than returning early, so its recursion reaches the
+/// tree's full depth.
+#[test]
+fn the_initializer_search_survives_a_pathologically_deep_file() {
+    let n = 60_000; // ~100x MAX_CST_DESCENT_DEPTH (512)
+    let mut src = String::from("package app\nfun f() {\n    val x = 1");
+    for _ in 0..n {
+        src.push_str("+1");
+    }
+    src.push_str("\n}\n");
+
+    let handle = std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024) // match Linux's default main-thread stack
+        .spawn(move || {
+            let idx = Indexer::new();
+            let file_uri = uri("/Deep.kt");
+            idx.index_content(&file_uri, &src);
+            idx.store_live_tree(&file_uri, &src);
+            crate::resolver::infer::infer_variable_type_from_cst(&idx, "never_declared", &file_uri)
+        })
+        .unwrap();
+    // A stack overflow aborts the process rather than failing this join.
+    let found = handle.join().expect("must not overflow the stack");
+    assert_eq!(found, None, "the name is not declared anywhere in the file");
+}

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -5966,3 +5966,35 @@ fn an_unrelated_same_named_object_does_not_validate_an_enum_entry_branch() {
         "an unrelated same-named object must not validate an enum entry: {labels:?}"
     );
 }
+
+/// Regression, from a production stack overflow with a 65,127-frame core
+/// dump: inferring a variable's type infers its initializer, which resolves
+/// the identifiers in it, which infers *their* variables. A self-referential
+/// initializer closed that into an unbounded loop and aborted the server
+/// during ordinary editing.
+///
+/// A depth cap could not catch it — the cycle runs back through
+/// `infer_expr_type`, a public entry point that restarts its depth counter at
+/// zero every lap — so this is guarded by refusing to re-enter a resolution
+/// already in flight.
+#[test]
+fn a_self_referential_initializer_does_not_recurse_forever() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Cycle.kt");
+    let src = "package app\nfun f() {\n    val a = a\n}\n";
+    idx.index_content(&file_uri, src);
+    idx.store_live_tree(&file_uri, src);
+    // Must terminate rather than exhaust the stack.
+    let _ = crate::resolver::infer::infer_variable_type_from_cst(&idx, "a", &file_uri);
+}
+
+/// The mutual case: two declarations whose initializers reference each other.
+#[test]
+fn mutually_referential_initializers_do_not_recurse_forever() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Cycle2.kt");
+    let src = "package app\nfun f() {\n    val a = b\n    val b = a\n}\n";
+    idx.index_content(&file_uri, src);
+    idx.store_live_tree(&file_uri, src);
+    let _ = crate::resolver::infer::infer_variable_type_from_cst(&idx, "a", &file_uri);
+}

--- a/src/semantic_tokens/helpers.rs
+++ b/src/semantic_tokens/helpers.rs
@@ -232,11 +232,21 @@ pub(super) fn push_token(
 }
 
 pub(super) fn visit_tree(node: Node<'_>, f: &mut impl FnMut(Node<'_>)) {
+    visit_tree_at(node, f, 0);
+}
+
+fn visit_tree_at(node: Node<'_>, f: &mut impl FnMut(Node<'_>), depth: usize) {
+    // See `crate::util::MAX_CST_DESCENT_DEPTH`: bail rather than overflow the
+    // stack on a pathologically deep tree (huge chained expression, or
+    // ERROR-recovery on a huge malformed file).
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return;
+    }
     f(node);
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
         loop {
-            visit_tree(cursor.node(), f);
+            visit_tree_at(cursor.node(), f, depth + 1);
             if !cursor.goto_next_sibling() {
                 break;
             }

--- a/src/semantic_tokens/helpers.rs
+++ b/src/semantic_tokens/helpers.rs
@@ -240,7 +240,7 @@ fn visit_tree_at(node: Node<'_>, f: &mut impl FnMut(Node<'_>), depth: usize) {
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("visit_tree_at", node);
+        crate::util::report_cst_depth_exceeded!("visit_tree_at", node);
         return;
     }
     f(node);

--- a/src/semantic_tokens/helpers.rs
+++ b/src/semantic_tokens/helpers.rs
@@ -240,6 +240,7 @@ fn visit_tree_at(node: Node<'_>, f: &mut impl FnMut(Node<'_>), depth: usize) {
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("visit_tree_at", node);
         return;
     }
     f(node);

--- a/src/semantic_tokens/java.rs
+++ b/src/semantic_tokens/java.rs
@@ -23,7 +23,7 @@ fn walk_java_at(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>, depth
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("walk_java_at", node);
+        crate::util::report_cst_depth_exceeded!("walk_java_at", node);
         return;
     }
     classify_java(node, src, out);

--- a/src/semantic_tokens/java.rs
+++ b/src/semantic_tokens/java.rs
@@ -23,6 +23,7 @@ fn walk_java_at(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>, depth
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("walk_java_at", node);
         return;
     }
     classify_java(node, src, out);

--- a/src/semantic_tokens/java.rs
+++ b/src/semantic_tokens/java.rs
@@ -15,11 +15,21 @@ use super::helpers::{child_ident, first_child_of_kind, push_token};
 use super::{modifier_bit, type_index, RawToken, Source};
 
 pub(super) fn walk_java(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    walk_java_at(node, src, out, 0);
+}
+
+fn walk_java_at(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>, depth: usize) {
+    // See `crate::util::MAX_CST_DESCENT_DEPTH`: bail rather than overflow the
+    // stack on a pathologically deep tree (huge chained expression, or
+    // ERROR-recovery on a huge malformed file).
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return;
+    }
     classify_java(node, src, out);
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
         loop {
-            walk_java(cursor.node(), src, out);
+            walk_java_at(cursor.node(), src, out, depth + 1);
             if !cursor.goto_next_sibling() {
                 break;
             }

--- a/src/semantic_tokens/kotlin.rs
+++ b/src/semantic_tokens/kotlin.rs
@@ -28,6 +28,7 @@ fn walk_kotlin_at(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>, dep
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("walk_kotlin_at", node);
         return;
     }
     classify_kotlin(node, src, out);

--- a/src/semantic_tokens/kotlin.rs
+++ b/src/semantic_tokens/kotlin.rs
@@ -28,7 +28,7 @@ fn walk_kotlin_at(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>, dep
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("walk_kotlin_at", node);
+        crate::util::report_cst_depth_exceeded!("walk_kotlin_at", node);
         return;
     }
     classify_kotlin(node, src, out);

--- a/src/semantic_tokens/kotlin.rs
+++ b/src/semantic_tokens/kotlin.rs
@@ -20,11 +20,21 @@ use super::helpers::{
 use super::{modifier_bit, type_index, RawToken, Source};
 
 pub(super) fn walk_kotlin(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    walk_kotlin_at(node, src, out, 0);
+}
+
+fn walk_kotlin_at(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>, depth: usize) {
+    // See `crate::util::MAX_CST_DESCENT_DEPTH`: bail rather than overflow the
+    // stack on a pathologically deep tree (huge chained expression, or
+    // ERROR-recovery on a huge malformed file).
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return;
+    }
     classify_kotlin(node, src, out);
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
         loop {
-            walk_kotlin(cursor.node(), src, out);
+            walk_kotlin_at(cursor.node(), src, out, depth + 1);
             if !cursor.goto_next_sibling() {
                 break;
             }

--- a/src/semantic_tokens/params.rs
+++ b/src/semantic_tokens/params.rs
@@ -70,7 +70,7 @@ fn emit_param_refs_in_scope(
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("emit_param_refs_in_scope", node);
+        crate::util::report_cst_depth_exceeded!("emit_param_refs_in_scope", node);
         return;
     }
     if node.kind() == KIND_FOR_STMT {

--- a/src/semantic_tokens/params.rs
+++ b/src/semantic_tokens/params.rs
@@ -70,6 +70,7 @@ fn emit_param_refs_in_scope(
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("emit_param_refs_in_scope", node);
         return;
     }
     if node.kind() == KIND_FOR_STMT {

--- a/src/semantic_tokens/params.rs
+++ b/src/semantic_tokens/params.rs
@@ -55,7 +55,7 @@ fn emit_param_uses_for_function(fn_node: Node<'_>, src: &Source<'_>, out: &mut V
     let Some(body) = first_child_of_kind(fn_node, KIND_FUN_BODY) else {
         return;
     };
-    emit_param_refs_in_scope(body, &params, &[], src, out);
+    emit_param_refs_in_scope(body, &params, &[], src, out, 0);
 }
 
 fn emit_param_refs_in_scope(
@@ -64,7 +64,14 @@ fn emit_param_refs_in_scope(
     shadowed: &[String],
     src: &Source<'_>,
     out: &mut Vec<RawToken>,
+    depth: usize,
 ) {
+    // See `crate::util::MAX_CST_DESCENT_DEPTH`: bail rather than overflow the
+    // stack on a pathologically deep tree (huge chained expression, or
+    // ERROR-recovery on a huge malformed file).
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return;
+    }
     if node.kind() == KIND_FOR_STMT {
         let body = first_child_of_kind(node, KIND_CONTROL_STRUCTURE_BODY);
         let shadow_names = local_binding_names(node, params, src.bytes);
@@ -84,7 +91,7 @@ fn emit_param_refs_in_scope(
                 } else {
                     shadowed
                 };
-                emit_param_refs_in_scope(child, params, child_shadowed, src, out);
+                emit_param_refs_in_scope(child, params, child_shadowed, src, out, depth + 1);
                 if !cursor.goto_next_sibling() {
                     break;
                 }
@@ -108,7 +115,7 @@ fn emit_param_refs_in_scope(
             loop {
                 let child = cursor.node();
                 let new_shadows = local_binding_names(child, params, src.bytes);
-                emit_param_refs_in_scope(child, params, &local_shadowed, src, out);
+                emit_param_refs_in_scope(child, params, &local_shadowed, src, out, depth + 1);
                 for name in new_shadows {
                     if !local_shadowed.iter().any(|shadow| shadow == &name) {
                         local_shadowed.push(name);
@@ -135,7 +142,7 @@ fn emit_param_refs_in_scope(
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
         loop {
-            emit_param_refs_in_scope(cursor.node(), params, shadowed, src, out);
+            emit_param_refs_in_scope(cursor.node(), params, shadowed, src, out, depth + 1);
             if !cursor.goto_next_sibling() {
                 break;
             }

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -39,7 +39,7 @@ pub(super) fn walk_references(
     }
     // Tier 1: direct index lookups (type refs, top-level calls, annotations)
     let mut resolved = Vec::new();
-    walk_kotlin_references(doc.tree.root_node(), src, indexer, uri, &mut resolved);
+    walk_kotlin_references(doc.tree.root_node(), src, indexer, uri, &mut resolved, 0);
     raw.extend(resolved);
 
     // Tier 2: receiver-inferred member coloring
@@ -55,7 +55,14 @@ fn walk_kotlin_references(
     indexer: &Indexer,
     uri: &Url,
     out: &mut Vec<RawToken>,
+    depth: usize,
 ) {
+    // See `crate::util::MAX_CST_DESCENT_DEPTH`: bail rather than overflow the
+    // stack on a pathologically deep tree (huge chained expression, or
+    // ERROR-recovery on a huge malformed file).
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        return;
+    }
     if is_kotlin_keyword_node(node) {
         push_token(node, type_index(&SemanticTokenType::KEYWORD), 0, src, out);
     } else if let Some(token_type) = classify_kotlin_reference(node, src.bytes, indexer, uri) {
@@ -64,7 +71,7 @@ fn walk_kotlin_references(
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
         loop {
-            walk_kotlin_references(cursor.node(), src, indexer, uri, out);
+            walk_kotlin_references(cursor.node(), src, indexer, uri, out, depth + 1);
             if !cursor.goto_next_sibling() {
                 break;
             }

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -61,7 +61,7 @@ fn walk_kotlin_references(
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded("walk_kotlin_references", node);
+        crate::util::report_cst_depth_exceeded!("walk_kotlin_references", node);
         return;
     }
     if is_kotlin_keyword_node(node) {

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -61,6 +61,7 @@ fn walk_kotlin_references(
     // stack on a pathologically deep tree (huge chained expression, or
     // ERROR-recovery on a huge malformed file).
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded("walk_kotlin_references", node);
         return;
     }
     if is_kotlin_keyword_node(node) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -578,6 +578,11 @@ pub(crate) struct FileTable {
     by_uri: dashmap::DashMap<String, FileId>,
 }
 
+/// Throttle counter for [`FileTable::url`]'s invariant-violation warning —
+/// see [`crate::util::throttled_warn`].
+static FILE_ID_LOOKUP_MISSES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 impl Default for FileTable {
     fn default() -> Self {
         Self::new()
@@ -618,12 +623,30 @@ impl FileTable {
     }
 
     /// The interned `Url` for `id`, or `None` if `id` is not from this table.
+    ///
+    /// `id` normally comes from a [`SymbolLoc`] this same table produced via
+    /// [`Self::intern`], and the table is append-only (see the struct doc) —
+    /// so a miss here isn't a legitimate "not found," it means a `SymbolLoc`
+    /// outlived or crossed into a different `FileTable` than the one that
+    /// interned it. Every caller (`location`, and the many direct `url()`
+    /// call sites across resolution) treats a miss as "drop this entry from
+    /// the result," which looks identical to an ordinary absence — this is
+    /// the one place that can tell the two apart.
     pub(crate) fn url(&self, id: FileId) -> Option<Arc<tower_lsp::lsp_types::Url>> {
-        self.by_id
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-            .get(id.0 as usize)
-            .cloned()
+        let table = self.by_id.read().unwrap_or_else(|e| e.into_inner());
+        let found = table.get(id.0 as usize).cloned();
+        if found.is_none() {
+            crate::util::throttled_warn(&FILE_ID_LOOKUP_MISSES, 5, || {
+                format!(
+                    "FileTable::url: FileId({}) has no entry (table holds {} interned files) — \
+                     a SymbolLoc referencing it predates or crosses into a different FileTable; \
+                     the caller silently drops whatever result depended on it",
+                    id.0,
+                    table.len(),
+                )
+            });
+        }
+        found
     }
 
     /// Build a `tower_lsp::Location` from a [`SymbolLoc`]. This is the ONLY place

--- a/src/util.rs
+++ b/src/util.rs
@@ -64,6 +64,28 @@ pub(crate) fn report_cst_depth_exceeded(site: &str, node: tree_sitter::Node<'_>)
     });
 }
 
+static RESOLUTION_CYCLE_REPORTS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Record that a resolution refused to re-enter itself, breaking a cycle.
+///
+/// Unlike a depth cap — which can fire on merely deep input — reaching here
+/// always means the source contains a genuine reference loop, or that
+/// inference followed one it should not have. It is never routine, so it is
+/// always worth a line in the log: silently returning `None` here is what
+/// makes a missing type look like an ordinary unresolvable one.
+pub(crate) fn report_resolution_cycle(site: &str, name: &str, uri: &tower_lsp::lsp_types::Url) {
+    throttled_warn(&RESOLUTION_CYCLE_REPORTS, MAX_DEPTH_REPORTS, || {
+        format!(
+            "resolution cycle broken in {site}: `{name}` in {} is already being resolved further \
+             up the stack, so its type is reported as unknown. This means a self- or \
+             mutually-referential declaration, and without this guard it would recurse until the \
+             stack was exhausted.",
+            uri.path(),
+        )
+    });
+}
+
 /// Log `message()` via `log::warn!`, capped at `limit` calls through this
 /// particular `counter`.
 ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,45 +13,98 @@ pub(crate) fn home_dir() -> Option<PathBuf> {
 /// (`node.children()` walked via plain Rust recursion rather than an
 /// iterative `TreeCursor` loop).
 ///
-/// Real Kotlin/Java syntax — even unusually deeply nested Compose UI —
-/// bottoms out at a few dozen levels; measured against the actual
-/// `nowinandroid` sample, a realistic file (including a malformed,
-/// mid-edit buffer) never exceeds ~20. This cap is generous relative to
-/// that (over an order of magnitude of headroom) while still sitting far
-/// below the few-thousand-frame threshold that overflows an 8 MiB stack —
-/// see the recursive descents in `features::call_arg_diagnostics`,
-/// `features::fill_when`, `features::missing_import_diagnostics`,
-/// `features::nullable_call_diagnostics`, and `indexer::cst_folding`,
-/// each of which independently stack-overflows on a pathological input
-/// (e.g. a single expression with tens of thousands of chained
-/// operators/segments, or an unclosed-brace file with tens of thousands of
-/// trailing lines) with no guard at all before this constant was
-/// introduced.
+/// Real Kotlin/Java syntax bottoms out at a few dozen levels of nesting,
+/// so this sits well above anything a human writes while staying far below
+/// the few-thousand frames that overflow an 8 MiB stack. Without a cap,
+/// tree depth translates directly into stack frames and a pathological
+/// input (one expression with tens of thousands of chained operators, or
+/// an unclosed brace followed by tens of thousands of lines) aborts the
+/// whole process.
 ///
-/// Not a correctness bound in the usual sense: once hit, callers simply
-/// stop descending into that subtree (under-reporting deeper diagnostics)
-/// rather than erroring — the same trade-off `resolve_chain`'s hierarchy
-/// walk already makes with its own `max_depth` parameter. Report every hit
-/// through [`report_cst_depth_exceeded`] so that trade-off stays visible.
+/// Not a correctness bound in the usual sense: once hit, callers stop
+/// descending into that subtree — under-reporting deeper results rather
+/// than erroring — the same trade-off `walk_hierarchy` already makes with
+/// its own `max_depth`. Report every hit through
+/// [`report_cst_depth_exceeded!`] so the trade-off stays visible.
 pub(crate) const MAX_CST_DESCENT_DEPTH: usize = 512;
 
-/// How many depth-cap hits to log before going quiet. One pathological tree
-/// trips the cap once per node past the limit, so an unthrottled log would
+/// How many hits one [`WarnThrottle`] logs per window. A single pathological
+/// tree trips a cap once per node past the limit, so an unthrottled log would
 /// bury everything else; the first few carry all the diagnostic value.
-const MAX_DEPTH_REPORTS: usize = 5;
+pub(crate) const MAX_DEPTH_REPORTS: usize = 5;
 
-static DEPTH_REPORTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+/// How long a [`WarnThrottle`] stays quiet before its budget refills.
+const WARN_WINDOW: std::time::Duration = std::time::Duration::from_secs(300);
+
+static PROCESS_START: std::sync::LazyLock<std::time::Instant> =
+    std::sync::LazyLock::new(std::time::Instant::now);
+
+/// A warn budget that refills every [`WARN_WINDOW`], for sites that can fire
+/// repeatedly over a long-running server's lifetime.
+///
+/// [`throttled_warn`]'s plain lifetime budget is right for a site that reports
+/// a one-off bug — a task that panicked once is a bug you fix, not one you
+/// need re-reported hourly. A depth cap or a broken cycle is different: it
+/// tracks whatever file the user has open, so a lifetime budget spent during
+/// startup indexing would leave the server permanently silent about every
+/// later occurrence.
+pub(crate) struct WarnThrottle {
+    limit: usize,
+    reports: std::sync::atomic::AtomicUsize,
+    window_started_secs: std::sync::atomic::AtomicU64,
+}
+
+impl WarnThrottle {
+    pub(crate) const fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            reports: std::sync::atomic::AtomicUsize::new(0),
+            window_started_secs: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// Log `message()` unless this window's budget is already spent.
+    ///
+    /// Two threads racing the window reset can cost or grant one extra line;
+    /// that is well within what a diagnostic log tolerates, and is worth not
+    /// taking a lock on a path that fires during a stack-depth emergency.
+    pub(crate) fn warn(&self, message: impl FnOnce() -> String) {
+        use std::sync::atomic::Ordering::Relaxed;
+        let now = PROCESS_START.elapsed().as_secs();
+        if now.saturating_sub(self.window_started_secs.load(Relaxed)) >= WARN_WINDOW.as_secs() {
+            self.window_started_secs.store(now, Relaxed);
+            self.reports.store(0, Relaxed);
+        }
+        let seen = self.reports.fetch_add(1, Relaxed);
+        if seen >= self.limit {
+            return;
+        }
+        let suffix = if seen + 1 == self.limit {
+            " Further reports from here suppressed until the next window."
+        } else {
+            ""
+        };
+        log::warn!("{}{suffix}", message());
+    }
+}
 
 /// Record that a recursive CST descent stopped at [`MAX_CST_DESCENT_DEPTH`].
 ///
-/// The cap exists to convert a stack overflow into degraded output, but a
-/// silent bail leaves nothing to explain *why* results went missing — and a
-/// hit on ordinary-looking source is itself the signal that something is
-/// wrong (a cycle, or a walker reaching far deeper than real syntax should).
-/// `site` names the walker; the node's position points at the input.
-pub(crate) fn report_cst_depth_exceeded(site: &str, node: tree_sitter::Node<'_>) {
+/// The cap converts a stack overflow into degraded output, but a silent bail
+/// leaves nothing to explain *why* results went missing — and a hit on
+/// ordinary-looking source is itself the signal that something is wrong (a
+/// cycle, or a walker reaching far deeper than real syntax should).
+///
+/// Call through the [`report_cst_depth_exceeded!`] macro rather than
+/// directly: it gives each walker its own budget, so the one walker caught in
+/// a loop cannot crowd the other fifteen out of the log.
+pub(crate) fn log_cst_depth_exceeded(
+    throttle: &WarnThrottle,
+    site: &str,
+    node: tree_sitter::Node<'_>,
+) {
     let position = node.start_position();
-    throttled_warn(&DEPTH_REPORTS, MAX_DEPTH_REPORTS, || {
+    throttle.warn(|| {
         format!(
             "CST descent hit the depth cap ({MAX_CST_DESCENT_DEPTH}) in {site} at \
              {}:{} (node kind `{}`) — deeper nodes were skipped. Real Kotlin/Java \
@@ -64,8 +117,19 @@ pub(crate) fn report_cst_depth_exceeded(site: &str, node: tree_sitter::Node<'_>)
     });
 }
 
-static RESOLUTION_CYCLE_REPORTS: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+/// Report a [`MAX_CST_DESCENT_DEPTH`] bail, with a warn budget private to the
+/// call site. Each expansion declares its own `static`, which is the whole
+/// point — see [`report_cst_depth_exceeded`].
+macro_rules! report_cst_depth_exceeded {
+    ($site:expr, $node:expr) => {{
+        static THROTTLE: $crate::util::WarnThrottle =
+            $crate::util::WarnThrottle::new($crate::util::MAX_DEPTH_REPORTS);
+        $crate::util::log_cst_depth_exceeded(&THROTTLE, $site, $node);
+    }};
+}
+pub(crate) use report_cst_depth_exceeded;
+
+static RESOLUTION_CYCLE_REPORTS: WarnThrottle = WarnThrottle::new(MAX_DEPTH_REPORTS);
 
 /// Record that a resolution refused to re-enter itself, breaking a cycle.
 ///
@@ -75,7 +139,7 @@ static RESOLUTION_CYCLE_REPORTS: std::sync::atomic::AtomicUsize =
 /// always worth a line in the log: silently returning `None` here is what
 /// makes a missing type look like an ordinary unresolvable one.
 pub(crate) fn report_resolution_cycle(site: &str, name: &str, uri: &tower_lsp::lsp_types::Url) {
-    throttled_warn(&RESOLUTION_CYCLE_REPORTS, MAX_DEPTH_REPORTS, || {
+    RESOLUTION_CYCLE_REPORTS.warn(|| {
         format!(
             "resolution cycle broken in {site}: `{name}` in {} is already being resolved further \
              up the stack, so its type is reported as unknown. This means a self- or \

--- a/src/util.rs
+++ b/src/util.rs
@@ -29,7 +29,44 @@ pub(crate) fn home_dir() -> Option<PathBuf> {
 /// introduced.
 ///
 /// Not a correctness bound in the usual sense: once hit, callers simply
-/// stop descending into that subtree (silently under-reporting deeper
-/// diagnostics) rather than erroring — the same trade-off `resolve_chain`'s
-/// hierarchy walk already makes with its own `max_depth` parameter.
+/// stop descending into that subtree (under-reporting deeper diagnostics)
+/// rather than erroring — the same trade-off `resolve_chain`'s hierarchy
+/// walk already makes with its own `max_depth` parameter. Report every hit
+/// through [`report_cst_depth_exceeded`] so that trade-off stays visible.
 pub(crate) const MAX_CST_DESCENT_DEPTH: usize = 512;
+
+/// How many depth-cap hits to log before going quiet. One pathological tree
+/// trips the cap once per node past the limit, so an unthrottled log would
+/// bury everything else; the first few carry all the diagnostic value.
+const MAX_DEPTH_REPORTS: usize = 5;
+
+static DEPTH_REPORTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Record that a recursive CST descent stopped at [`MAX_CST_DESCENT_DEPTH`].
+///
+/// The cap exists to convert a stack overflow into degraded output, but a
+/// silent bail leaves nothing to explain *why* results went missing — and a
+/// hit on ordinary-looking source is itself the signal that something is
+/// wrong (a cycle, or a walker reaching far deeper than real syntax should).
+/// `site` names the walker; the node's position points at the input.
+pub(crate) fn report_cst_depth_exceeded(site: &str, node: tree_sitter::Node<'_>) {
+    let seen = DEPTH_REPORTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    if seen >= MAX_DEPTH_REPORTS {
+        return;
+    }
+    let position = node.start_position();
+    log::warn!(
+        "CST descent hit the depth cap ({MAX_CST_DESCENT_DEPTH}) in {site} at \
+         {}:{} (node kind `{}`) — deeper nodes were skipped. Real Kotlin/Java \
+         nests a few dozen levels, so this points at either a pathologically \
+         large expression or a resolution loop.{}",
+        position.row + 1,
+        position.column + 1,
+        node.kind(),
+        if seen + 1 == MAX_DEPTH_REPORTS {
+            " Further reports suppressed."
+        } else {
+            ""
+        },
+    );
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,3 +8,28 @@ use std::path::PathBuf;
 pub(crate) fn home_dir() -> Option<PathBuf> {
     std::env::home_dir()
 }
+
+/// Shared recursion-depth cap for hand-rolled recursive CST descents
+/// (`node.children()` walked via plain Rust recursion rather than an
+/// iterative `TreeCursor` loop).
+///
+/// Real Kotlin/Java syntax — even unusually deeply nested Compose UI —
+/// bottoms out at a few dozen levels; measured against the actual
+/// `nowinandroid` sample, a realistic file (including a malformed,
+/// mid-edit buffer) never exceeds ~20. This cap is generous relative to
+/// that (over an order of magnitude of headroom) while still sitting far
+/// below the few-thousand-frame threshold that overflows an 8 MiB stack —
+/// see the recursive descents in `features::call_arg_diagnostics`,
+/// `features::fill_when`, `features::missing_import_diagnostics`,
+/// `features::nullable_call_diagnostics`, and `indexer::cst_folding`,
+/// each of which independently stack-overflows on a pathological input
+/// (e.g. a single expression with tens of thousands of chained
+/// operators/segments, or an unclosed-brace file with tens of thousands of
+/// trailing lines) with no guard at all before this constant was
+/// introduced.
+///
+/// Not a correctness bound in the usual sense: once hit, callers simply
+/// stop descending into that subtree (silently under-reporting deeper
+/// diagnostics) rather than erroring — the same trade-off `resolve_chain`'s
+/// hierarchy walk already makes with its own `max_depth` parameter.
+pub(crate) const MAX_CST_DESCENT_DEPTH: usize = 512;

--- a/src/util.rs
+++ b/src/util.rs
@@ -50,23 +50,62 @@ static DEPTH_REPORTS: std::sync::atomic::AtomicUsize = std::sync::atomic::Atomic
 /// wrong (a cycle, or a walker reaching far deeper than real syntax should).
 /// `site` names the walker; the node's position points at the input.
 pub(crate) fn report_cst_depth_exceeded(site: &str, node: tree_sitter::Node<'_>) {
-    let seen = DEPTH_REPORTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    if seen >= MAX_DEPTH_REPORTS {
+    let position = node.start_position();
+    throttled_warn(&DEPTH_REPORTS, MAX_DEPTH_REPORTS, || {
+        format!(
+            "CST descent hit the depth cap ({MAX_CST_DESCENT_DEPTH}) in {site} at \
+             {}:{} (node kind `{}`) — deeper nodes were skipped. Real Kotlin/Java \
+             nests a few dozen levels, so this points at either a pathologically \
+             large expression or a resolution loop.",
+            position.row + 1,
+            position.column + 1,
+            node.kind(),
+        )
+    });
+}
+
+/// Log `message()` via `log::warn!`, capped at `limit` calls through this
+/// particular `counter`.
+///
+/// Generalizes the counter-and-suppress dance [`report_cst_depth_exceeded`]
+/// established, so every other "this should be rare, but on pathological or
+/// looping input could fire on every request" call site can declare its own
+/// `static AtomicUsize` and reuse this instead of reinventing the throttle.
+/// `message` is a closure (not a plain `String`) so the formatting work is
+/// skipped entirely once a site has gone quiet.
+pub(crate) fn throttled_warn(
+    counter: &std::sync::atomic::AtomicUsize,
+    limit: usize,
+    message: impl FnOnce() -> String,
+) {
+    let seen = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    if seen >= limit {
         return;
     }
-    let position = node.start_position();
-    log::warn!(
-        "CST descent hit the depth cap ({MAX_CST_DESCENT_DEPTH}) in {site} at \
-         {}:{} (node kind `{}`) — deeper nodes were skipped. Real Kotlin/Java \
-         nests a few dozen levels, so this points at either a pathologically \
-         large expression or a resolution loop.{}",
-        position.row + 1,
-        position.column + 1,
-        node.kind(),
-        if seen + 1 == MAX_DEPTH_REPORTS {
-            " Further reports suppressed."
-        } else {
-            ""
-        },
-    );
+    let suffix = if seen + 1 == limit {
+        " Further reports suppressed."
+    } else {
+        ""
+    };
+    log::warn!("{}{suffix}", message());
+}
+
+/// Describe a `spawn_blocking`/`tokio::spawn` task that failed to complete —
+/// panicked or was cancelled — for use inside a [`throttled_warn`] call at
+/// each `JoinHandle` await site that currently converts the `Err` into an
+/// empty/default result.
+///
+/// A panic there is never a legitimate "nothing found": the task's own logic
+/// decides what counts as absent and returns `None`/`vec![]` on that path
+/// deliberately. Reaching `Err` means the task unwound instead, and without
+/// this the caller's fallback silently looks identical to a real miss —
+/// exactly the "diagnostic that never fired" / "results silently missing"
+/// failure mode this module's other guard exists to catch.
+/// `what` should say which task and, where cheap, which input (a URI, a
+/// symbol name); `err` is the `JoinError` tokio handed back.
+pub(crate) fn join_failure_message(what: &str, err: &tokio::task::JoinError) -> String {
+    format!(
+        "background task panicked or was cancelled while {what}: {err} — falling back to an \
+         empty/default result that will look like an ordinary miss to the caller"
+    )
 }

--- a/src/workspace/document_handler.rs
+++ b/src/workspace/document_handler.rs
@@ -28,6 +28,27 @@ const STRONG_BUILD_MARKERS: [&str; 6] = [
 ];
 const WEAK_BUILD_MARKERS: [&str; 1] = ["Package.swift"];
 
+/// Throttle counters for the `spawn_blocking`/`tokio::spawn` join-panic
+/// warnings below — see [`crate::util::throttled_warn`]. Each names a
+/// distinct background task, so a panic in one doesn't spend the budget of
+/// an unrelated one.
+static FILE_SAVED_REINDEX_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static STORE_LIVE_TREE_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static OPEN_DOC_INDEX_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static OPEN_DOC_SEMANTIC_DIAGS_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static REPUBLISH_PROMOTION_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static REPUBLISH_SEMANTIC_DIAGS_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static OUTSIDE_ROOT_INDEX_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static LIVE_TREES_URI_PARSE_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 pub(crate) struct DocumentHandler {
     indexer: Arc<Indexer>,
     client: Option<Client>,
@@ -95,12 +116,20 @@ impl DocumentHandler {
             let Ok(permit) = semaphore.acquire_owned().await else {
                 return;
             };
-            tokio::task::spawn_blocking(move || {
+            let display_path = path.display().to_string();
+            let join_result = tokio::task::spawn_blocking(move || {
                 let _permit = permit;
                 indexer.index_content(&uri, &content);
             })
-            .await
-            .ok();
+            .await;
+            if let Err(ref e) = join_result {
+                crate::util::throttled_warn(&FILE_SAVED_REINDEX_JOIN_FAILURES, 5, || {
+                    crate::util::join_failure_message(
+                        &format!("re-indexing {display_path} after didSave"),
+                        e,
+                    )
+                });
+            }
         });
     }
 
@@ -130,9 +159,19 @@ impl DocumentHandler {
         self.indexer.set_live_lines(uri, content);
 
         let indexer = Arc::clone(&self.indexer);
+        let uri_for_log = uri.clone();
         let uri = uri.clone();
         let content = content.to_owned();
-        let _ = tokio::task::spawn_blocking(move || indexer.store_live_tree(&uri, &content)).await;
+        let join_result =
+            tokio::task::spawn_blocking(move || indexer.store_live_tree(&uri, &content)).await;
+        if let Err(ref e) = join_result {
+            crate::util::throttled_warn(&STORE_LIVE_TREE_JOIN_FAILURES, 5, || {
+                crate::util::join_failure_message(
+                    &format!("parsing the live tree for {}", uri_for_log.path()),
+                    e,
+                )
+            });
+        }
     }
 
     fn spawn_open_document_indexing(&self, uri: Url, content: String) {
@@ -179,6 +218,17 @@ impl DocumentHandler {
                 }
                 Err(join_error) => Err(join_error),
             };
+            if let Err(ref e) = result {
+                crate::util::throttled_warn(&OPEN_DOC_INDEX_JOIN_FAILURES, 5, || {
+                    crate::util::join_failure_message(
+                        &format!(
+                            "indexing freshly-opened document {}",
+                            diagnostics_uri.path()
+                        ),
+                        e,
+                    )
+                });
+            }
 
             let (index_result, diagnostics_text) = match result {
                 Ok((data, text)) => (Ok(data), text),
@@ -231,9 +281,19 @@ impl DocumentHandler {
                     d
                 }
             })
-            .await
-            .unwrap_or_default();
-            diagnostics.extend(semantic_diags);
+            .await;
+            if let Err(ref e) = semantic_diags {
+                crate::util::throttled_warn(&OPEN_DOC_SEMANTIC_DIAGS_JOIN_FAILURES, 5, || {
+                    crate::util::join_failure_message(
+                        &format!(
+                            "computing semantic diagnostics for freshly-opened {}",
+                            diagnostics_uri.path()
+                        ),
+                        e,
+                    )
+                });
+            }
+            diagnostics.extend(semantic_diags.unwrap_or_default());
 
             if let Some(client) = client {
                 client
@@ -253,7 +313,25 @@ impl DocumentHandler {
             .indexer
             .live_trees
             .iter()
-            .filter_map(|entry| Url::parse(entry.key()).ok())
+            .filter_map(|entry| match Url::parse(entry.key()) {
+                Ok(uri) => Some(uri),
+                Err(e) => {
+                    // `live_trees` keys are always `Url::to_string()` of a URI this
+                    // process itself inserted (see `live_tree_impl.rs`) — this should
+                    // never fail to round-trip. A hit here means the key was
+                    // corrupted, and that open file silently drops out of this
+                    // republish pass (its diagnostics stay stale/suppressed).
+                    crate::util::throttled_warn(&LIVE_TREES_URI_PARSE_FAILURES, 5, || {
+                        format!(
+                            "republish_open_file_diagnostics: live_trees key {:?} failed to \
+                             parse as a URI ({e}) — skipping; this file's diagnostics will not \
+                             be republished",
+                            entry.key()
+                        )
+                    });
+                    None
+                }
+            })
             .collect();
 
         // Re-attempt import promotion for EVERY open file, SEQUENTIALLY in
@@ -273,12 +351,24 @@ impl DocumentHandler {
         tokio::task::spawn(async move {
             let promotion_indexer = Arc::clone(&handler_indexer);
             let promotion_uris = open_uris.clone();
-            let _ = tokio::task::spawn_blocking(move || {
+            let promotion_uri_count = promotion_uris.len();
+            let join_result = tokio::task::spawn_blocking(move || {
                 for uri in &promotion_uris {
                     promote_file_imports(&promotion_indexer, uri);
                 }
             })
             .await;
+            if let Err(ref e) = join_result {
+                crate::util::throttled_warn(&REPUBLISH_PROMOTION_JOIN_FAILURES, 5, || {
+                    crate::util::join_failure_message(
+                        &format!(
+                            "re-promoting imports for {promotion_uri_count} open file(s) after \
+                             the JAR scan completed"
+                        ),
+                        e,
+                    )
+                });
+            }
 
             for uri in open_uris {
                 let indexer = Arc::clone(&handler_indexer);
@@ -312,10 +402,24 @@ impl DocumentHandler {
                             d
                         }
                     })
-                    .await
-                    .unwrap_or_default();
+                    .await;
+                    if let Err(ref e) = semantic_diags {
+                        crate::util::throttled_warn(
+                            &REPUBLISH_SEMANTIC_DIAGS_JOIN_FAILURES,
+                            5,
+                            || {
+                                crate::util::join_failure_message(
+                                    &format!(
+                                        "computing republished semantic diagnostics for {}",
+                                        uri.path()
+                                    ),
+                                    e,
+                                )
+                            },
+                        );
+                    }
                     let mut diagnostics = syntax_diags;
-                    diagnostics.extend(semantic_diags);
+                    diagnostics.extend(semantic_diags.unwrap_or_default());
                     if let Some(client) = client {
                         client.publish_diagnostics(uri, diagnostics, None).await;
                     }
@@ -329,11 +433,20 @@ impl DocumentHandler {
         let semaphore = indexer.parse_sem();
         tokio::task::spawn(async move {
             if let Ok(permit) = semaphore.acquire_owned().await {
-                let _ = tokio::task::spawn_blocking(move || {
+                let display_path = uri.path().to_owned();
+                let join_result = tokio::task::spawn_blocking(move || {
                     let _permit = permit;
                     indexer.index_content(&uri, &content);
                 })
                 .await;
+                if let Err(ref e) = join_result {
+                    crate::util::throttled_warn(&OUTSIDE_ROOT_INDEX_JOIN_FAILURES, 5, || {
+                        crate::util::join_failure_message(
+                            &format!("indexing outside-root document {display_path}"),
+                            e,
+                        )
+                    });
+                }
             }
         });
     }

--- a/src/workspace/file_change_handler.rs
+++ b/src/workspace/file_change_handler.rs
@@ -15,6 +15,14 @@ use crate::features::unused_import_diagnostics::unused_import_diagnostics;
 use crate::indexer::live_tree::{lang_for_path, parse_live};
 use crate::indexer::Indexer;
 
+/// Throttle counters for the `spawn_blocking` join-panic warnings below — see
+/// [`crate::util::throttled_warn`]. Each names a distinct task; a panic in
+/// one is unrelated to a panic in the other, so they're capped separately.
+static INDEX_CONTENT_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static SEMANTIC_DIAGS_JOIN_FAILURES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 pub(crate) struct FileChangeHandler {
     indexer: Arc<Indexer>,
     client: Option<Client>,
@@ -142,6 +150,17 @@ impl FileChangeHandler {
                 return;
             }
 
+            if let Err(ref e) = result {
+                crate::util::throttled_warn(&INDEX_CONTENT_JOIN_FAILURES, 5, || {
+                    crate::util::join_failure_message(
+                        &format!(
+                            "re-indexing {} on the debounced didChange path",
+                            diagnostics_uri.path()
+                        ),
+                        e,
+                    )
+                });
+            }
             let (index_result, diagnostics_text) = result.unwrap_or_else(|_| (None, String::new()));
             let index_hit_cache = index_result.is_none();
             log::debug!(
@@ -193,8 +212,19 @@ impl FileChangeHandler {
                     diagnostics
                 }
             })
-            .await
-            .unwrap_or_default();
+            .await;
+            if let Err(ref e) = semantic_diags {
+                crate::util::throttled_warn(&SEMANTIC_DIAGS_JOIN_FAILURES, 5, || {
+                    crate::util::join_failure_message(
+                        &format!(
+                            "computing semantic diagnostics for {} on the debounced didChange path",
+                            diagnostics_uri.path()
+                        ),
+                        e,
+                    )
+                });
+            }
+            let semantic_diags = semantic_diags.unwrap_or_default();
 
             let mut diagnostics = syntax_diags;
             diagnostics.extend(semantic_diags);

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -372,6 +372,10 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
         // Transition to InProgress before spawning.
         if let Ok(mut phase) = self.indexer.jar_phase.lock() {
             *phase = JarPhase::InProgress;
+        } else {
+            crate::indexer::jar_phase::report_jar_phase_lock_poisoned(
+                "ScanHandler::spawn_jar_indexing (-> InProgress)",
+            );
         }
 
         let indexer = Arc::clone(&self.indexer);
@@ -531,6 +535,10 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             if paths.is_empty() && sources_total == 0 {
                 if let Ok(mut phase) = indexer.jar_phase.lock() {
                     *phase = JarPhase::Ready { count: 0 };
+                } else {
+                    crate::indexer::jar_phase::report_jar_phase_lock_poisoned(
+                        "ScanHandler::spawn_jar_indexing (-> Ready{0}, no jars found)",
+                    );
                 }
                 in_progress.store(false, Ordering::Release);
                 let _ = jar_done_tx.send(());
@@ -565,6 +573,10 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             };
             if let Ok(mut phase) = indexer.jar_phase.lock() {
                 *phase = final_phase;
+            } else {
+                crate::indexer::jar_phase::report_jar_phase_lock_poisoned(
+                    "ScanHandler::spawn_jar_indexing (-> Ready/Failed, terminal)",
+                );
             }
             // Invalidate the completion cache so the next request returns JAR
             // symbols (launch, collect, etc.) without requiring a retype.
@@ -594,6 +606,14 @@ fn abandon_stale_jar_scan(
                 count: indexer.jar_definitions.len(),
             };
         }
+    } else {
+        // Worse here than at the other transition sites: this function's own
+        // doc comment says leaving `jar_phase` stuck in Pending/InProgress
+        // "would keep `call_arg_diagnostics` suppressed indefinitely" — a
+        // poisoned lock produces exactly that stuck state, silently.
+        crate::indexer::jar_phase::report_jar_phase_lock_poisoned(
+            "ScanHandler::abandon_stale_jar_scan",
+        );
     }
     let _ = jar_done_tx.send(());
 }


### PR DESCRIPTION
**Stacked on #258.** Retarget as the stack merges.

## Summary

A user hit a hard crash in live use — `thread 'main' has overflowed its stack / fatal runtime error: stack overflow, aborting`, which Helix reported as "Timed out waiting for language servers to shutdown" (the process had already aborted).

This branch does two distinct things: it **fixes the actual crash** (a resolution cycle, proven from a core dump), and it **bounds a whole class of neighbouring recursion hazards** found while hunting for it.

## The crash (commit `4af53be`)

Root cause proven from the crash core dump — 65,127 frames, build-id verified against the crashing binary — as an exact four-frame cycle:

```
infer_expr_type
  → infer_expr_type_at_depth
    → infer_ident_type
      → infer_variable_type_from_cst
        → infer_expr_type          ← public entry: depth restarts at 0
```

Inferring a variable's type infers its initializer, which resolves the identifiers inside it, which infers *their* variables. A self- or mutually-referential initializer closes the loop, and it runs until the stack is exhausted and the process aborts, taking the server down mid-edit.

**Why every depth cap missed it:** the loop passes back through `infer_expr_type`, a *public* entry point that resets its depth counter to zero on every lap. The counter never climbs. This is why the sweep below — and its own instrumentation — stayed silent through every reproduction.

**Fix:** a thread-local in-flight set keyed on `(uri, var_name)` — the full identity of the query — released by RAII so early returns and unwinds cannot leak an entry. Re-entering the same variable in the same file cannot produce an answer the outer call is not already computing, so returning `None` loses nothing; a different variable or file is unaffected. Breaking a cycle always means the source really is self-referential, so it reports through `report_resolution_cycle` rather than failing silently.

## The sweep (commits `3e33313`, `8cd9f96`, `64182b0`)

Found first, via a separate reproduction: a `when` whose subject is a 20,000-segment navigation chain, run through `kmp-lsp diagnose`. Bisecting with `--only`:

```
syntax           OK
when             CRASH
call-arg         CRASH
nullable         CRASH
missing-import   CRASH
```

Every *semantic* diagnostic overflowed; only the non-CST one survived — so this was not a bug in any one feature but in the pattern they share. Each hand-rolled recursive CST walk (`node.children()` via plain Rust recursion rather than an iterative `TreeCursor` loop) had **no depth bound at all**, so tree depth translated directly into stack frames. Confirmed pre-existing, not introduced by the branches below: reverting `fill_when.rs` to its parent commit reproduces it identically.

A shared `crate::util::MAX_CST_DESCENT_DEPTH = 512`, threaded as a `depth` parameter through **18 walkers across 15 files**, bailing (not erroring) past the cap. This follows the codebase's existing precedent — `walk_hierarchy` already takes a `max_depth`, `speculative.rs` has `MAX_ASCENT` — and extends it to the walkers that lacked one. 512 is generous: measured against the real `nowinandroid` sample, an ordinary file (including a malformed mid-edit buffer) never exceeds depth ~20, while overflow needs a few thousand frames.

Two alternatives were rejected: a single generic shared combinator (call sites differ too much in collection and early-return semantics), and rejecting whole files past a depth threshold (silently blanks *all* diagnostics for one deep expression instead of degrading gracefully). Deliberately not bounded: `match_type_args_recursive` (`type_subst.rs`), which recurses on *textual* `<...>` nesting rather than tree structure.

These are real, independently reproducible crashes — but note that none of them was the user's. The user's file is 86 lines at depth 17.

Review of the first pass found two more walkers of the same class that the sweep had missed, now also guarded (commit `73fcdaf`): `find_prop_initializer` (`resolver/infer.rs`) — searched by name over the whole file, so a name that is never declared walks to full depth instead of returning early, and it sits directly behind the new cycle guard — and `collect_used_identifier_texts_inner` (`features/unused_import_diagnostics.rs`), which visits every node in the file.

## Diagnostics (commits `fe68475`, `5601517`)

The reason this took several passes is that every failure mode above was **silent**. Both are now reported, throttled through a shared `util::throttled_warn`:

- `report_cst_depth_exceeded!` — a depth-cap bail names the walker and the node position. On ordinary-looking source, a hit is itself the signal that something is wrong.
- `report_resolution_cycle` — a broken cycle is never routine and always logs.

Review caught these going *permanently* silent: all the walkers shared one process-lifetime budget of five reports, so five hits during startup indexing would suppress every later depth report from every walker for the rest of the server's uptime. `WarnThrottle` now refills every five minutes, and `report_cst_depth_exceeded!` is a macro so each expansion gets its own static budget — the one walker caught in a loop can't crowd out the others. `throttled_warn` stays as-is for the join-failure sites, where a lifetime budget is right: a task that panicked once is a bug you fix, not one you need re-reported hourly.
- Swallowed `JoinError`s at `spawn_blocking` await sites, which previously made a panicked background task indistinguishable from an ordinary empty result.

## Test plan
- [x] Crash cycle: `a_self_referential_initializer_does_not_recurse_forever` and `mutually_referential_initializers_do_not_recurse_forever`, **both verified to abort the test binary with SIGABRT when the guard is removed**
- [x] Depth sweep: 8 `*_survives_a_pathologically_deep_*` regression tests, **each verified red** — the six pre-existing ones re-checked by setting the cap to `usize::MAX`, all six overflow; the two new ones by removing their guard individually
- [x] Caught during that re-check: the two new tests initially used the 5,000-repetition input the existing tests use and **passed without their guard** — 5,005 frames is real recursion but not enough to exhaust 8 MiB for a small-frame walker. Raised to 60,000, which reproduces
- [x] Reproduced the original `diagnose` crash pre-fix; every `--only` kind now completes
- [x] `cargo test --bin kmp-lsp`: 1712 passed, 0 failed
- [x] All 6 integration suites pass; `cargo fmt --check` and `cargo clippy --bin kmp-lsp --tests` clean, zero warnings

## Known gap

`visit_unshadowed_name_matches` (`src/indexer/infer/cst_symbol.rs`) is an unguarded recursive CST walk of the same class, on the rename/references path. Left out deliberately to keep a proven crash fix from growing; tracked as follow-up.
