### PR TITLE
fix(release): support glibc 2.28+ on linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,13 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            # Use a container with glibc 2.28
+            container: "quay.io/pypa/manylinux_2_28_x86_64"
             binary: kmp-lsp
             asset: kmp-lsp-linux-x86_64
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
+            container: "quay.io/pypa/manylinux_2_28_aarch64"
             binary: kmp-lsp
             asset: kmp-lsp-linux-aarch64
           - target: x86_64-apple-darwin
@@ -42,6 +45,7 @@ jobs:
             asset: kmp-lsp-windows-aarch64
 
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v4
 
@@ -49,15 +53,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools (Linux aarch64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-
       - name: Build release binary
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package binary (Unix)


### PR DESCRIPTION
Building on ubuntu-latest enforces an unnecessary dependency on glibc 2.39+ due to an issue with the rustc linker. Fixed by building inside a container with glibc 2.28.

See https://github.com/helix-editor/helix/issues/13960