### PR TITLE
fix(rename): bound the local-scope walker's unguarded CST recursion

### DIFF
--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -381,7 +381,7 @@ pub(crate) fn local_scope_occurrences(
         .find(|scope| declares_name_directly(*scope, &name, &doc.bytes).is_some())?;
 
     let mut occurrences: Vec<Occurrence> = Vec::new();
-    visit_unshadowed_name_matches(
+    let complete = visit_unshadowed_name_matches(
         body,
         &name,
         0,
@@ -389,7 +389,13 @@ pub(crate) fn local_scope_occurrences(
         None,
         &doc.bytes,
         &mut |node, generation| occurrences.push(Occurrence { node, generation }),
+        0,
     );
+    if !complete {
+        // Some occurrences were never seen; renaming the rest would corrupt
+        // the file. Fall through to the cross-file path instead.
+        return None;
+    }
 
     let cursor_generation = occurrences
         .iter()
@@ -541,6 +547,10 @@ fn declares_name_directly<'a>(scope: Node<'a>, name: &str, bytes: &[u8]) -> Opti
 /// one — `val x: Any = "hello"; val x = x as String`'s own initializer
 /// reference must see the FIRST `x`, since the second doesn't exist yet
 /// while its own initializer runs.
+///
+/// Returns `false` if the walk stopped at [`crate::util::MAX_CST_DESCENT_DEPTH`],
+/// leaving `visit` incomplete — see [`visit_unshadowed_name_matches`].
+#[must_use]
 fn visit_statements_with_generations<'a>(
     statements: Node<'a>,
     name: &str,
@@ -548,12 +558,13 @@ fn visit_statements_with_generations<'a>(
     already_shadowed: bool,
     bytes: &[u8],
     visit: &mut impl FnMut(Node<'a>, usize),
-) {
+    depth: usize,
+) -> bool {
     let mut cursor = statements.walk();
     for statement in statements.children(&mut cursor) {
-        match declares_name_directly(statement, name, bytes) {
+        let complete = match declares_name_directly(statement, name, bytes) {
             Some(declaration_node) => {
-                visit_unshadowed_name_matches(
+                let complete = visit_unshadowed_name_matches(
                     statement,
                     name,
                     generation,
@@ -561,11 +572,13 @@ fn visit_statements_with_generations<'a>(
                     Some(declaration_node),
                     bytes,
                     visit,
+                    depth + 1,
                 );
                 generation += 1;
                 if !already_shadowed {
                     visit(declaration_node, generation);
                 }
+                complete
             }
             None => visit_unshadowed_name_matches(
                 statement,
@@ -575,9 +588,14 @@ fn visit_statements_with_generations<'a>(
                 None,
                 bytes,
                 visit,
+                depth + 1,
             ),
+        };
+        if !complete {
+            return false;
         }
     }
+    true
 }
 
 /// Walk `node`'s subtree, calling `visit` on every `simple_identifier`
@@ -585,6 +603,14 @@ fn visit_statements_with_generations<'a>(
 /// nested scope boundary that itself redeclares `name` (shadowing).
 /// `exclude` suppresses one node — a declaration re-emitted separately by
 /// [`visit_statements_with_generations`] at its own new generation.
+///
+/// Returns `false` if it stopped at [`crate::util::MAX_CST_DESCENT_DEPTH`]
+/// instead of finishing. Callers must not use a partial result: a rename that
+/// applies to some occurrences of a name and not others is worse than one that
+/// declines, so [`local_scope_occurrences`] gives up its fast path on `false`
+/// rather than returning the occurrences it did find.
+#[must_use]
+#[allow(clippy::too_many_arguments)]
 fn visit_unshadowed_name_matches<'a>(
     node: Node<'a>,
     name: &str,
@@ -593,7 +619,12 @@ fn visit_unshadowed_name_matches<'a>(
     exclude: Option<Node<'a>>,
     bytes: &[u8],
     visit: &mut impl FnMut(Node<'a>, usize),
-) {
+    depth: usize,
+) -> bool {
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded!("visit_unshadowed_name_matches", node);
+        return false;
+    }
     let is_excluded = exclude.is_some_and(|excluded| excluded.id() == node.id());
     if !already_shadowed
         && !is_excluded
@@ -604,15 +635,22 @@ fn visit_unshadowed_name_matches<'a>(
         visit(node, generation);
     }
     if node.kind() == KIND_STATEMENTS {
-        visit_statements_with_generations(node, name, generation, already_shadowed, bytes, visit);
-        return;
+        return visit_statements_with_generations(
+            node,
+            name,
+            generation,
+            already_shadowed,
+            bytes,
+            visit,
+            depth + 1,
+        );
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         let child_shadowed = already_shadowed
             || (scope_boundary_at(child).is_some()
                 && declares_name_directly(child, name, bytes).is_some());
-        visit_unshadowed_name_matches(
+        if !visit_unshadowed_name_matches(
             child,
             name,
             generation,
@@ -620,8 +658,12 @@ fn visit_unshadowed_name_matches<'a>(
             exclude,
             bytes,
             visit,
-        );
+            depth + 1,
+        ) {
+            return false;
+        }
     }
+    true
 }
 
 /// Convert a tree-sitter node's byte-based position into an LSP `Location`

--- a/src/indexer/infer/cst_symbol_tests.rs
+++ b/src/indexer/infer/cst_symbol_tests.rs
@@ -604,3 +604,34 @@ fn local_scope_occurrences_returns_none_when_cursor_is_on_a_named_argument_label
          the local fast path must not claim this position, got {result:?}"
     );
 }
+
+/// The walk descends only the body that declares the name, but one expression
+/// nested that deeply inside it still reaches the same frame count -- and this
+/// walker's frames are heavy enough to exhaust 8 MiB at ~10,000 levels.
+#[test]
+fn local_scope_occurrences_survives_a_pathologically_deep_body() {
+    let n = 4_000; // ~8x MAX_CST_DESCENT_DEPTH (512)
+    let mut src = String::from("fun run() {\n    val total = 0\n    print(total");
+    for _ in 0..n {
+        src.push_str("+1");
+    }
+    src.push_str(")\n}\n");
+
+    let handle = std::thread::Builder::new()
+        // Deliberately small: the guard caps the walk at 512 frames whatever
+        // the stack size, and n=4,000 overflows 2 MiB unguarded, so this pins
+        // the same defect as an 8 MiB thread would at n=10,000 -- without the
+        // quadratic parse-depth cost of getting there.
+        .stack_size(2 * 1024 * 1024)
+        .spawn(move || {
+            let (file_uri, indexer) = indexed_with_live("/Deep.kt", &src);
+            local_scope_occurrences(&indexer, &file_uri, Position::new(1, 8))
+        })
+        .unwrap();
+    // A stack overflow aborts the process rather than failing this join.
+    let result = handle.join().expect("must not overflow the stack");
+    assert!(
+        result.is_none(),
+        "a truncated walk must decline the local fast path, not rename a subset"
+    );
+}


### PR DESCRIPTION
Closes the gap disclosed in #259.

## It is a real crash, not a theoretical one

`visit_unshadowed_name_matches` / `visit_statements_with_generations` (`indexer/infer/cst_symbol.rs`) are a mutually recursive pair with no depth bound. They are reached from exactly one place — `local_scope_occurrences`, which `rename_impl` tries **first on every rename**.

I had assumed this one was lower-risk than the walkers capped in #259, because it starts at the declaring scope rather than the file root. That assumption was wrong, so I measured instead:

| stack | nesting | result |
|---|---|---|
| 8 MiB | 10,000 | **overflow, SIGABRT** |
| 4 MiB | 4,000 | survives |
| 2 MiB | 4,000 | **overflow** |
| 1 MiB | 4,000 | **overflow** |

Its frames run ~500–1000 bytes — several times heavier than the other walkers — so it exhausts a default stack at roughly *half* their nesting depth.

## Fix

Both halves thread a `depth` counter and bail at `MAX_CST_DESCENT_DEPTH`, as the 18 other walkers do.

**The bail cannot under-report here.** Every other capped walker drops a diagnostic when it stops early, which degrades gracefully. A rename that applies to *some* occurrences of a name and not others silently corrupts the file. So both walkers return whether they completed, and `local_scope_occurrences` declines its fast path on a truncated walk — rename falls through to the cross-file path rather than renaming a subset.

## Test plan
- [x] `local_scope_occurrences_survives_a_pathologically_deep_body`, **verified red** — without the guard it aborts the test binary with SIGABRT
- [x] The test uses a 2 MiB thread at n=4,000 rather than 8 MiB at n=10,000. Same defect, but see below — the realistic parameters take ~50s to reach the crash, which is too slow for the suite
- [x] All 15 pre-existing `local_scope_occurrences_*` tests still pass (shadowing, sibling scopes, redeclaration generations, destructuring, catch-block scoping)
- [x] `cargo test --bin kmp-lsp`: 1713 passed, 0 failed; all 6 integration suites pass; clippy and fmt clean

## Separate pre-existing bug found while measuring, NOT fixed here

This walk is **quadratic in nesting depth**: 1,000 → 0.54s, 2,000 → 2.1s, 4,000 → 8.4s. Cause is that tree-sitter's `Node::parent()` is O(depth), and `is_declaration_site` calls it per node.

The cost splits evenly between the scope-finding pass (`declares_name_directly`, iterative — so this cap does not apply to it) and the walk itself. With this fix a rename inside a 10,000-level expression no longer crashes the server, but still takes ~26s. That is a slow request rather than a dead process, so it is a genuine improvement — but the quadratic wants its own change, most cleanly by threading the known parent kind through `declares_name_directly`'s stack instead of calling `parent()`.