### PR TITLE
ci(test): validate static/musl kmp-jar-indexer build for Termux/Android (#263)

### DIFF
--- a/.github/workflows/test-musl-sidecar.yml
+++ b/.github/workflows/test-musl-sidecar.yml
@@ -1,0 +1,76 @@
+name: Test musl static sidecar build
+
+# Throwaway/discovery workflow — NOT part of the release pipeline.
+#
+# Validates whether kmp-jar-indexer can be built as a static, musl-libc-linked
+# native-image binary (no dynamic-linker dependency), which is what's needed to
+# run under environments without a standard glibc Linux userspace, e.g. Termux
+# on Android. See https://github.com/Hessesian/kmp-lsp/issues/263.
+#
+# Builds are uploaded as a workflow artifact only (no GitHub release created).
+# Delete this file once musl support is proven and folded into release.yml.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/test-musl-sidecar.yml"
+      - "java-sidecar/**"
+  workflow_dispatch:
+
+jobs:
+  build-musl-sidecar:
+    runs-on: ubuntu-24.04-arm
+    defaults:
+      run:
+        working-directory: java-sidecar
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: "21"
+          distribution: "graalvm-community"
+          native-image-job-reports: "true"
+
+      - name: Install musl toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      # GraalVM's --libc=musl static build needs a static zlib built against
+      # musl (Ubuntu's zlib1g-dev is glibc-only). Built from the official
+      # upstream source and dropped in a fixed path the Gradle build points at.
+      - name: Build static zlib against musl
+        run: |
+          set -euo pipefail
+          MUSL_GCC="$(command -v musl-gcc)"
+          echo "musl-gcc: $MUSL_GCC"
+          curl -fsSL -o /tmp/zlib.tar.gz https://zlib.net/zlib-1.3.1.tar.gz
+          tar -xzf /tmp/zlib.tar.gz -C /tmp
+          cd /tmp/zlib-1.3.1
+          CC="$MUSL_GCC" ./configure --static
+          make -j"$(nproc)" libz.a
+          sudo mkdir -p /opt/musl-zlib
+          sudo cp libz.a /opt/musl-zlib/
+
+      - name: Build static musl native sidecar
+        run: |
+          ./gradlew nativeCompile \
+            -PstaticMusl=true \
+            -PmuslZlibDir=/opt/musl-zlib \
+            -PmuslCC="$(command -v musl-gcc)" \
+            --info
+
+      - name: Package sidecar
+        run: |
+          mkdir -p dist
+          cp build/native/nativeCompile/kmp-jar-indexer dist/kmp-jar-indexer-linux-aarch64-musl
+          chmod +x dist/kmp-jar-indexer-linux-aarch64-musl
+          file dist/kmp-jar-indexer-linux-aarch64-musl
+          ldd dist/kmp-jar-indexer-linux-aarch64-musl || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: kmp-jar-indexer-linux-aarch64-musl
+          path: java-sidecar/dist/kmp-jar-indexer-linux-aarch64-musl
+          if-no-files-found: error

--- a/.github/workflows/test-musl-sidecar.yml
+++ b/.github/workflows/test-musl-sidecar.yml
@@ -45,7 +45,8 @@ jobs:
           set -euo pipefail
           MUSL_GCC="$(command -v musl-gcc)"
           echo "musl-gcc: $MUSL_GCC"
-          curl -fsSL -o /tmp/zlib.tar.gz https://zlib.net/zlib-1.3.1.tar.gz
+          curl -fsSL --retry 3 -o /tmp/zlib.tar.gz \
+            https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz
           tar -xzf /tmp/zlib.tar.gz -C /tmp
           cd /tmp/zlib-1.3.1
           CC="$MUSL_GCC" ./configure --static

--- a/java-sidecar/build.gradle.kts
+++ b/java-sidecar/build.gradle.kts
@@ -72,6 +72,19 @@ graalvmNative {
                 "--gc=serial",
                 "-O2",
             )
+            // Opt-in static/musl build (test workflow only — never set for the real
+            // release matrix). Produces a linker-independent binary that runs under
+            // environments without a standard glibc dynamic linker, e.g. Termux.
+            // -PmuslZlibDir and -PmuslCC point at the toolchain the test workflow sets up.
+            if (project.hasProperty("staticMusl")) {
+                buildArgs.addAll("--static", "--libc=musl")
+                (project.findProperty("muslZlibDir") as String?)?.let {
+                    buildArgs.addAll("-H:NativeLinkerOption=-L$it", "-H:NativeLinkerOption=-lz")
+                }
+                (project.findProperty("muslCC") as String?)?.let {
+                    buildArgs.add("-H:CCompilerPath=$it")
+                }
+            }
         }
     }
     toolchainDetection.set(false)


### PR DESCRIPTION
## Summary
- Throwaway discovery workflow (`.github/workflows/test-musl-sidecar.yml`) that builds `kmp-jar-indexer` as a **static, musl-linked** native-image binary — no dynamic-linker dependency, so it should run under environments without a standard glibc userspace (Termux/Android is the motivating case, see #263).
- Gated behind an opt-in `-PstaticMusl` Gradle property in `java-sidecar/build.gradle.kts`; the real release matrix (`release.yml`) is untouched and unaffected.
- Not part of the release pipeline — the binary is uploaded as a **workflow artifact only**, no GitHub release is cut, no tag needed.

## Why
Root cause of the ARM64 install failures reported in #263: Termux isn't a standard glibc Linux userspace, so no dynamically-linked binary — prebuilt by CI or even hand-built inside a `proot` chroot — can execute there directly. A fully static build sidesteps that.

## What to expect
This is a discovery run, not a guaranteed-working recipe — first-pass CI failure is an acceptable/expected outcome here, the logs will tell us what (if anything) needs adjusting in the musl/zlib toolchain setup.

## Test plan
- [ ] CI job `build-musl-sidecar` succeeds on `ubuntu-24.04-arm`
- [ ] `file`/`ldd` output in the job log confirms the binary is statically linked
- [ ] Download the `kmp-jar-indexer-linux-aarch64-musl` artifact from the run and confirm it executes under Termux (cc @dessalines on #263 if this gets far enough to test)

Delete this workflow once musl support is proven and folded into `release.yml` properly.