### PR TITLE
feat(resolution-accuracy): resolver-recall + cache-candidate CLI benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,13 @@ jobs:
 
       - name: Install runtime tools (Linux)
         if: runner.os == 'Linux'
+        # azure.archive.ubuntu.com (the runner's default mirror) has hung
+        # apt-get update indefinitely before, silently eating the full
+        # 6h job timeout instead of failing — bound both apt's own
+        # retry/timeout and the step itself so a flaky mirror fails fast.
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
+          sudo apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15
           sudo apt-get install -y ripgrep fd-find
           sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
 

--- a/docs/superpowers/plans/2026-08-15-resolution-accuracy-benchmark.md
+++ b/docs/superpowers/plans/2026-08-15-resolution-accuracy-benchmark.md
@@ -65,12 +65,17 @@ fn member_call_on_jar_receiver_resolves_cst_resolved() {
 
     let idx = Indexer::new();
     let uri = Url::parse("file:///t/Flow.kt").unwrap();
+    // Deliberately no same-file `collect` declaration here — that collision
+    // scenario is `same_file_shape_mismatched_self_declaration_is_filtered_candidate_not_gap`'s
+    // own job below. `resolve_qualified`'s uppercase-root branch tries
+    // `resolve_extension_in_scope` before the member/jar lookup and returns
+    // immediately on any name match there, with no arity check — so a
+    // same-file same-named extension would short-circuit before this jar
+    // member is ever reached, regardless of this test's call shape. This
+    // fixture isolates the claim this test actually makes: an unambiguous
+    // JAR-member reference resolves via `resolve_identity` alone.
     let src = "package com.example\n\
                import kotlinx.coroutines.flow.Flow\n\
-               class CoroutineScope\n\
-               fun <T : Any> Flow<T>.collect(scope: CoroutineScope, block: (T) -> Unit) {\n\
-                   collect(block)\n\
-               }\n\
                fun useTriggers(triggers: Flow<String>) {\n\
                    triggers.collect { trigger -> println(trigger) }\n\
                }\n";
@@ -135,7 +140,7 @@ fn member_call_on_jar_receiver_resolves_cst_resolved() {
 
     let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
     let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
-    let outcome = outcome_at(&outcomes, "collect", 7);
+    let outcome = outcome_at(&outcomes, "collect", 3);
     match &outcome.outcome {
         ResolutionOutcome::Success { tier, locations } => {
             assert_eq!(*tier, SuccessTier::CstResolved);
@@ -268,6 +273,16 @@ Replace `src/features/unresolved_symbol_diagnostics.rs`'s content (keep the `mod
 //! methodology. Not wired into a live diagnostic yet; named and positioned
 //! like its `missing_import_diagnostics`/`unused_import_diagnostics`
 //! siblings so that reuse doesn't need restructuring later.
+
+// Temporary: this module's `pub(crate)` items have no consumer outside
+// `#[cfg(test)]` until Task 4 registers `cli::resolution_accuracy_poc` in
+// `cli/mod.rs`. The repo's pre-commit hook runs bare `cargo clippy -D
+// warnings` (no `--tests`), which doesn't compile `#[cfg(test)]` code, so
+// without this every commit before Task 4 fails on dead-code errors. Remove
+// this line in Task 4 once the CLI wiring makes the whole chain reachable
+// from a non-test entry point — `cargo clippy -- -D warnings` passing clean
+// afterward confirms every item here is genuinely used.
+#![cfg_attr(not(test), allow(dead_code))]
 
 use tower_lsp::lsp_types::{Location, Position, Url};
 use tree_sitter::Node;
@@ -424,6 +439,8 @@ Expected: PASS (5 tests: `member_call_on_jar_receiver_resolves_cst_resolved`,
 `collect_resolution_outcomes_survives_a_pathologically_deep_expression`).
 
 Also run the full suite to confirm nothing else broke: `cargo test --bin kmp-lsp` — expected all pass (1743 pre-existing + 5 new).
+
+Also run: `cargo clippy -- -D warnings` (no `--tests`/`--all-targets` — matches this repo's pre-commit hook exactly, `.git/hooks/pre-commit`, which does not compile `#[cfg(test)]` code). Without the `#![cfg_attr(not(test), allow(dead_code))]` line from Step 3, this fails with 6 dead-code errors (nothing outside tests consumes these items until Task 4). Expected: clean, because that line is present.
 
 - [ ] **Step 5: Commit**
 
@@ -794,7 +811,7 @@ fn top_n(map: &BTreeMap<String, NamedSample>, n: usize) -> Vec<(String, NamedSam
 Run: `cargo test --bin kmp-lsp unresolved_symbol_diagnostics -- --nocapture`
 Expected: PASS (7 tests total in this module now).
 
-Also run: `cargo clippy --all-targets -- -D warnings` — expected clean (no unused-field warnings; every field is read by at least one method already in this same commit).
+Also run: `cargo clippy -- -D warnings` (no `--tests`/`--all-targets` — matches the pre-commit hook). Expected: clean — the `#![cfg_attr(not(test), allow(dead_code))]` line from Task 1 still covers every new item here too (same file), and every field added in this task is read by at least one method already in this same commit (no *additional* dead-code risk beyond what that line already suppresses).
 
 - [ ] **Step 5: Commit**
 
@@ -1002,6 +1019,7 @@ git commit -m "feat(resolution-accuracy): add CLI workspace-walk + report printi
 - Modify: `src/cli/mod.rs`
 - Modify: `src/cli/args.rs`
 - Modify: `src/cli/run.rs`
+- Modify: `src/features/unresolved_symbol_diagnostics.rs` (remove the Task 1 temporary dead-code suppression, Step 6)
 
 **Interfaces:**
 - Consumes: `super::resolution_accuracy_poc::run_resolution_accuracy` (Task 3).
@@ -1075,18 +1093,31 @@ In `src/cli/run.rs`'s `run` function, add a match arm (after the `Subcommand::Un
         }
 ```
 
-- [ ] **Step 6: Build and run the full test suite**
+- [ ] **Step 6: Remove the temporary dead-code suppression**
+
+This step 1-5 wiring is what finally gives `src/features/unresolved_symbol_diagnostics.rs`'s items a non-test consumer
+(`cli::resolution_accuracy_poc`, now reachable from `run()`). Remove the line added in Task 1 Step 3:
+
+```rust
+#![cfg_attr(not(test), allow(dead_code))]
+```
+
+and its explanatory comment block immediately above it, from the top of `src/features/unresolved_symbol_diagnostics.rs`.
+
+- [ ] **Step 7: Build and run the full test suite**
 
 Run: `cargo build`
 Expected: builds clean, no warnings.
 
+Run: `cargo clippy -- -D warnings` (no `--tests`/`--all-targets` — matches the pre-commit hook). Expected: clean, with the suppression from Step 6 already removed — this is the confirmation that every item in `unresolved_symbol_diagnostics.rs` is now genuinely reachable from the CLI binary, not just from tests. If this fails, something in `resolution_accuracy_poc.rs` (Task 3) doesn't actually call the item clippy flags — do not restore the suppression to work around it; fix the missing call instead.
+
 Run: `cargo test --bin kmp-lsp`
 Expected: all pass (1743 pre-existing + 7 new from Tasks 1–2 = 1750).
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
-git add src/cli/mod.rs src/cli/args.rs src/cli/run.rs
+git add src/cli/mod.rs src/cli/args.rs src/cli/run.rs src/features/unresolved_symbol_diagnostics.rs
 git commit -m "feat(resolution-accuracy): wire the resolution-accuracy CLI subcommand"
 ```
 

--- a/docs/superpowers/plans/2026-08-15-resolution-accuracy-benchmark.md
+++ b/docs/superpowers/plans/2026-08-15-resolution-accuracy-benchmark.md
@@ -1,0 +1,1129 @@
+# Resolution-Accuracy Benchmark Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a CLI benchmark (`kmp-lsp resolution-accuracy <root>`) that measures what fraction of references in a Kotlin/Java workspace the resolver can actually find (recall), and surfaces which symbols get resolved identically over and over (cache-candidate signal), per `docs/superpowers/specs/2026-08-15-resolution-accuracy-benchmark-design.md`.
+
+**Architecture:** A shared, pure classification function (`collect_resolution_outcomes`, in a new `src/features/unresolved_symbol_diagnostics.rs`, positioned like its `missing_import_diagnostics`/`unused_import_diagnostics` siblings for later live-diagnostic reuse) walks every identifier in one file's CST, classifies each via the existing `classify_cursor`/`resolve_identity` pipeline, and buckets the result into `Success` / `FilteredCandidate` / `Gap`. A pure `ResolutionAccuracyAggregator` accumulates these across a whole workspace scan into a recall summary and a cache-candidate report. A new CLI subcommand (`src/cli/resolution_accuracy_poc.rs`, mirroring `missing_import_poc.rs`) owns all I/O: building the index, warming the JAR index, walking workspace files, and printing the report.
+
+**Tech Stack:** Rust, tree-sitter (Kotlin/Java grammars), `tower_lsp::lsp_types`, existing `Indexer`/`classify_cursor`/`resolve_identity` infrastructure — no new dependencies.
+
+## Global Constraints
+
+- CLI-only this pass — no live-diagnostic wiring (per the design's "Risks / deferred" section and the user's explicit sequencing: CLI first, LSP later).
+- Classification must go through `classify_cursor` + `resolve_identity` directly, never `find_definition`'s full pipeline — its `rg`-grep fallback would mask real resolver regressions (see design's "Classification algorithm" section).
+- Any new hand-rolled recursive CST descent must be bounded via `crate::util::MAX_CST_DESCENT_DEPTH` + `crate::util::report_cst_depth_exceeded!`, matching the codebase-wide convention from the PR #257–#259 stack-overflow hardening pass.
+- Follow the exact sibling-file structure already established by `missing_import_diagnostics.rs` / `cli/missing_import_poc.rs` (shared detection function in `features/`, I/O-only CLI wrapper in `cli/`).
+- `tree-sitter` node `start_position().column` is a byte offset, not a UTF-16 code unit offset (LSP's `Position.character`). Use it directly as an approximation — the same simplification `missing_import_diagnostics.rs`'s own candidate collection already relies on (see `src/features/missing_import_diagnostics.rs:286-289`). Do not attempt a "more correct" UTF-16 conversion; that would be unbuilt-upon scope creep on a benchmark tool.
+
+---
+
+### Task 1: Core classification — identifier walk + `collect_resolution_outcomes`
+
+**Files:**
+- Create: `src/features/unresolved_symbol_diagnostics.rs`
+- Create: `src/features/unresolved_symbol_diagnostics_tests.rs`
+- Modify: `src/features/mod.rs` (register the new module)
+
+**Interfaces:**
+- Consumes: `crate::indexer::{classify_cursor, resolve_identity, Indexer, NavigationSource, SymbolAtCursor, SymbolRole}` (all already `pub(crate)`, re-exported at `src/indexer.rs:36-45`); `crate::indexer::live_tree::LiveDoc`; `crate::queries::{KIND_SIMPLE_IDENT, KIND_TYPE_IDENT}`; `crate::util::{MAX_CST_DESCENT_DEPTH, report_cst_depth_exceeded}`.
+- Produces (used by Task 2 and Task 3):
+  - `pub(crate) enum SuccessTier { CstResolved, NameScan }` (derives `Debug, Clone, Copy, PartialEq, Eq`)
+  - `pub(crate) enum ResolutionOutcome { Success { tier: SuccessTier, locations: Vec<Location> }, FilteredCandidate, Gap }` (derives `Debug, Clone`)
+  - `pub(crate) struct ReferenceOutcome { pub name: String, pub receiver_type: Option<String>, pub line: u32, pub col: u32, pub outcome: ResolutionOutcome }` (derives `Debug, Clone`)
+  - `pub(crate) fn collect_resolution_outcomes(indexer: &Indexer, uri: &Url, doc: &LiveDoc) -> Vec<ReferenceOutcome>`
+
+- [ ] **Step 1: Write the failing tests**
+
+The design doc's Testing section calls for "a bare local-variable reference → `Success/NameScan`" as the fourth case. This plan uses a bare *call to a top-level function* instead
+(`bare_call_to_top_level_function_resolves_name_scan_success` below) — `resolve_identity`'s
+`Reference { receiver_type: None, .. }` arm handles every bare reference identically regardless of
+whether the referent is a local `val` or a top-level declaration (same `find_definition_qualified(name, None, uri)` call either way), so this exercises the identical code path without depending on unverified assumptions about whether local variable declarations are indexed the same way top-level ones are.
+
+Create `src/features/unresolved_symbol_diagnostics_tests.rs`:
+
+```rust
+use super::*;
+use crate::indexer::Indexer;
+use tower_lsp::lsp_types::{Position, Url};
+
+/// Find the one outcome for `name` at 0-indexed `line` — fixtures below
+/// sometimes have the same name appear more than once on different lines
+/// (a declaration site, a self-shadowed bare call, an explicit-receiver
+/// call), so matching by name alone would be ambiguous.
+fn outcome_at<'a>(outcomes: &'a [ReferenceOutcome], name: &str, line: u32) -> &'a ReferenceOutcome {
+    outcomes
+        .iter()
+        .find(|o| o.name == name && o.line == line)
+        .unwrap_or_else(|| panic!("no reference outcome named `{name}` at line {line}, got: {outcomes:?}"))
+}
+
+#[test]
+fn member_call_on_jar_receiver_resolves_cst_resolved() {
+    use crate::types::{FileData, SourceSet, SymbolEntry, Visibility};
+    use std::sync::Arc;
+
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Flow.kt").unwrap();
+    let src = "package com.example\n\
+               import kotlinx.coroutines.flow.Flow\n\
+               class CoroutineScope\n\
+               fun <T : Any> Flow<T>.collect(scope: CoroutineScope, block: (T) -> Unit) {\n\
+                   collect(block)\n\
+               }\n\
+               fun useTriggers(triggers: Flow<String>) {\n\
+                   triggers.collect { trigger -> println(trigger) }\n\
+               }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+
+    let jar_uri_str = "jar:file:///fake-coroutines.jar!/Flow.kt".to_string();
+    let jar_uri = Url::parse(&jar_uri_str).unwrap();
+    let type_range = tower_lsp::lsp_types::Range {
+        start: Position::new(0, 0),
+        end: Position::new(0, 4),
+    };
+    let member_range = tower_lsp::lsp_types::Range {
+        start: Position::new(1, 0),
+        end: Position::new(1, 7),
+    };
+    let member = SymbolEntry {
+        name: "collect".to_owned(),
+        kind: tower_lsp::lsp_types::SymbolKind::METHOD,
+        visibility: Visibility::Public,
+        range: member_range,
+        selection_range: member_range,
+        detail: "suspend fun collect(collector: FlowCollector<T>)".to_owned(),
+        container: Some("Flow".to_owned()),
+        params: "collector: FlowCollector<T>".to_owned(),
+        param_counts: (1, 1),
+        cold: crate::types::pack_cold_fields(vec![], String::new(), String::new(), String::new()),
+        trailing_lambda: false,
+        deprecated: false,
+    };
+    let flow_type = SymbolEntry {
+        name: "Flow".to_owned(),
+        kind: tower_lsp::lsp_types::SymbolKind::INTERFACE,
+        visibility: Visibility::Public,
+        range: type_range,
+        selection_range: type_range,
+        detail: "interface Flow<T>".to_owned(),
+        container: None,
+        params: String::new(),
+        param_counts: (0, 0),
+        cold: crate::types::pack_cold_fields(vec![], String::new(), String::new(), String::new()),
+        trailing_lambda: false,
+        deprecated: false,
+    };
+    idx.jar_files.insert(
+        jar_uri_str.clone(),
+        Arc::new(FileData {
+            symbols: vec![flow_type, member],
+            source_set: SourceSet::Library,
+            package: Some("kotlinx.coroutines.flow".to_owned()),
+            lines: Arc::new(vec![]),
+            ..Default::default()
+        }),
+    );
+    idx.jar_definitions
+        .entry("Flow".to_owned())
+        .or_default()
+        .push(tower_lsp::lsp_types::Location {
+            uri: jar_uri.clone(),
+            range: type_range,
+        });
+
+    let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcome = outcome_at(&outcomes, "collect", 7);
+    match &outcome.outcome {
+        ResolutionOutcome::Success { tier, locations } => {
+            assert_eq!(*tier, SuccessTier::CstResolved);
+            assert_eq!(locations.len(), 1);
+            assert_eq!(locations[0].uri, jar_uri);
+        }
+        other => panic!("expected Success/CstResolved, got: {other:?}"),
+    }
+}
+
+#[test]
+fn same_file_shape_mismatched_self_declaration_is_filtered_candidate_not_gap() {
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Flow.kt").unwrap();
+    let src = "package com.example\n\
+               class Flow<T>\n\
+               class CoroutineScope\n\
+               fun <T> Flow<T>.collect(scope: CoroutineScope, block: (T) -> Unit) {\n\
+               }\n\
+               fun useTriggers(triggers: Flow<String>, scope: CoroutineScope) {\n\
+                   triggers.collect { trigger -> println(trigger) }\n\
+               }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+
+    let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcome = outcome_at(&outcomes, "collect", 6);
+    assert!(
+        matches!(outcome.outcome, ResolutionOutcome::FilteredCandidate),
+        "expected FilteredCandidate (a same-file wrong-arity self-declaration exists), got: {:?}",
+        outcome.outcome
+    );
+}
+
+#[test]
+fn undeclared_member_reference_is_gap() {
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Foo.kt").unwrap();
+    let src = "package com.example\n\
+               class Foo\n\
+               fun useFoo(foo: Foo) {\n\
+                   foo.totallyUndeclaredMethod()\n\
+               }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+
+    let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcome = outcome_at(&outcomes, "totallyUndeclaredMethod", 3);
+    assert!(
+        matches!(outcome.outcome, ResolutionOutcome::Gap),
+        "expected Gap, got: {:?}",
+        outcome.outcome
+    );
+}
+
+#[test]
+fn bare_call_to_top_level_function_resolves_name_scan_success() {
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Helper.kt").unwrap();
+    let src = "package com.example\n\
+               fun helper(): Int = 5\n\
+               fun useHelper() {\n\
+                   val result = helper()\n\
+               }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+
+    let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcome = outcome_at(&outcomes, "helper", 3);
+    match &outcome.outcome {
+        ResolutionOutcome::Success { tier, locations } => {
+            assert_eq!(*tier, SuccessTier::NameScan);
+            assert_eq!(locations.len(), 1);
+        }
+        other => panic!("expected Success/NameScan, got: {other:?}"),
+    }
+}
+
+#[test]
+fn collect_resolution_outcomes_survives_a_pathologically_deep_expression() {
+    let n = 5_000; // several times MAX_CST_DESCENT_DEPTH (512)
+    let mut src = String::from("package app\nfun f() {\n    val x = 1");
+    for _ in 0..n {
+        src.push_str("+1");
+    }
+    src.push_str("\n}\n");
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Deep.kt").unwrap();
+    idx.index_content(&uri, &src);
+    idx.store_live_tree(&uri, &src);
+    let doc = crate::indexer::live_tree::parse_live(&src, tree_sitter_kotlin::language()).unwrap();
+    let _ = collect_resolution_outcomes(&idx, &uri, &doc);
+}
+```
+
+Add the test wiring at the bottom of `src/features/unresolved_symbol_diagnostics.rs` (create the file with just this for now):
+
+```rust
+#[cfg(test)]
+#[path = "unresolved_symbol_diagnostics_tests.rs"]
+mod tests;
+```
+
+Register the module in `src/features/mod.rs` — insert alphabetically between `traits_impl` and `unused_import_diagnostics`:
+
+```rust
+pub(crate) mod unresolved_symbol_diagnostics;
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin kmp-lsp unresolved_symbol_diagnostics -- --nocapture`
+Expected: compile FAILURE — `collect_resolution_outcomes`, `ReferenceOutcome`, `ResolutionOutcome`, `SuccessTier` don't exist yet.
+
+- [ ] **Step 3: Implement the classification logic**
+
+Replace `src/features/unresolved_symbol_diagnostics.rs`'s content (keep the `mod tests` block at the bottom) with:
+
+```rust
+//! Resolution-accuracy benchmark: classify and resolve every `Reference`
+//! identifier in a file, bucketing the result into `Success` /
+//! `FilteredCandidate` / `Gap`.
+//!
+//! Shared with the `resolution-accuracy` CLI subcommand
+//! (`cli::resolution_accuracy_poc`), which runs this over an entire
+//! workspace to measure recall — see that module for the aggregate
+//! methodology. Not wired into a live diagnostic yet; named and positioned
+//! like its `missing_import_diagnostics`/`unused_import_diagnostics`
+//! siblings so that reuse doesn't need restructuring later.
+
+use tower_lsp::lsp_types::{Location, Position, Url};
+use tree_sitter::Node;
+
+use crate::indexer::live_tree::LiveDoc;
+use crate::indexer::{
+    classify_cursor, resolve_identity, Indexer, NavigationSource, SymbolAtCursor, SymbolRole,
+};
+use crate::queries::{KIND_SIMPLE_IDENT, KIND_TYPE_IDENT};
+
+/// Which resolution path produced a `Success` outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SuccessTier {
+    /// Precise, receiver-verified — `resolve_identity`'s `CstResolved` path.
+    CstResolved,
+    /// Found by name only. Reachable here exclusively for bare references:
+    /// `resolve_identity`'s `Reference { receiver_type: Some(_), .. }` arm
+    /// only ever returns `CstResolved` for a non-empty result (see
+    /// `classify_reference` below), so a member reference never lands here.
+    NameScan,
+}
+
+/// The outcome of attempting to resolve one `Reference`-classified identifier.
+#[derive(Debug, Clone)]
+pub(crate) enum ResolutionOutcome {
+    Success {
+        tier: SuccessTier,
+        locations: Vec<Location>,
+    },
+    /// The receiver-typed lookup came back empty, but an untyped lookup by
+    /// the same name found *something* elsewhere in the workspace. Ambiguous
+    /// by design: could be a correct self-shadow-style suppression (the
+    /// arity-filtering this session's fixes rely on), or a genuine resolver
+    /// miss — reported separately, not scored as a plain failure.
+    FilteredCandidate,
+    /// No candidate found anywhere by this name — the actionable bucket.
+    Gap,
+}
+
+/// One classified-and-resolved reference.
+#[derive(Debug, Clone)]
+pub(crate) struct ReferenceOutcome {
+    pub name: String,
+    /// `Some` for a member reference (`x.foo()`); `None` for a bare
+    /// reference (local var, unqualified call). Matches
+    /// `SymbolRole::Reference::receiver_type`.
+    pub receiver_type: Option<String>,
+    pub line: u32,
+    pub col: u32,
+    pub outcome: ResolutionOutcome,
+}
+
+/// Find every `simple_identifier`/`type_identifier` node's start position in
+/// `root`, via depth-bounded recursion (see `crate::util::MAX_CST_DESCENT_DEPTH`)
+/// — a pathological input can nest far deeper than any real Kotlin/Java
+/// syntax, and an unbounded walk would overflow the stack rather than degrade.
+fn collect_identifier_positions(node: Node, out: &mut Vec<Position>, depth: usize) {
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded!("collect_identifier_positions", node);
+        return;
+    }
+    if matches!(node.kind(), KIND_SIMPLE_IDENT | KIND_TYPE_IDENT) {
+        let point = node.start_position();
+        // `column` is a byte offset (tree-sitter), used directly as an
+        // approximation of the UTF-16 offset `classify_cursor` expects —
+        // same simplification `missing_import_diagnostics.rs`'s own
+        // candidate collection already relies on.
+        out.push(Position::new(point.row as u32, point.column as u32));
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_identifier_positions(child, out, depth + 1);
+    }
+}
+
+/// Classify and resolve every `Reference`-role identifier in `doc`.
+///
+/// `Declaration` and `ImportSegment` roles are skipped — declarations
+/// resolve by construction, imports are the `missing-imports`/
+/// `unused-imports` benchmarks' own territory.
+///
+/// The caller is responsible for `uri` having a live tree stored
+/// (`indexer.store_live_tree`) before calling this — `classify_cursor`
+/// resolves through `indexer.live_doc_or_parse(uri)` internally, the same
+/// requirement `collect_missing_import_flags` documents.
+pub(crate) fn collect_resolution_outcomes(
+    indexer: &Indexer,
+    uri: &Url,
+    doc: &LiveDoc,
+) -> Vec<ReferenceOutcome> {
+    let mut positions = Vec::new();
+    collect_identifier_positions(doc.tree.root_node(), &mut positions, 0);
+
+    let mut outcomes = Vec::new();
+    for position in positions {
+        let Some(symbol) = classify_cursor(indexer, uri, position) else {
+            continue;
+        };
+        let receiver_type = match &symbol.role {
+            SymbolRole::Reference { receiver_type, .. } => receiver_type.clone(),
+            SymbolRole::Declaration { .. } | SymbolRole::ImportSegment => continue,
+        };
+        let name = symbol.name.clone();
+        let outcome = classify_reference(indexer, uri, &symbol, receiver_type.clone());
+        outcomes.push(ReferenceOutcome {
+            name,
+            receiver_type,
+            line: position.line,
+            col: position.character,
+            outcome,
+        });
+    }
+    outcomes
+}
+
+/// Resolve one `Reference`-role symbol to a `ResolutionOutcome`.
+fn classify_reference(
+    indexer: &Indexer,
+    uri: &Url,
+    symbol: &SymbolAtCursor,
+    receiver_type: Option<String>,
+) -> ResolutionOutcome {
+    let success = match resolve_identity(symbol, indexer, uri) {
+        NavigationSource::CstResolved(defs) if !defs.is_empty() => {
+            Some((SuccessTier::CstResolved, defs.0))
+        }
+        NavigationSource::NameScan(defs) if !defs.is_empty() => {
+            Some((SuccessTier::NameScan, defs.0))
+        }
+        _ => None,
+    };
+    match success {
+        Some((tier, locations)) => ResolutionOutcome::Success { tier, locations },
+        None if receiver_type.is_some() => {
+            let probe = indexer.find_definition_qualified(&symbol.name, None, uri);
+            if probe.is_empty() {
+                ResolutionOutcome::Gap
+            } else {
+                ResolutionOutcome::FilteredCandidate
+            }
+        }
+        None => ResolutionOutcome::Gap,
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin kmp-lsp unresolved_symbol_diagnostics -- --nocapture`
+Expected: PASS (5 tests: `member_call_on_jar_receiver_resolves_cst_resolved`,
+`same_file_shape_mismatched_self_declaration_is_filtered_candidate_not_gap`,
+`undeclared_member_reference_is_gap`,
+`bare_call_to_top_level_function_resolves_name_scan_success`,
+`collect_resolution_outcomes_survives_a_pathologically_deep_expression`).
+
+Also run the full suite to confirm nothing else broke: `cargo test --bin kmp-lsp` — expected all pass (1743 pre-existing + 5 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/unresolved_symbol_diagnostics.rs src/features/unresolved_symbol_diagnostics_tests.rs src/features/mod.rs
+git commit -m "feat(resolution-accuracy): classify+resolve every reference into Success/FilteredCandidate/Gap"
+```
+
+---
+
+### Task 2: Aggregator — recall summary + cache-candidate grouping
+
+**Files:**
+- Modify: `src/features/unresolved_symbol_diagnostics.rs` (append)
+- Modify: `src/features/unresolved_symbol_diagnostics_tests.rs` (append)
+
+**Interfaces:**
+- Consumes: `ReferenceOutcome`, `ResolutionOutcome`, `SuccessTier` from Task 1 (same file).
+- Produces (used by Task 3):
+  - `pub(crate) struct RecallSummary { pub member_total: usize, pub member_cst_resolved: usize, pub bare_total: usize, pub bare_success: usize }` (derives `Debug, Clone, Copy, Default`) with `member_recall_pct(&self) -> f64`, `bare_recall_pct(&self) -> f64`
+  - `pub(crate) struct NamedSample { pub count: usize, pub sample_location: String }` (derives `Debug, Clone`)
+  - `pub(crate) struct CacheCandidate { pub name: String, pub receiver_type: Option<String>, pub count: usize, pub location: String }` (derives `Debug, Clone`)
+  - `pub(crate) struct UnstableHotKey { pub name: String, pub receiver_type: Option<String>, pub count: usize, pub distinct_locations: usize }` (derives `Debug, Clone`)
+  - `pub(crate) struct ResolutionAccuracyAggregator` (derives `Debug, Default`) with:
+    - `pub(crate) fn add(&mut self, file_label: &str, outcome: &ReferenceOutcome)`
+    - `pub(crate) fn recall(&self) -> RecallSummary`
+    - `pub(crate) fn top_filtered_candidates(&self, n: usize) -> Vec<(String, NamedSample)>`
+    - `pub(crate) fn top_gaps(&self, n: usize) -> Vec<(String, NamedSample)>`
+    - `pub(crate) fn cache_candidates(&self, n: usize) -> Vec<CacheCandidate>`
+    - `pub(crate) fn unstable_hot_keys(&self, n: usize) -> Vec<UnstableHotKey>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/features/unresolved_symbol_diagnostics_tests.rs`:
+
+```rust
+fn test_location(line: u32) -> tower_lsp::lsp_types::Location {
+    tower_lsp::lsp_types::Location {
+        uri: Url::parse("file:///t/Target.kt").unwrap(),
+        range: tower_lsp::lsp_types::Range {
+            start: Position::new(line, 0),
+            end: Position::new(line, 5),
+        },
+    }
+}
+
+#[test]
+fn recall_summary_counts_member_and_bare_lanes_separately() {
+    let mut agg = ResolutionAccuracyAggregator::default();
+    agg.add(
+        "A.kt",
+        &ReferenceOutcome {
+            name: "foo".to_owned(),
+            receiver_type: Some("Bar".to_owned()),
+            line: 0,
+            col: 0,
+            outcome: ResolutionOutcome::Success {
+                tier: SuccessTier::CstResolved,
+                locations: vec![test_location(0)],
+            },
+        },
+    );
+    agg.add(
+        "A.kt",
+        &ReferenceOutcome {
+            name: "missing".to_owned(),
+            receiver_type: Some("Bar".to_owned()),
+            line: 1,
+            col: 0,
+            outcome: ResolutionOutcome::Gap,
+        },
+    );
+    agg.add(
+        "A.kt",
+        &ReferenceOutcome {
+            name: "helper".to_owned(),
+            receiver_type: None,
+            line: 2,
+            col: 0,
+            outcome: ResolutionOutcome::Success {
+                tier: SuccessTier::NameScan,
+                locations: vec![test_location(0)],
+            },
+        },
+    );
+
+    let recall = agg.recall();
+    assert_eq!(recall.member_total, 2);
+    assert_eq!(recall.member_cst_resolved, 1);
+    assert!((recall.member_recall_pct() - 50.0).abs() < 0.01);
+    assert_eq!(recall.bare_total, 1);
+    assert_eq!(recall.bare_success, 1);
+    assert_eq!(recall.bare_recall_pct(), 100.0);
+
+    let gaps = agg.top_gaps(10);
+    assert_eq!(gaps.len(), 1);
+    assert_eq!(gaps[0].0, "missing");
+    assert_eq!(gaps[0].1.count, 1);
+    assert_eq!(gaps[0].1.sample_location, "A.kt:2");
+}
+
+#[test]
+fn cache_candidate_grouping_separates_stable_from_unstable_keys() {
+    let mut agg = ResolutionAccuracyAggregator::default();
+    let stable_loc = test_location(10);
+    for line in 0..5u32 {
+        agg.add(
+            "A.kt",
+            &ReferenceOutcome {
+                name: "widelyUsed".to_owned(),
+                receiver_type: Some("Bar".to_owned()),
+                line,
+                col: 0,
+                outcome: ResolutionOutcome::Success {
+                    tier: SuccessTier::CstResolved,
+                    locations: vec![stable_loc.clone()],
+                },
+            },
+        );
+    }
+    for (line, loc_line) in [(0u32, 1u32), (1, 2)] {
+        agg.add(
+            "B.kt",
+            &ReferenceOutcome {
+                name: "shadowed".to_owned(),
+                receiver_type: None,
+                line,
+                col: 0,
+                outcome: ResolutionOutcome::Success {
+                    tier: SuccessTier::NameScan,
+                    locations: vec![test_location(loc_line)],
+                },
+            },
+        );
+    }
+
+    let candidates = agg.cache_candidates(10);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].name, "widelyUsed");
+    assert_eq!(candidates[0].count, 5);
+
+    let unstable = agg.unstable_hot_keys(10);
+    assert_eq!(unstable.len(), 1);
+    assert_eq!(unstable[0].name, "shadowed");
+    assert_eq!(unstable[0].count, 2);
+    assert_eq!(unstable[0].distinct_locations, 2);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --bin kmp-lsp unresolved_symbol_diagnostics -- --nocapture`
+Expected: compile FAILURE — `ResolutionAccuracyAggregator` doesn't exist yet.
+
+- [ ] **Step 3: Implement the aggregator**
+
+Append to `src/features/unresolved_symbol_diagnostics.rs` (before the `#[cfg(test)]` block at the bottom), and add `use std::collections::{BTreeMap, HashMap, HashSet};` to the top-of-file `use` block:
+
+```rust
+/// One name's occurrence count plus a representative location, for the
+/// `FilteredCandidate`/`Gap` top-N reports.
+#[derive(Debug, Clone)]
+pub(crate) struct NamedSample {
+    pub count: usize,
+    pub sample_location: String,
+}
+
+/// Aggregate recall counts across a workspace scan.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct RecallSummary {
+    pub member_total: usize,
+    pub member_cst_resolved: usize,
+    pub bare_total: usize,
+    pub bare_success: usize,
+}
+
+impl RecallSummary {
+    /// `CstResolved / total` for member refs, as a percentage. `0.0` when
+    /// there were no member refs to score (an empty corpus, not a failure).
+    pub(crate) fn member_recall_pct(&self) -> f64 {
+        percent(self.member_cst_resolved, self.member_total)
+    }
+
+    /// `Success / total` for bare refs, as a percentage.
+    pub(crate) fn bare_recall_pct(&self) -> f64 {
+        percent(self.bare_success, self.bare_total)
+    }
+}
+
+fn percent(part: usize, total: usize) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        (part as f64 / total as f64) * 100.0
+    }
+}
+
+/// A `(name, receiver_type)` symbol resolved repeatedly to the exact same
+/// location — a candidate for a resolver-level memoization cache.
+#[derive(Debug, Clone)]
+pub(crate) struct CacheCandidate {
+    pub name: String,
+    pub receiver_type: Option<String>,
+    pub count: usize,
+    pub location: String,
+}
+
+/// A `(name, receiver_type)` symbol resolved often but to *different*
+/// locations across occurrences — not cacheable by this simple a key.
+#[derive(Debug, Clone)]
+pub(crate) struct UnstableHotKey {
+    pub name: String,
+    pub receiver_type: Option<String>,
+    pub count: usize,
+    pub distinct_locations: usize,
+}
+
+#[derive(Debug, Default)]
+struct CacheGroupState {
+    count: usize,
+    locations: HashSet<String>,
+    sample_location: String,
+}
+
+/// `Location`'s own `uri`/`range` fields, flattened to a string key —
+/// `Location` implements `Eq`/`PartialEq` but not `Hash`, so it can't sit in
+/// a `HashSet` directly.
+fn location_key(location: &Location) -> String {
+    format!(
+        "{}#{}:{}-{}:{}",
+        location.uri,
+        location.range.start.line,
+        location.range.start.character,
+        location.range.end.line,
+        location.range.end.character
+    )
+}
+
+/// Accumulates `ReferenceOutcome`s across a workspace scan, one file at a
+/// time, into a recall summary and a repeat-resolution/cache-candidate
+/// report — avoids holding every reference from a large corpus in memory
+/// simultaneously.
+#[derive(Debug, Default)]
+pub(crate) struct ResolutionAccuracyAggregator {
+    recall: RecallSummary,
+    filtered_candidate: BTreeMap<String, NamedSample>,
+    gap: BTreeMap<String, NamedSample>,
+    cache: HashMap<(String, Option<String>), CacheGroupState>,
+}
+
+impl ResolutionAccuracyAggregator {
+    /// Record one reference's outcome. `file_label` is a display-friendly
+    /// path (workspace-relative, e.g. `"src/Foo.kt"`) used only for sample
+    /// locations in the reports below.
+    pub(crate) fn add(&mut self, file_label: &str, outcome: &ReferenceOutcome) {
+        let sample_location = format!("{file_label}:{}", outcome.line + 1);
+        let is_member = outcome.receiver_type.is_some();
+        match &outcome.outcome {
+            ResolutionOutcome::Success { tier, locations } => {
+                if is_member {
+                    self.recall.member_total += 1;
+                    if *tier == SuccessTier::CstResolved {
+                        self.recall.member_cst_resolved += 1;
+                    }
+                } else {
+                    self.recall.bare_total += 1;
+                    self.recall.bare_success += 1;
+                }
+                let key = (outcome.name.clone(), outcome.receiver_type.clone());
+                let group = self.cache.entry(key).or_insert_with(|| CacheGroupState {
+                    count: 0,
+                    locations: HashSet::new(),
+                    sample_location: sample_location.clone(),
+                });
+                group.count += 1;
+                for location in locations {
+                    group.locations.insert(location_key(location));
+                }
+            }
+            ResolutionOutcome::FilteredCandidate => {
+                self.recall.member_total += 1;
+                let entry = self
+                    .filtered_candidate
+                    .entry(outcome.name.clone())
+                    .or_insert_with(|| NamedSample {
+                        count: 0,
+                        sample_location: sample_location.clone(),
+                    });
+                entry.count += 1;
+            }
+            ResolutionOutcome::Gap => {
+                if is_member {
+                    self.recall.member_total += 1;
+                } else {
+                    self.recall.bare_total += 1;
+                }
+                let entry = self.gap.entry(outcome.name.clone()).or_insert_with(|| NamedSample {
+                    count: 0,
+                    sample_location: sample_location.clone(),
+                });
+                entry.count += 1;
+            }
+        }
+    }
+
+    pub(crate) fn recall(&self) -> RecallSummary {
+        self.recall
+    }
+
+    /// Top `n` `FilteredCandidate` names by occurrence count, ties broken by name.
+    pub(crate) fn top_filtered_candidates(&self, n: usize) -> Vec<(String, NamedSample)> {
+        top_n(&self.filtered_candidate, n)
+    }
+
+    /// Top `n` `Gap` names by occurrence count, ties broken by name.
+    pub(crate) fn top_gaps(&self, n: usize) -> Vec<(String, NamedSample)> {
+        top_n(&self.gap, n)
+    }
+
+    /// Top `n` cache candidates (singleton resolved location) by occurrence count.
+    pub(crate) fn cache_candidates(&self, n: usize) -> Vec<CacheCandidate> {
+        let mut candidates: Vec<CacheCandidate> = self
+            .cache
+            .iter()
+            .filter(|(_, group)| group.locations.len() == 1)
+            .map(|((name, receiver_type), group)| CacheCandidate {
+                name: name.clone(),
+                receiver_type: receiver_type.clone(),
+                count: group.count,
+                location: group.sample_location.clone(),
+            })
+            .collect();
+        candidates.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.name.cmp(&b.name)));
+        candidates.truncate(n);
+        candidates
+    }
+
+    /// Top `n` high-frequency but location-unstable keys, by occurrence count.
+    pub(crate) fn unstable_hot_keys(&self, n: usize) -> Vec<UnstableHotKey> {
+        let mut hot: Vec<UnstableHotKey> = self
+            .cache
+            .iter()
+            .filter(|(_, group)| group.locations.len() > 1)
+            .map(|((name, receiver_type), group)| UnstableHotKey {
+                name: name.clone(),
+                receiver_type: receiver_type.clone(),
+                count: group.count,
+                distinct_locations: group.locations.len(),
+            })
+            .collect();
+        hot.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.name.cmp(&b.name)));
+        hot.truncate(n);
+        hot
+    }
+}
+
+fn top_n(map: &BTreeMap<String, NamedSample>, n: usize) -> Vec<(String, NamedSample)> {
+    let mut entries: Vec<(String, NamedSample)> =
+        map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+    entries.sort_by(|a, b| b.1.count.cmp(&a.1.count).then_with(|| a.0.cmp(&b.0)));
+    entries.truncate(n);
+    entries
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --bin kmp-lsp unresolved_symbol_diagnostics -- --nocapture`
+Expected: PASS (7 tests total in this module now).
+
+Also run: `cargo clippy --all-targets -- -D warnings` — expected clean (no unused-field warnings; every field is read by at least one method already in this same commit).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/unresolved_symbol_diagnostics.rs src/features/unresolved_symbol_diagnostics_tests.rs
+git commit -m "feat(resolution-accuracy): add recall + cache-candidate aggregator"
+```
+
+---
+
+### Task 3: CLI POC — workspace walk + report printing
+
+**Files:**
+- Create: `src/cli/resolution_accuracy_poc.rs`
+
+**Interfaces:**
+- Consumes: `crate::features::unresolved_symbol_diagnostics::{collect_resolution_outcomes, ResolutionAccuracyAggregator}` (Tasks 1–2); `crate::indexer::live_tree::{lang_for_path, parse_live}`; `crate::indexer::Indexer`; `crate::indexer::jar::{scan_gradle_jars, index_jars}`; `super::run::build_index`.
+- Produces (used by Task 4): `pub(crate) async fn run_resolution_accuracy(root: &Path)`
+
+- [ ] **Step 1: Write the file**
+
+No new unit tests in this task — it's I/O orchestration mirroring the already-tested `missing_import_poc.rs` pattern exactly (workspace walk, JAR warming, aggregation via Task 2's already-tested `ResolutionAccuracyAggregator`). Verified via the manual smoke run in Task 5.
+
+Create `src/cli/resolution_accuracy_poc.rs`:
+
+```rust
+//! POC: resolution-accuracy recall benchmark over a workspace.
+//!
+//! Runs [`collect_resolution_outcomes`] (shared with a future live
+//! diagnostic — see `features::unresolved_symbol_diagnostics`) over every
+//! indexed workspace file and prints an aggregate recall summary plus a
+//! repeat-resolution/cache-candidate report.
+//!
+//! Unlike the missing-imports/unused-imports precision POCs (run against a
+//! project you know compiles, so every flag is a false positive), there is
+//! no compiler ground truth for recall — treat this as a trend metric:
+//! compare the same corpus before/after a resolver change, not an absolute
+//! score. `Gap` names are the actionable bucket; `FilteredCandidate` is
+//! ambiguous by design (see `ResolutionOutcome`'s doc) and needs
+//! spot-checking, not blind trust.
+
+use std::path::Path;
+
+use tower_lsp::lsp_types::Url;
+
+use crate::features::unresolved_symbol_diagnostics::{
+    collect_resolution_outcomes, ResolutionAccuracyAggregator,
+};
+use crate::indexer::live_tree::{lang_for_path, parse_live};
+use crate::indexer::Indexer;
+
+/// Feed one already-indexed workspace file's reference outcomes into `aggregator`.
+fn scan_file(
+    indexer: &Indexer,
+    uri: &Url,
+    source: &str,
+    file_label: &str,
+    aggregator: &mut ResolutionAccuracyAggregator,
+) {
+    let Some(lang) = lang_for_path(uri.path()) else {
+        return;
+    };
+    let Some(doc) = parse_live(source, lang) else {
+        return;
+    };
+    indexer.store_live_tree(uri, source);
+    let outcomes = collect_resolution_outcomes(indexer, uri, &doc);
+    indexer.remove_live_tree(uri);
+    for outcome in &outcomes {
+        aggregator.add(file_label, outcome);
+    }
+}
+
+/// Run the benchmark over every indexed workspace `.kt`/`.java` file under
+/// `root` and print an aggregate recall + cache-candidate summary.
+pub(crate) async fn run_resolution_accuracy(root: &Path) {
+    eprintln!("Indexing {}...", root.display());
+    let index = super::run::build_index(root, true).await;
+    eprintln!(
+        "Indexed: {} files, {} symbols",
+        index.files.len(),
+        index.definitions.len()
+    );
+
+    // Member-ref recall depends on library-typed receivers resolving —
+    // without warming the compiled-JAR index, every library type looks
+    // unresolvable and member recall would be an artifact of missing setup,
+    // not resolver quality. Same requirement `missing_import_poc` documents.
+    let gradle_paths = crate::indexer::jar::scan_gradle_jars(None);
+    if !gradle_paths.is_empty() {
+        let mut sidecar = index.jar_sidecar.lock().unwrap_or_else(|e| e.into_inner());
+        let n = crate::indexer::jar::index_jars(&index, &gradle_paths, &mut sidecar);
+        eprintln!(
+            "Indexed {n} compiled-jar symbols from {} gradle jars",
+            gradle_paths.len()
+        );
+    } else {
+        eprintln!("(no gradle jars found — library-typed receivers will look unresolved)");
+    }
+
+    let mut uris: Vec<String> = index
+        .files
+        .iter()
+        .map(|e| e.key().clone())
+        .filter(|u| u.starts_with("file://") && !index.library_uris.contains(u))
+        .filter(|u| u.ends_with(".kt") || u.ends_with(".java"))
+        .collect();
+    uris.sort();
+
+    let mut aggregator = ResolutionAccuracyAggregator::default();
+    let mut total_files = 0usize;
+    for uri_str in &uris {
+        let Ok(uri) = Url::parse(uri_str) else {
+            continue;
+        };
+        let Ok(path) = uri.to_file_path() else {
+            continue;
+        };
+        let Ok(source) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        total_files += 1;
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .display()
+            .to_string();
+        scan_file(&index, &uri, &source, &rel, &mut aggregator);
+    }
+
+    print_report(total_files, &aggregator);
+}
+
+fn print_report(total_files: usize, aggregator: &ResolutionAccuracyAggregator) {
+    let recall = aggregator.recall();
+    eprintln!("\n──────── resolution-accuracy summary ────────");
+    eprintln!("files scanned          : {total_files}");
+    eprintln!(
+        "member refs             : {} ({} CstResolved, {:.1}% recall)",
+        recall.member_total,
+        recall.member_cst_resolved,
+        recall.member_recall_pct()
+    );
+    eprintln!(
+        "bare refs               : {} ({} resolved, {:.1}% recall)",
+        recall.bare_total,
+        recall.bare_success,
+        recall.bare_recall_pct()
+    );
+
+    eprintln!("\ntop Gap names (actionable — no candidate found anywhere):");
+    for (name, sample) in aggregator.top_gaps(20) {
+        eprintln!(
+            "  {:>4}  {name:<32} e.g. {}",
+            sample.count, sample.sample_location
+        );
+    }
+
+    eprintln!("\ntop FilteredCandidate names (ambiguous — spot-check, not a plain miss):");
+    for (name, sample) in aggregator.top_filtered_candidates(20) {
+        eprintln!(
+            "  {:>4}  {name:<32} e.g. {}",
+            sample.count, sample.sample_location
+        );
+    }
+
+    eprintln!("\ntop cache candidates (same symbol resolved to the same place, repeatedly):");
+    for candidate in aggregator.cache_candidates(20) {
+        let receiver = candidate.receiver_type.as_deref().unwrap_or("<bare>");
+        eprintln!(
+            "  {:>4}  {receiver}.{:<24} -> {}",
+            candidate.count, candidate.name, candidate.location
+        );
+    }
+
+    eprintln!(
+        "\nhigh-frequency but unstable (not a simple cache key — same name, different targets):"
+    );
+    for hot in aggregator.unstable_hot_keys(10) {
+        let receiver = hot.receiver_type.as_deref().unwrap_or("<bare>");
+        eprintln!(
+            "  {:>4}  {receiver}.{:<24} -> {} distinct locations",
+            hot.count, hot.name, hot.distinct_locations
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Confirm it compiles**
+
+This file isn't reachable yet (no `mod` declaration, no subcommand wiring) — Task 4 wires it in. Skip straight to Task 4; do not attempt to build this file in isolation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/resolution_accuracy_poc.rs
+git commit -m "feat(resolution-accuracy): add CLI workspace-walk + report printing"
+```
+
+---
+
+### Task 4: Wire the `resolution-accuracy` subcommand
+
+**Files:**
+- Modify: `src/cli/mod.rs`
+- Modify: `src/cli/args.rs`
+- Modify: `src/cli/run.rs`
+
+**Interfaces:**
+- Consumes: `super::resolution_accuracy_poc::run_resolution_accuracy` (Task 3).
+- Produces: a working `kmp-lsp resolution-accuracy [root]` CLI subcommand.
+
+**Note:** the existing `missing-imports`/`unused-imports` subcommands are themselves not listed in `print_help`'s `SUBCOMMANDS`/`EXAMPLES` sections (an existing gap, not introduced here) — this task matches that same scope exactly: functionally wired and usable, not added to the help text, for consistency with its two siblings.
+
+- [ ] **Step 1: Register the CLI module**
+
+In `src/cli/mod.rs`, insert alphabetically between `mod output;` and `mod run;`:
+
+```rust
+mod resolution_accuracy_poc;
+```
+
+- [ ] **Step 2: Add the `Subcommand` variant**
+
+In `src/cli/args.rs`, add to the `Subcommand` enum (after the `UnusedImports` variant):
+
+```rust
+    /// POC: report resolution-accuracy recall + cache-candidate signals across the workspace.
+    ResolutionAccuracy {
+        root: Option<PathBuf>,
+    },
+```
+
+- [ ] **Step 3: Recognize the subcommand name**
+
+In `src/cli/args.rs`'s `is_subcommand` function, add `"resolution-accuracy"` to the `matches!` list (after `"unused-imports"`):
+
+```rust
+fn is_subcommand(value: &str) -> bool {
+    matches!(
+        value,
+        "find"
+            | "refs"
+            | "hover"
+            | "complete"
+            | "index"
+            | "tokens"
+            | "tree"
+            | "diagnose"
+            | "sources"
+            | "extract-sources"
+            | "check"
+            | "missing-imports"
+            | "unused-imports"
+            | "resolution-accuracy"
+    )
+}
+```
+
+- [ ] **Step 4: Parse the subcommand**
+
+In `src/cli/args.rs`'s `build_subcommand` function, add a match arm (after the `"unused-imports"` arm, before the closing `_ => unreachable!()`):
+
+```rust
+        "resolution-accuracy" => Ok(Subcommand::ResolutionAccuracy {
+            root: positionals.first().map(PathBuf::from),
+        }),
+```
+
+- [ ] **Step 5: Dispatch it in `run`**
+
+In `src/cli/run.rs`'s `run` function, add a match arm (after the `Subcommand::UnusedImports` arm, before the closing `}` of the `match args.subcommand` block):
+
+```rust
+        Subcommand::ResolutionAccuracy { root } => {
+            let root = resolve_root(root.as_deref().or(args.root.as_deref()));
+            super::resolution_accuracy_poc::run_resolution_accuracy(&root).await;
+        }
+```
+
+- [ ] **Step 6: Build and run the full test suite**
+
+Run: `cargo build`
+Expected: builds clean, no warnings.
+
+Run: `cargo test --bin kmp-lsp`
+Expected: all pass (1743 pre-existing + 7 new from Tasks 1–2 = 1750).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli/mod.rs src/cli/args.rs src/cli/run.rs
+git commit -m "feat(resolution-accuracy): wire the resolution-accuracy CLI subcommand"
+```
+
+---
+
+### Task 5: Full verification + smoke run
+
+**Files:** none (verification only).
+
+**Interfaces:** none — this task only runs commands and inspects output.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `cargo test --bin kmp-lsp`
+Expected: all pass.
+
+Run: `cargo test --tests`
+Expected: all pass (integration tests unaffected — this feature has no integration-test surface yet, CLI-only).
+
+- [ ] **Step 2: Run clippy and fmt**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: clean.
+
+Run: `cargo fmt --check`
+Expected: clean (run `cargo fmt` first if not).
+
+- [ ] **Step 3: Smoke-run the new subcommand**
+
+Run: `cargo run --bin kmp-lsp -- resolution-accuracy tests/fixtures`
+Expected: completes without panicking, prints "Indexing ...", a jar-warming line, and the "──────── resolution-accuracy summary ────────" report with non-negative counts. `tests/fixtures` only has 2 `.kt` files, so this is a functional smoke check (the tool runs end-to-end and produces sane-looking output), not a meaningful recall measurement — a real accuracy run needs a full real project (e.g. nowInAndroid, the way `missing-imports`/`unused-imports` were validated), which isn't available in this environment. Leave that as a follow-up for whoever has such a project checked out.
+
+- [ ] **Step 4: Final commit (if fmt made changes)**
+
+```bash
+git add -A
+git commit -m "chore(resolution-accuracy): fmt"
+```
+
+(Skip this step if `cargo fmt --check` was already clean in Step 2 — nothing to commit.)

--- a/docs/superpowers/specs/2026-08-15-resolution-accuracy-benchmark-design.md
+++ b/docs/superpowers/specs/2026-08-15-resolution-accuracy-benchmark-design.md
@@ -20,6 +20,15 @@ return *empty* rather than the wrong answer. That's the right per-call behavior,
 observability: nothing currently measures whether "return empty" is trending down (gaps closing)
 or just moving the failure from "wrong answer" to "no answer" without ever being followed up.
 
+The same corpus walk this needs (resolve every reference once, workspace-wide) also produces a
+second, independent signal for free: how often the resolver redoes *identical* work for the same
+symbol. Nothing in the resolution path memoizes by symbol today, so a frequently-referenced symbol
+(a common receiver type's method, a widely-used utility) is re-resolved from scratch on every
+occurrence — including on every live syntax-highlighting/hover request that touches it. Surfacing
+which symbols are resolved the most, and whether they resolve identically every time, points at
+where a resolver-level cache would pay off — see "Repeat-resolution / cache-candidate report"
+below.
+
 ## Framing
 
 No compiler ground-truth exists to validate recall against (an equivalent to "run against a
@@ -112,6 +121,35 @@ Mirrors the existing POCs' "top flagged names" style:
   the bucket to eyeball for self-shadow-style suppressions.
 - `Gap` count and top-N names by frequency (with one sample location each) — the actionable bucket.
 
+## Repeat-resolution / cache-candidate report
+
+A second signal from the same walk, unrelated to accuracy: how often does the resolver redo
+*identical* work? Every occurrence of the same symbol re-runs the full `classify_cursor` +
+`resolve_identity` pipeline from scratch today — there is no per-(name, receiver-type) memoization
+anywhere in the resolution path. A symbol referenced hundreds of times across a file or workspace
+(a common receiver type's frequently-called method, a widely-used utility function) means hundreds
+of redundant identical resolutions. This is exactly the pattern behind "syntax highlighting
+reparsing already-known symbols": semantic-tokens/hover requests hit the same resolver path anew
+for every occurrence of a symbol that has already been resolved once with an identical outcome.
+
+No new resolver calls needed — this is pure aggregation over the `ReferenceOutcome`s the walk
+already produces:
+
+- Group `Success` outcomes (both `CstResolved` and `NameScan`) by key `(name, receiver_type)` —
+  the same lane split as the recall report (`receiver_type: None` for bare refs).
+- Per key, track the occurrence count and the distinct set of resolved `Location`s seen.
+- A key is a **cache candidate** when its occurrence count is high *and* the resolved location set
+  is a singleton — i.e., every occurrence of this symbol resolved to the exact same place, so
+  memoizing `(name, receiver_type) → Location` would eliminate the redundant re-resolution without
+  changing behavior. A high-count key whose location set varies (the same bare name resolving to
+  different declarations depending on file/scope) is reported separately, flagged as **not**
+  cacheable by this simple a key — a real occurrence, not a bug in the report.
+- Output: top-N cache candidates by occurrence count (name, receiver_type, count, the one stable
+  location), plus a smaller "high-frequency but unstable" list for visibility.
+
+This report exists to point at where a resolver-level cache would pay off most, not to implement
+one — follow-up work, not this pass.
+
 ## Testing
 
 Unit tests for the classifier (mirroring `missing_import_diagnostics_tests.rs`'s structure) with
@@ -125,6 +163,12 @@ synthetic indexer setups:
 Identifier walker: a depth-bound test matching the existing `*_survives_a_pathologically_deep_*`
 convention (`collect_candidates`'s own sibling tests), confirming a pathologically nested input
 returns partial results rather than overflowing the stack.
+
+Cache-candidate grouping: a symbol referenced N times in a file resolving to the same location
+each time is grouped into one candidate with `count == N` and a singleton location set; a symbol
+resolving to different locations across occurrences (e.g. two same-named-but-different local
+variables shadowing each other in different scopes) is excluded from the cache-candidate list and
+appears only in the unstable list.
 
 ## Risks / deferred
 

--- a/docs/superpowers/specs/2026-08-15-resolution-accuracy-benchmark-design.md
+++ b/docs/superpowers/specs/2026-08-15-resolution-accuracy-benchmark-design.md
@@ -1,0 +1,140 @@
+# Resolution-Accuracy Benchmark — Design
+
+Status: **proposed** (approved 2026-08-15, methodology independently reviewed by Fable before
+write-up). CLI-only for this pass; positioned to grow a live diagnostic later, same dual-purpose
+shape as `missing_import_diagnostics`/`unused_import_diagnostics` (a shared detection function
+used by both a CLI benchmark and, eventually, a real LSP diagnostic).
+
+## Context (why)
+
+This codebase has no compiler or type-checker backing it — resolution is CST heuristics plus
+cross-file/JAR symbol lookup. Two existing CLI benchmarks (`missing-imports`, `unused-imports`)
+measure **precision**: run against a project known to compile cleanly, every flag is by
+construction a false positive, so the flag count is a direct precision signal (ideal: zero).
+
+There is no equivalent tool for the mirror statistic, **recall**: of every reference in a
+workspace, what fraction can the resolver actually find? This matters directly to this session's
+work — five separate self-shadow bugs were just fixed (an arity-incompatible same-file
+declaration wrongly resurrected in place of the real target), each fixed by making the resolver
+return *empty* rather than the wrong answer. That's the right per-call behavior, but it has no
+observability: nothing currently measures whether "return empty" is trending down (gaps closing)
+or just moving the failure from "wrong answer" to "no answer" without ever being followed up.
+
+## Framing
+
+No compiler ground-truth exists to validate recall against (an equivalent to "run against a
+project you know compiles" doesn't exist for "run against a project you know resolves correctly"
+— nothing computes that independently). This is explicitly a **trend metric**: run on the same
+corpus before/after a resolver change and compare deltas ("member-ref recall went 71%→78% after
+this fix"), not chase an absolute score. The tool's output should be framed the same way the
+precision POCs frame "ideal is zero" — here, "ideal is monotonically up; watch the Gap bucket's
+top names for regressions."
+
+## Scope
+
+Only identifiers `classify_symbol_at` classifies as `SymbolRole::Reference` — `Declaration` and
+`ImportSegment` are excluded (declarations resolve by construction; imports are the existing
+precision POCs' territory).
+
+Reported in two separate lanes rather than filtering one out:
+- **Member refs** (`receiver_type: Some(_)`, e.g. `x.foo()`, `viewModel.state`) — the harder,
+  receiver-typed path, where resolver quality actually shows up.
+- **Bare refs** (`receiver_type: None`, e.g. local vars, top-level unqualified calls) — expected
+  to sit near 100%; reported as a sanity baseline, not filtered out as noise.
+
+## Classification algorithm
+
+Uses `classify_cursor` + `resolve_identity` directly — **not** `find_definition`'s full pipeline.
+`find_definition` has an `rg`-grep text-search fallback and several contextual special cases
+beyond what `resolve_identity` covers; going through it would let a lucky grep match mask a real
+resolver regression, making the benchmark insensitive to exactly the class of bug it exists to
+catch. This is a deliberate floor, not the full user-facing success rate — documented in the
+tool's own output header.
+
+For each `Reference`, four possible outcomes:
+
+- **Member ref**: run the receiver-typed lookup (`find_definition_qualified(name,
+  Some(receiver_type), uri)`), then the same shape filter `resolve_identity` already applies when
+  a call shape is present.
+  - Filtered result non-empty → **Success/CstResolved**.
+  - Filtered result empty → probe the untyped lookup (`find_definition_qualified(name, None,
+    uri)`):
+    - Probe non-empty → **FilteredCandidate**. Ambiguous by design: could be a correct
+      self-shadow-style suppression (the exact scenario last session's fixes address) or a
+      genuine miss. Reported as its own bucket, not folded into a plain failure count.
+    - Probe empty too → **Gap**. No candidate anywhere by that name — the actionable bucket.
+- **Bare ref**: `resolve_identity`'s own result for a bare reference *is* the untyped lookup
+  already (no receiver to filter by), so there is no separate probe:
+  - Non-empty → **Success/NameScan**.
+  - Empty → **Gap** directly.
+
+`CstResolved` and `NameScan` successes are reported as separate tiers, not blended into one
+"success" number — `CstResolved` is precise/receiver-verified; `NameScan` (only reachable for bare
+refs here, since a member ref's `resolve_identity` arm never returns non-empty under the
+`NameScan` label) is "found by name, possibly one of several same-named workspace symbols." Headline
+recall is `CstResolved / total-member-refs` for the member lane.
+
+## New infrastructure
+
+One new piece of infrastructure: an identifier walker that finds every
+`simple_identifier`/`type_identifier` position in a file's CST. Nothing currently does this
+generically — `classify_symbol_at` operates on one cursor position at a time;
+`missing_import_diagnostics.rs`'s walk (`collect_candidates`) is a narrower, bespoke pass (skips
+import/package subtrees, tracks in-scope type params) not meant for general reuse.
+
+Bounded recursion using the existing convention (`crate::util::MAX_CST_DESCENT_DEPTH` +
+`crate::util::report_cst_depth_exceeded!`), matching `collect_candidates`'s own depth guard — the
+prior stack-overflow-hardening pass (PRs #257–#259) bounded every hand-rolled recursive CST
+descent in this codebase; this walker follows the same pattern from the start rather than needing
+a later retrofit.
+
+## Files
+
+- `src/features/unresolved_symbol_diagnostics.rs` (new) — the identifier walker plus
+  `collect_resolution_outcomes(indexer, uri, doc) -> Vec<ReferenceOutcome>`, the shared detection
+  function. Named and positioned like its `missing_import_diagnostics`/`unused_import_diagnostics`
+  siblings specifically so a later live diagnostic can reuse it without restructuring.
+- `src/cli/resolution_accuracy_poc.rs` (new) — same skeleton as `missing_import_poc.rs`: build the
+  index, warm the JAR/compiled-library index (member-ref recall depends on library-typed receivers
+  resolving), walk every workspace `.kt`/`.java` file, aggregate.
+- `src/cli/args.rs` — new `resolution-accuracy [root]` subcommand, following the existing
+  `missing-imports`/`unused-imports` subcommand pattern (positional optional root, `--json` via the
+  existing global flag).
+
+## Output
+
+Mirrors the existing POCs' "top flagged names" style:
+
+- Files scanned, total references (member / bare split).
+- Member-ref recall % (`CstResolved / total-member`), bare-ref recall % (`Success /
+  total-bare`).
+- `FilteredCandidate` count and top-N names by frequency (with one sample location each) —
+  the bucket to eyeball for self-shadow-style suppressions.
+- `Gap` count and top-N names by frequency (with one sample location each) — the actionable bucket.
+
+## Testing
+
+Unit tests for the classifier (mirroring `missing_import_diagnostics_tests.rs`'s structure) with
+synthetic indexer setups:
+- A JAR-backed target resolves → `Success/CstResolved`.
+- A same-file, shape-mismatched self-declaration (the `triggers.collect { trigger -> }` shape
+  from this session's fixes) → `FilteredCandidate`, not `Gap` and not counted as a plain miss.
+- A genuinely undeclared name → `Gap`.
+- A bare local-variable reference → `Success/NameScan`.
+
+Identifier walker: a depth-bound test matching the existing `*_survives_a_pathologically_deep_*`
+convention (`collect_candidates`'s own sibling tests), confirming a pathologically nested input
+returns partial results rather than overflowing the stack.
+
+## Risks / deferred
+
+- `FilteredCandidate` is inherently ambiguous — this design deliberately does not try to further
+  auto-classify it (e.g. distinguishing "shape-filtered" from "receiver-type mismatch"). Reported
+  as one bucket for a human to spot-check; a finer split is a possible follow-up if the bucket
+  proves too large to eyeball on a real corpus.
+- Live-diagnostic wiring (an actual editor-visible "unresolved reference" squiggle) is explicitly
+  out of scope for this pass — CLI benchmark only, per the user's stated sequencing ("cli first,
+  then expand into lsp"). The shared function is positioned for that reuse, not implementing it.
+- No compiler ground truth: a reference this tool calls a `Gap` may be genuinely unresolvable by
+  design (external SDK symbol outside indexed JARs, generated code, DSL magic) — same caveat the
+  precision POCs' "systematic FP source" framing already carries in the opposite direction.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -76,6 +76,10 @@ pub(crate) enum Subcommand {
     UnusedImports {
         root: Option<PathBuf>,
     },
+    /// POC: report resolution-accuracy recall + cache-candidate signals across the workspace.
+    ResolutionAccuracy {
+        root: Option<PathBuf>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -322,6 +326,9 @@ fn build_subcommand(subcommand: &str, parsed: ParsedCliFlags) -> Result<Subcomma
         "unused-imports" => Ok(Subcommand::UnusedImports {
             root: positionals.first().map(PathBuf::from),
         }),
+        "resolution-accuracy" => Ok(Subcommand::ResolutionAccuracy {
+            root: positionals.first().map(PathBuf::from),
+        }),
         _ => unreachable!(),
     }
 }
@@ -453,6 +460,7 @@ fn is_subcommand(value: &str) -> bool {
             | "check"
             | "missing-imports"
             | "unused-imports"
+            | "resolution-accuracy"
     )
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod extract_sources;
 mod hover;
 mod missing_import_poc;
 mod output;
+mod resolution_accuracy_poc;
 mod run;
 mod sources;
 mod tokens;

--- a/src/cli/resolution_accuracy_poc.rs
+++ b/src/cli/resolution_accuracy_poc.rs
@@ -29,8 +29,10 @@ use crate::indexer::live_tree::{lang_for_path, parse_live};
 use crate::indexer::Indexer;
 
 /// Feed one already-indexed workspace file's reference outcomes into
-/// `aggregator`. Returns whether the file's tree had a parse error — the
-/// visible proxy for "this file's identifiers may have gone through
+/// `aggregator`. Returns `None` if the file was skipped (unsupported
+/// language or unparsable), or `Some(has_parse_error)` if it was scanned —
+/// callers must not count a skipped file as scanned. `has_parse_error` is
+/// the visible proxy for "this file's identifiers may have gone through
 /// `classify_symbol_at`'s expensive speculative brace-repair path"
 /// (`lambda_doc_at` re-parses the whole file, up to `MAX_BRACE_REPAIRS`
 /// times, whenever the tree has an error and no enclosing lambda is found).
@@ -40,13 +42,9 @@ fn scan_file(
     source: &str,
     file_label: &str,
     aggregator: &mut ResolutionAccuracyAggregator,
-) -> bool {
-    let Some(lang) = lang_for_path(uri.path()) else {
-        return false;
-    };
-    let Some(doc) = parse_live(source, lang) else {
-        return false;
-    };
+) -> Option<bool> {
+    let lang = lang_for_path(uri.path())?;
+    let doc = parse_live(source, lang)?;
     let has_parse_error = doc.tree.root_node().has_error();
     indexer.store_live_tree(uri, source);
     let outcomes = collect_resolution_outcomes(indexer, uri, &doc);
@@ -54,7 +52,7 @@ fn scan_file(
     for outcome in &outcomes {
         aggregator.add(file_label, outcome);
     }
-    has_parse_error
+    Some(has_parse_error)
 }
 
 /// Run the benchmark over every indexed workspace `.kt`/`.java` file under
@@ -75,9 +73,9 @@ pub(crate) async fn run_resolution_accuracy(root: &Path) {
     let gradle_paths = crate::indexer::jar::scan_gradle_jars(None);
     if !gradle_paths.is_empty() {
         let mut sidecar = index.jar_sidecar.lock().unwrap_or_else(|e| e.into_inner());
-        let n = crate::indexer::jar::index_jars(&index, &gradle_paths, &mut sidecar);
+        let jar_symbol_count = crate::indexer::jar::index_jars(&index, &gradle_paths, &mut sidecar);
         eprintln!(
-            "Indexed {n} compiled-jar symbols from {} gradle jars",
+            "Indexed {jar_symbol_count} compiled-jar symbols from {} gradle jars",
             gradle_paths.len()
         );
     } else {
@@ -97,8 +95,8 @@ pub(crate) async fn run_resolution_accuracy(root: &Path) {
     let mut total_files = 0usize;
     let mut files_with_parse_errors = 0usize;
     let total_uris = uris.len();
-    for (i, uri_str) in uris.iter().enumerate() {
-        let Ok(uri) = Url::parse(uri_str) else {
+    for (uri_index, uri_string) in uris.iter().enumerate() {
+        let Ok(uri) = Url::parse(uri_string) else {
             continue;
         };
         let Ok(path) = uri.to_file_path() else {
@@ -107,8 +105,7 @@ pub(crate) async fn run_resolution_accuracy(root: &Path) {
         let Ok(source) = std::fs::read_to_string(&path) else {
             continue;
         };
-        total_files += 1;
-        let rel = path
+        let relative_path = path
             .strip_prefix(root)
             .unwrap_or(&path)
             .display()
@@ -116,9 +113,14 @@ pub(crate) async fn run_resolution_accuracy(root: &Path) {
         // A real corpus can take a while — print progress so a long run
         // doesn't look silent/hung (matches `missing_import_poc`'s
         // streaming-output convention).
-        eprintln!("[{}/{total_uris}] {rel}", i + 1);
-        if scan_file(&index, &uri, &source, &rel, &mut aggregator) {
-            files_with_parse_errors += 1;
+        eprintln!("[{}/{total_uris}] {relative_path}", uri_index + 1);
+        if let Some(has_parse_error) =
+            scan_file(&index, &uri, &source, &relative_path, &mut aggregator)
+        {
+            total_files += 1;
+            if has_parse_error {
+                files_with_parse_errors += 1;
+            }
         }
     }
 

--- a/src/cli/resolution_accuracy_poc.rs
+++ b/src/cli/resolution_accuracy_poc.rs
@@ -1,0 +1,160 @@
+//! POC: resolution-accuracy recall benchmark over a workspace.
+//!
+//! Runs [`collect_resolution_outcomes`] (shared with a future live
+//! diagnostic — see `features::unresolved_symbol_diagnostics`) over every
+//! indexed workspace file and prints an aggregate recall summary plus a
+//! repeat-resolution/cache-candidate report.
+//!
+//! Unlike the missing-imports/unused-imports precision POCs (run against a
+//! project you know compiles, so every flag is a false positive), there is
+//! no compiler ground truth for recall — treat this as a trend metric:
+//! compare the same corpus before/after a resolver change, not an absolute
+//! score. `Gap` names are the actionable bucket; `FilteredCandidate` is
+//! ambiguous by design (see `ResolutionOutcome`'s doc) and needs
+//! spot-checking, not blind trust.
+
+use std::path::Path;
+
+use tower_lsp::lsp_types::Url;
+
+use crate::features::unresolved_symbol_diagnostics::{
+    collect_resolution_outcomes, ResolutionAccuracyAggregator,
+};
+use crate::indexer::live_tree::{lang_for_path, parse_live};
+use crate::indexer::Indexer;
+
+/// Feed one already-indexed workspace file's reference outcomes into `aggregator`.
+fn scan_file(
+    indexer: &Indexer,
+    uri: &Url,
+    source: &str,
+    file_label: &str,
+    aggregator: &mut ResolutionAccuracyAggregator,
+) {
+    let Some(lang) = lang_for_path(uri.path()) else {
+        return;
+    };
+    let Some(doc) = parse_live(source, lang) else {
+        return;
+    };
+    indexer.store_live_tree(uri, source);
+    let outcomes = collect_resolution_outcomes(indexer, uri, &doc);
+    indexer.remove_live_tree(uri);
+    for outcome in &outcomes {
+        aggregator.add(file_label, outcome);
+    }
+}
+
+/// Run the benchmark over every indexed workspace `.kt`/`.java` file under
+/// `root` and print an aggregate recall + cache-candidate summary.
+pub(crate) async fn run_resolution_accuracy(root: &Path) {
+    eprintln!("Indexing {}...", root.display());
+    let index = super::run::build_index(root, true).await;
+    eprintln!(
+        "Indexed: {} files, {} symbols",
+        index.files.len(),
+        index.definitions.len()
+    );
+
+    // Member-ref recall depends on library-typed receivers resolving —
+    // without warming the compiled-JAR index, every library type looks
+    // unresolvable and member recall would be an artifact of missing setup,
+    // not resolver quality. Same requirement `missing_import_poc` documents.
+    let gradle_paths = crate::indexer::jar::scan_gradle_jars(None);
+    if !gradle_paths.is_empty() {
+        let mut sidecar = index.jar_sidecar.lock().unwrap_or_else(|e| e.into_inner());
+        let n = crate::indexer::jar::index_jars(&index, &gradle_paths, &mut sidecar);
+        eprintln!(
+            "Indexed {n} compiled-jar symbols from {} gradle jars",
+            gradle_paths.len()
+        );
+    } else {
+        eprintln!("(no gradle jars found — library-typed receivers will look unresolved)");
+    }
+
+    let mut uris: Vec<String> = index
+        .files
+        .iter()
+        .map(|e| e.key().clone())
+        .filter(|u| u.starts_with("file://") && !index.library_uris.contains(u))
+        .filter(|u| u.ends_with(".kt") || u.ends_with(".java"))
+        .collect();
+    uris.sort();
+
+    let mut aggregator = ResolutionAccuracyAggregator::default();
+    let mut total_files = 0usize;
+    for uri_str in &uris {
+        let Ok(uri) = Url::parse(uri_str) else {
+            continue;
+        };
+        let Ok(path) = uri.to_file_path() else {
+            continue;
+        };
+        let Ok(source) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        total_files += 1;
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .display()
+            .to_string();
+        scan_file(&index, &uri, &source, &rel, &mut aggregator);
+    }
+
+    print_report(total_files, &aggregator);
+}
+
+fn print_report(total_files: usize, aggregator: &ResolutionAccuracyAggregator) {
+    let recall = aggregator.recall();
+    eprintln!("\n──────── resolution-accuracy summary ────────");
+    eprintln!("files scanned          : {total_files}");
+    eprintln!(
+        "member refs             : {} ({} CstResolved, {:.1}% recall)",
+        recall.member_total,
+        recall.member_cst_resolved,
+        recall.member_recall_pct()
+    );
+    eprintln!(
+        "bare refs               : {} ({} resolved, {:.1}% recall)",
+        recall.bare_total,
+        recall.bare_success,
+        recall.bare_recall_pct()
+    );
+
+    eprintln!("\ntop Gap names (actionable — no candidate found anywhere):");
+    for (name, sample) in aggregator.top_gaps(20) {
+        eprintln!(
+            "  {:>4}  {name:<32} e.g. {}",
+            sample.count, sample.sample_location
+        );
+    }
+
+    eprintln!("\ntop FilteredCandidate names (ambiguous — spot-check, not a plain miss):");
+    for (name, sample) in aggregator.top_filtered_candidates(20) {
+        eprintln!(
+            "  {:>4}  {name:<32} e.g. {}",
+            sample.count, sample.sample_location
+        );
+    }
+
+    eprintln!("\ntop cache candidates (same symbol resolved to the same place, repeatedly):");
+    for candidate in aggregator.cache_candidates(20) {
+        let receiver = candidate.receiver_type.as_deref().unwrap_or("<bare>");
+        eprintln!(
+            "  {:>4}  {receiver}.{:<24} -> {}",
+            candidate.count, candidate.name, candidate.location
+        );
+    }
+
+    eprintln!(
+        "\nhigh-frequency but unstable (not a simple cache key — same name, different targets):"
+    );
+    for hot in aggregator.unstable_hot_keys(10) {
+        let receiver = hot.receiver_type.as_deref().unwrap_or("<bare>");
+        eprintln!(
+            "  {:>4}  {receiver}.{:<24} -> {} distinct locations",
+            hot.count, hot.name, hot.distinct_locations
+        );
+    }
+}

--- a/src/cli/resolution_accuracy_poc.rs
+++ b/src/cli/resolution_accuracy_poc.rs
@@ -9,9 +9,14 @@
 //! project you know compiles, so every flag is a false positive), there is
 //! no compiler ground truth for recall — treat this as a trend metric:
 //! compare the same corpus before/after a resolver change, not an absolute
-//! score. `Gap` names are the actionable bucket; `FilteredCandidate` is
-//! ambiguous by design (see `ResolutionOutcome`'s doc) and needs
-//! spot-checking, not blind trust.
+//! score. This also only exercises `classify_cursor`+`resolve_identity`, not
+//! the full goto-definition pipeline (no rg-grep fallback, no local-scope/
+//! parameter/lambda-param resolution) — so its numbers are a conservative
+//! floor, not what a user would see from goto-definition. Member-ref `Gap`
+//! names are the actionable bucket; bare-ref `Gap`s are mostly expected
+//! noise (locals/params this benchmark's resolver can't see, by design);
+//! `FilteredCandidate` is ambiguous by design (see `ResolutionOutcome`'s
+//! doc) and needs spot-checking, not blind trust.
 
 use std::path::Path;
 
@@ -23,26 +28,33 @@ use crate::features::unresolved_symbol_diagnostics::{
 use crate::indexer::live_tree::{lang_for_path, parse_live};
 use crate::indexer::Indexer;
 
-/// Feed one already-indexed workspace file's reference outcomes into `aggregator`.
+/// Feed one already-indexed workspace file's reference outcomes into
+/// `aggregator`. Returns whether the file's tree had a parse error — the
+/// visible proxy for "this file's identifiers may have gone through
+/// `classify_symbol_at`'s expensive speculative brace-repair path"
+/// (`lambda_doc_at` re-parses the whole file, up to `MAX_BRACE_REPAIRS`
+/// times, whenever the tree has an error and no enclosing lambda is found).
 fn scan_file(
     indexer: &Indexer,
     uri: &Url,
     source: &str,
     file_label: &str,
     aggregator: &mut ResolutionAccuracyAggregator,
-) {
+) -> bool {
     let Some(lang) = lang_for_path(uri.path()) else {
-        return;
+        return false;
     };
     let Some(doc) = parse_live(source, lang) else {
-        return;
+        return false;
     };
+    let has_parse_error = doc.tree.root_node().has_error();
     indexer.store_live_tree(uri, source);
     let outcomes = collect_resolution_outcomes(indexer, uri, &doc);
     indexer.remove_live_tree(uri);
     for outcome in &outcomes {
         aggregator.add(file_label, outcome);
     }
+    has_parse_error
 }
 
 /// Run the benchmark over every indexed workspace `.kt`/`.java` file under
@@ -83,7 +95,9 @@ pub(crate) async fn run_resolution_accuracy(root: &Path) {
 
     let mut aggregator = ResolutionAccuracyAggregator::default();
     let mut total_files = 0usize;
-    for uri_str in &uris {
+    let mut files_with_parse_errors = 0usize;
+    let total_uris = uris.len();
+    for (i, uri_str) in uris.iter().enumerate() {
         let Ok(uri) = Url::parse(uri_str) else {
             continue;
         };
@@ -99,16 +113,36 @@ pub(crate) async fn run_resolution_accuracy(root: &Path) {
             .unwrap_or(&path)
             .display()
             .to_string();
-        scan_file(&index, &uri, &source, &rel, &mut aggregator);
+        // A real corpus can take a while — print progress so a long run
+        // doesn't look silent/hung (matches `missing_import_poc`'s
+        // streaming-output convention).
+        eprintln!("[{}/{total_uris}] {rel}", i + 1);
+        if scan_file(&index, &uri, &source, &rel, &mut aggregator) {
+            files_with_parse_errors += 1;
+        }
     }
 
-    print_report(total_files, &aggregator);
+    print_report(total_files, files_with_parse_errors, &aggregator);
 }
 
-fn print_report(total_files: usize, aggregator: &ResolutionAccuracyAggregator) {
+fn print_report(
+    total_files: usize,
+    files_with_parse_errors: usize,
+    aggregator: &ResolutionAccuracyAggregator,
+) {
     let recall = aggregator.recall();
     eprintln!("\n──────── resolution-accuracy summary ────────");
-    eprintln!("files scanned          : {total_files}");
+    eprintln!(
+        "NOTE: this measures classify_cursor+resolve_identity only — not the full\n\
+         goto-definition pipeline (no rg-grep fallback, no local-scope/parameter/\n\
+         lambda-param resolution). Real user-facing resolution is higher than these\n\
+         numbers. Treat this as a floor / trend metric: compare runs on the same\n\
+         corpus over time, don't read the percentage as an absolute accuracy score."
+    );
+    eprintln!("files scanned           : {total_files}");
+    eprintln!(
+        "files with parse errors : {files_with_parse_errors} (identifiers in these may have hit the speculative brace-repair path)"
+    );
     eprintln!(
         "member refs             : {} ({} CstResolved, {:.1}% recall)",
         recall.member_total,
@@ -121,9 +155,27 @@ fn print_report(total_files: usize, aggregator: &ResolutionAccuracyAggregator) {
         recall.bare_success,
         recall.bare_recall_pct()
     );
+    eprintln!(
+        "FilteredCandidate total : {} (ambiguous — spot-check, not a plain miss)",
+        recall.filtered_candidate_total
+    );
+    eprintln!(
+        "Gap total               : {} member (actionable) + {} bare (expected — mostly locals/params)",
+        recall.member_gap_total, recall.bare_gap_total
+    );
 
-    eprintln!("\ntop Gap names (actionable — no candidate found anywhere):");
-    for (name, sample) in aggregator.top_gaps(20) {
+    eprintln!("\ntop member-ref Gap names (actionable — no candidate found anywhere):");
+    for (name, sample) in aggregator.top_member_gaps(20) {
+        eprintln!(
+            "  {:>4}  {name:<32} e.g. {}",
+            sample.count, sample.sample_location
+        );
+    }
+
+    eprintln!(
+        "\ntop bare-ref Gap names (mostly locals/params outside this benchmark's resolution surface — not actionable):"
+    );
+    for (name, sample) in aggregator.top_bare_gaps(20) {
         eprintln!(
             "  {:>4}  {name:<32} e.g. {}",
             sample.count, sample.sample_location

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -444,6 +444,10 @@ pub(crate) async fn run(args: CliArgs) {
             let root = resolve_root(root.as_deref().or(args.root.as_deref()));
             super::unused_import_poc::run_unused_imports(&root).await;
         }
+        Subcommand::ResolutionAccuracy { root } => {
+            let root = resolve_root(root.as_deref().or(args.root.as_deref()));
+            super::resolution_accuracy_poc::run_resolution_accuracy(&root).await;
+        }
     }
 }
 

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -34,5 +34,6 @@ pub(crate) mod symbols;
 pub(crate) mod text_utils;
 pub(crate) mod traits;
 mod traits_impl;
+pub(crate) mod unresolved_symbol_diagnostics;
 pub(crate) mod unused_import_diagnostics;
 pub(crate) mod workspace_symbols;

--- a/src/features/unresolved_symbol_diagnostics.rs
+++ b/src/features/unresolved_symbol_diagnostics.rs
@@ -1,0 +1,168 @@
+//! Resolution-accuracy benchmark: classify and resolve every `Reference`
+//! identifier in a file, bucketing the result into `Success` /
+//! `FilteredCandidate` / `Gap`.
+//!
+//! Shared with the `resolution-accuracy` CLI subcommand
+//! (`cli::resolution_accuracy_poc`), which runs this over an entire
+//! workspace to measure recall — see that module for the aggregate
+//! methodology. Not wired into a live diagnostic yet; named and positioned
+//! like its `missing_import_diagnostics`/`unused_import_diagnostics`
+//! siblings so that reuse doesn't need restructuring later.
+
+// Temporary: this module's `pub(crate)` items have no consumer outside
+// `#[cfg(test)]` until Task 4 registers `cli::resolution_accuracy_poc` in
+// `cli/mod.rs`. The repo's pre-commit hook runs bare `cargo clippy -D
+// warnings` (no `--tests`), which doesn't compile `#[cfg(test)]` code, so
+// without this every commit before Task 4 fails on dead-code errors. Remove
+// this line in Task 4 once the CLI wiring makes the whole chain reachable
+// from a non-test entry point — `cargo clippy -- -D warnings` passing clean
+// afterward confirms every item here is genuinely used.
+#![cfg_attr(not(test), allow(dead_code))]
+
+use tower_lsp::lsp_types::{Location, Position, Url};
+use tree_sitter::Node;
+
+use crate::indexer::live_tree::LiveDoc;
+use crate::indexer::{
+    classify_cursor, resolve_identity, Indexer, NavigationSource, SymbolAtCursor, SymbolRole,
+};
+use crate::queries::{KIND_SIMPLE_IDENT, KIND_TYPE_IDENT};
+
+/// Which resolution path produced a `Success` outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SuccessTier {
+    /// Precise, receiver-verified — `resolve_identity`'s `CstResolved` path.
+    CstResolved,
+    /// Found by name only. Reachable here exclusively for bare references:
+    /// `resolve_identity`'s `Reference { receiver_type: Some(_), .. }` arm
+    /// only ever returns `CstResolved` for a non-empty result (see
+    /// `classify_reference` below), so a member reference never lands here.
+    NameScan,
+}
+
+/// The outcome of attempting to resolve one `Reference`-classified identifier.
+#[derive(Debug, Clone)]
+pub(crate) enum ResolutionOutcome {
+    Success {
+        tier: SuccessTier,
+        locations: Vec<Location>,
+    },
+    /// The receiver-typed lookup came back empty, but an untyped lookup by
+    /// the same name found *something* elsewhere in the workspace. Ambiguous
+    /// by design: could be a correct self-shadow-style suppression (the
+    /// arity-filtering this session's fixes rely on), or a genuine resolver
+    /// miss — reported separately, not scored as a plain failure.
+    FilteredCandidate,
+    /// No candidate found anywhere by this name — the actionable bucket.
+    Gap,
+}
+
+/// One classified-and-resolved reference.
+#[derive(Debug, Clone)]
+pub(crate) struct ReferenceOutcome {
+    pub name: String,
+    /// `Some` for a member reference (`x.foo()`); `None` for a bare
+    /// reference (local var, unqualified call). Matches
+    /// `SymbolRole::Reference::receiver_type`.
+    pub receiver_type: Option<String>,
+    pub line: u32,
+    pub col: u32,
+    pub outcome: ResolutionOutcome,
+}
+
+/// Find every `simple_identifier`/`type_identifier` node's start position in
+/// `root`, via depth-bounded recursion (see `crate::util::MAX_CST_DESCENT_DEPTH`)
+/// — a pathological input can nest far deeper than any real Kotlin/Java
+/// syntax, and an unbounded walk would overflow the stack rather than degrade.
+fn collect_identifier_positions(node: Node, out: &mut Vec<Position>, depth: usize) {
+    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+        crate::util::report_cst_depth_exceeded!("collect_identifier_positions", node);
+        return;
+    }
+    if matches!(node.kind(), KIND_SIMPLE_IDENT | KIND_TYPE_IDENT) {
+        let point = node.start_position();
+        // `column` is a byte offset (tree-sitter), used directly as an
+        // approximation of the UTF-16 offset `classify_cursor` expects —
+        // same simplification `missing_import_diagnostics.rs`'s own
+        // candidate collection already relies on.
+        out.push(Position::new(point.row as u32, point.column as u32));
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_identifier_positions(child, out, depth + 1);
+    }
+}
+
+/// Classify and resolve every `Reference`-role identifier in `doc`.
+///
+/// `Declaration` and `ImportSegment` roles are skipped — declarations
+/// resolve by construction, imports are the `missing-imports`/
+/// `unused-imports` benchmarks' own territory.
+///
+/// The caller is responsible for `uri` having a live tree stored
+/// (`indexer.store_live_tree`) before calling this — `classify_cursor`
+/// resolves through `indexer.live_doc_or_parse(uri)` internally, the same
+/// requirement `collect_missing_import_flags` documents.
+pub(crate) fn collect_resolution_outcomes(
+    indexer: &Indexer,
+    uri: &Url,
+    doc: &LiveDoc,
+) -> Vec<ReferenceOutcome> {
+    let mut positions = Vec::new();
+    collect_identifier_positions(doc.tree.root_node(), &mut positions, 0);
+
+    let mut outcomes = Vec::new();
+    for position in positions {
+        let Some(symbol) = classify_cursor(indexer, uri, position) else {
+            continue;
+        };
+        let receiver_type = match &symbol.role {
+            SymbolRole::Reference { receiver_type, .. } => receiver_type.clone(),
+            SymbolRole::Declaration { .. } | SymbolRole::ImportSegment => continue,
+        };
+        let name = symbol.name.clone();
+        let outcome = classify_reference(indexer, uri, &symbol, receiver_type.clone());
+        outcomes.push(ReferenceOutcome {
+            name,
+            receiver_type,
+            line: position.line,
+            col: position.character,
+            outcome,
+        });
+    }
+    outcomes
+}
+
+/// Resolve one `Reference`-role symbol to a `ResolutionOutcome`.
+fn classify_reference(
+    indexer: &Indexer,
+    uri: &Url,
+    symbol: &SymbolAtCursor,
+    receiver_type: Option<String>,
+) -> ResolutionOutcome {
+    let success = match resolve_identity(symbol, indexer, uri) {
+        NavigationSource::CstResolved(defs) if !defs.is_empty() => {
+            Some((SuccessTier::CstResolved, defs.0))
+        }
+        NavigationSource::NameScan(defs) if !defs.is_empty() => {
+            Some((SuccessTier::NameScan, defs.0))
+        }
+        _ => None,
+    };
+    match success {
+        Some((tier, locations)) => ResolutionOutcome::Success { tier, locations },
+        None if receiver_type.is_some() => {
+            let probe = indexer.find_definition_qualified(&symbol.name, None, uri);
+            if probe.is_empty() {
+                ResolutionOutcome::Gap
+            } else {
+                ResolutionOutcome::FilteredCandidate
+            }
+        }
+        None => ResolutionOutcome::Gap,
+    }
+}
+
+#[cfg(test)]
+#[path = "unresolved_symbol_diagnostics_tests.rs"]
+mod tests;

--- a/src/features/unresolved_symbol_diagnostics.rs
+++ b/src/features/unresolved_symbol_diagnostics.rs
@@ -18,7 +18,7 @@ use crate::indexer::live_tree::LiveDoc;
 use crate::indexer::{
     classify_cursor, resolve_identity, Indexer, NavigationSource, SymbolAtCursor, SymbolRole,
 };
-use crate::queries::{KIND_SIMPLE_IDENT, KIND_TYPE_IDENT};
+use crate::queries::{KIND_IMPORT_HEADER, KIND_PACKAGE_HEADER, KIND_SIMPLE_IDENT, KIND_TYPE_IDENT};
 
 /// Which resolution path produced a `Success` outcome.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,6 +69,15 @@ pub(crate) struct ReferenceOutcome {
 fn collect_identifier_positions(node: Node, out: &mut Vec<Position>, depth: usize) {
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
         crate::util::report_cst_depth_exceeded!("collect_identifier_positions", node);
+        return;
+    }
+    // Don't descend into import/package declarations — their segments aren't
+    // `Reference`-role identifiers (`classify_cursor` tags them
+    // `ImportSegment`/skips them), so walking in only produces bare-name
+    // lookups against `com`/`example`-style path segments that can never
+    // resolve — spurious `Gap`s that crowd out genuinely actionable names.
+    // Mirrors `missing_import_diagnostics.rs`'s own `collect_candidates` walk.
+    if matches!(node.kind(), KIND_IMPORT_HEADER | KIND_PACKAGE_HEADER) {
         return;
     }
     if matches!(node.kind(), KIND_SIMPLE_IDENT | KIND_TYPE_IDENT) {
@@ -170,6 +179,16 @@ pub(crate) struct RecallSummary {
     pub member_cst_resolved: usize,
     pub bare_total: usize,
     pub bare_success: usize,
+    /// Member refs whose receiver-typed lookup came back empty but an
+    /// untyped lookup found something elsewhere (`ResolutionOutcome::FilteredCandidate`
+    /// — only ever constructed for member refs, see `classify_reference`).
+    pub filtered_candidate_total: usize,
+    /// Member refs with no candidate found anywhere — the actionable Gap bucket.
+    pub member_gap_total: usize,
+    /// Bare refs with no candidate found anywhere — expected/mostly-noise,
+    /// since this benchmark's `resolve_identity` path has no local-scope,
+    /// parameter, or lambda-param awareness (see module doc).
+    pub bare_gap_total: usize,
 }
 
 impl RecallSummary {
@@ -200,6 +219,9 @@ pub(crate) struct CacheCandidate {
     pub name: String,
     pub receiver_type: Option<String>,
     pub count: usize,
+    /// The resolved target's location (`location_key` of the singleton
+    /// entry in `group.locations`) — where this symbol resolves *to*, not
+    /// where it was first referenced.
     pub location: String,
 }
 
@@ -217,7 +239,6 @@ pub(crate) struct UnstableHotKey {
 struct CacheGroupState {
     count: usize,
     locations: HashSet<String>,
-    sample_location: String,
 }
 
 /// `Location`'s own `uri`/`range` fields, flattened to a string key —
@@ -242,7 +263,16 @@ fn location_key(location: &Location) -> String {
 pub(crate) struct ResolutionAccuracyAggregator {
     recall: RecallSummary,
     filtered_candidate: BTreeMap<String, NamedSample>,
-    gap: BTreeMap<String, NamedSample>,
+    /// `Gap`s for member references (`x.foo()`) — the actionable bucket:
+    /// these should have resolved via a typed lookup and didn't.
+    member_gap: BTreeMap<String, NamedSample>,
+    /// `Gap`s for bare references (locals/params/unqualified calls) — mostly
+    /// expected noise, since `resolve_identity`'s bare-reference arm has no
+    /// local-scope/parameter/lambda-param awareness (that lives in
+    /// `find_definition`'s async pipeline, which this benchmark deliberately
+    /// doesn't use). Kept separate so it doesn't crowd out `member_gap`'s
+    /// genuinely actionable names.
+    bare_gap: BTreeMap<String, NamedSample>,
     cache: HashMap<(String, Option<String>), CacheGroupState>,
 }
 
@@ -268,7 +298,6 @@ impl ResolutionAccuracyAggregator {
                 let group = self.cache.entry(key).or_insert_with(|| CacheGroupState {
                     count: 0,
                     locations: HashSet::new(),
-                    sample_location: sample_location.clone(),
                 });
                 group.count += 1;
                 for location in locations {
@@ -276,7 +305,16 @@ impl ResolutionAccuracyAggregator {
                 }
             }
             ResolutionOutcome::FilteredCandidate => {
+                // Only ever constructed from `classify_reference`'s
+                // `receiver_type.is_some()` arm — a bare-reference
+                // `FilteredCandidate` would silently miscount into
+                // `member_total` below.
+                debug_assert!(
+                    outcome.receiver_type.is_some(),
+                    "FilteredCandidate outcome without a receiver_type: {outcome:?}"
+                );
                 self.recall.member_total += 1;
+                self.recall.filtered_candidate_total += 1;
                 let entry = self
                     .filtered_candidate
                     .entry(outcome.name.clone())
@@ -287,13 +325,16 @@ impl ResolutionAccuracyAggregator {
                 entry.count += 1;
             }
             ResolutionOutcome::Gap => {
-                if is_member {
+                let map = if is_member {
                     self.recall.member_total += 1;
+                    self.recall.member_gap_total += 1;
+                    &mut self.member_gap
                 } else {
                     self.recall.bare_total += 1;
-                }
-                let entry = self
-                    .gap
+                    self.recall.bare_gap_total += 1;
+                    &mut self.bare_gap
+                };
+                let entry = map
                     .entry(outcome.name.clone())
                     .or_insert_with(|| NamedSample {
                         count: 0,
@@ -313,9 +354,16 @@ impl ResolutionAccuracyAggregator {
         top_n(&self.filtered_candidate, n)
     }
 
-    /// Top `n` `Gap` names by occurrence count, ties broken by name.
-    pub(crate) fn top_gaps(&self, n: usize) -> Vec<(String, NamedSample)> {
-        top_n(&self.gap, n)
+    /// Top `n` member-reference `Gap` names by occurrence count, ties broken
+    /// by name — the actionable bucket (see `member_gap`'s doc).
+    pub(crate) fn top_member_gaps(&self, n: usize) -> Vec<(String, NamedSample)> {
+        top_n(&self.member_gap, n)
+    }
+
+    /// Top `n` bare-reference `Gap` names by occurrence count, ties broken
+    /// by name — mostly expected noise (see `bare_gap`'s doc).
+    pub(crate) fn top_bare_gaps(&self, n: usize) -> Vec<(String, NamedSample)> {
+        top_n(&self.bare_gap, n)
     }
 
     /// Top `n` cache candidates (singleton resolved location) by occurrence count.
@@ -328,7 +376,11 @@ impl ResolutionAccuracyAggregator {
                 name: name.clone(),
                 receiver_type: receiver_type.clone(),
                 count: group.count,
-                location: group.sample_location.clone(),
+                // `group.locations` is a singleton exactly when this
+                // candidate qualifies (the `filter` above) — that one entry
+                // is the actual resolved target, unlike the reference-site
+                // `sample_location` this used to (incorrectly) report.
+                location: group.locations.iter().next().cloned().unwrap_or_default(),
             })
             .collect();
         candidates.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.name.cmp(&b.name)));

--- a/src/features/unresolved_symbol_diagnostics.rs
+++ b/src/features/unresolved_symbol_diagnostics.rs
@@ -19,6 +19,8 @@
 // afterward confirms every item here is genuinely used.
 #![cfg_attr(not(test), allow(dead_code))]
 
+use std::collections::{BTreeMap, HashMap, HashSet};
+
 use tower_lsp::lsp_types::{Location, Position, Url};
 use tree_sitter::Node;
 
@@ -161,6 +163,214 @@ fn classify_reference(
         }
         None => ResolutionOutcome::Gap,
     }
+}
+
+/// One name's occurrence count plus a representative location, for the
+/// `FilteredCandidate`/`Gap` top-N reports.
+#[derive(Debug, Clone)]
+pub(crate) struct NamedSample {
+    pub count: usize,
+    pub sample_location: String,
+}
+
+/// Aggregate recall counts across a workspace scan.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct RecallSummary {
+    pub member_total: usize,
+    pub member_cst_resolved: usize,
+    pub bare_total: usize,
+    pub bare_success: usize,
+}
+
+impl RecallSummary {
+    /// `CstResolved / total` for member refs, as a percentage. `0.0` when
+    /// there were no member refs to score (an empty corpus, not a failure).
+    pub(crate) fn member_recall_pct(&self) -> f64 {
+        percent(self.member_cst_resolved, self.member_total)
+    }
+
+    /// `Success / total` for bare refs, as a percentage.
+    pub(crate) fn bare_recall_pct(&self) -> f64 {
+        percent(self.bare_success, self.bare_total)
+    }
+}
+
+fn percent(part: usize, total: usize) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        (part as f64 / total as f64) * 100.0
+    }
+}
+
+/// A `(name, receiver_type)` symbol resolved repeatedly to the exact same
+/// location — a candidate for a resolver-level memoization cache.
+#[derive(Debug, Clone)]
+pub(crate) struct CacheCandidate {
+    pub name: String,
+    pub receiver_type: Option<String>,
+    pub count: usize,
+    pub location: String,
+}
+
+/// A `(name, receiver_type)` symbol resolved often but to *different*
+/// locations across occurrences — not cacheable by this simple a key.
+#[derive(Debug, Clone)]
+pub(crate) struct UnstableHotKey {
+    pub name: String,
+    pub receiver_type: Option<String>,
+    pub count: usize,
+    pub distinct_locations: usize,
+}
+
+#[derive(Debug, Default)]
+struct CacheGroupState {
+    count: usize,
+    locations: HashSet<String>,
+    sample_location: String,
+}
+
+/// `Location`'s own `uri`/`range` fields, flattened to a string key —
+/// `Location` implements `Eq`/`PartialEq` but not `Hash`, so it can't sit in
+/// a `HashSet` directly.
+fn location_key(location: &Location) -> String {
+    format!(
+        "{}#{}:{}-{}:{}",
+        location.uri,
+        location.range.start.line,
+        location.range.start.character,
+        location.range.end.line,
+        location.range.end.character
+    )
+}
+
+/// Accumulates `ReferenceOutcome`s across a workspace scan, one file at a
+/// time, into a recall summary and a repeat-resolution/cache-candidate
+/// report — avoids holding every reference from a large corpus in memory
+/// simultaneously.
+#[derive(Debug, Default)]
+pub(crate) struct ResolutionAccuracyAggregator {
+    recall: RecallSummary,
+    filtered_candidate: BTreeMap<String, NamedSample>,
+    gap: BTreeMap<String, NamedSample>,
+    cache: HashMap<(String, Option<String>), CacheGroupState>,
+}
+
+impl ResolutionAccuracyAggregator {
+    /// Record one reference's outcome. `file_label` is a display-friendly
+    /// path (workspace-relative, e.g. `"src/Foo.kt"`) used only for sample
+    /// locations in the reports below.
+    pub(crate) fn add(&mut self, file_label: &str, outcome: &ReferenceOutcome) {
+        let sample_location = format!("{file_label}:{}", outcome.line + 1);
+        let is_member = outcome.receiver_type.is_some();
+        match &outcome.outcome {
+            ResolutionOutcome::Success { tier, locations } => {
+                if is_member {
+                    self.recall.member_total += 1;
+                    if *tier == SuccessTier::CstResolved {
+                        self.recall.member_cst_resolved += 1;
+                    }
+                } else {
+                    self.recall.bare_total += 1;
+                    self.recall.bare_success += 1;
+                }
+                let key = (outcome.name.clone(), outcome.receiver_type.clone());
+                let group = self.cache.entry(key).or_insert_with(|| CacheGroupState {
+                    count: 0,
+                    locations: HashSet::new(),
+                    sample_location: sample_location.clone(),
+                });
+                group.count += 1;
+                for location in locations {
+                    group.locations.insert(location_key(location));
+                }
+            }
+            ResolutionOutcome::FilteredCandidate => {
+                self.recall.member_total += 1;
+                let entry = self
+                    .filtered_candidate
+                    .entry(outcome.name.clone())
+                    .or_insert_with(|| NamedSample {
+                        count: 0,
+                        sample_location: sample_location.clone(),
+                    });
+                entry.count += 1;
+            }
+            ResolutionOutcome::Gap => {
+                if is_member {
+                    self.recall.member_total += 1;
+                } else {
+                    self.recall.bare_total += 1;
+                }
+                let entry = self
+                    .gap
+                    .entry(outcome.name.clone())
+                    .or_insert_with(|| NamedSample {
+                        count: 0,
+                        sample_location: sample_location.clone(),
+                    });
+                entry.count += 1;
+            }
+        }
+    }
+
+    pub(crate) fn recall(&self) -> RecallSummary {
+        self.recall
+    }
+
+    /// Top `n` `FilteredCandidate` names by occurrence count, ties broken by name.
+    pub(crate) fn top_filtered_candidates(&self, n: usize) -> Vec<(String, NamedSample)> {
+        top_n(&self.filtered_candidate, n)
+    }
+
+    /// Top `n` `Gap` names by occurrence count, ties broken by name.
+    pub(crate) fn top_gaps(&self, n: usize) -> Vec<(String, NamedSample)> {
+        top_n(&self.gap, n)
+    }
+
+    /// Top `n` cache candidates (singleton resolved location) by occurrence count.
+    pub(crate) fn cache_candidates(&self, n: usize) -> Vec<CacheCandidate> {
+        let mut candidates: Vec<CacheCandidate> = self
+            .cache
+            .iter()
+            .filter(|(_, group)| group.locations.len() == 1)
+            .map(|((name, receiver_type), group)| CacheCandidate {
+                name: name.clone(),
+                receiver_type: receiver_type.clone(),
+                count: group.count,
+                location: group.sample_location.clone(),
+            })
+            .collect();
+        candidates.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.name.cmp(&b.name)));
+        candidates.truncate(n);
+        candidates
+    }
+
+    /// Top `n` high-frequency but location-unstable keys, by occurrence count.
+    pub(crate) fn unstable_hot_keys(&self, n: usize) -> Vec<UnstableHotKey> {
+        let mut hot: Vec<UnstableHotKey> = self
+            .cache
+            .iter()
+            .filter(|(_, group)| group.locations.len() > 1)
+            .map(|((name, receiver_type), group)| UnstableHotKey {
+                name: name.clone(),
+                receiver_type: receiver_type.clone(),
+                count: group.count,
+                distinct_locations: group.locations.len(),
+            })
+            .collect();
+        hot.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.name.cmp(&b.name)));
+        hot.truncate(n);
+        hot
+    }
+}
+
+fn top_n(map: &BTreeMap<String, NamedSample>, n: usize) -> Vec<(String, NamedSample)> {
+    let mut entries: Vec<(String, NamedSample)> =
+        map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+    entries.sort_by(|a, b| b.1.count.cmp(&a.1.count).then_with(|| a.0.cmp(&b.0)));
+    entries.truncate(n);
+    entries
 }
 
 #[cfg(test)]

--- a/src/features/unresolved_symbol_diagnostics.rs
+++ b/src/features/unresolved_symbol_diagnostics.rs
@@ -9,16 +9,6 @@
 //! like its `missing_import_diagnostics`/`unused_import_diagnostics`
 //! siblings so that reuse doesn't need restructuring later.
 
-// Temporary: this module's `pub(crate)` items have no consumer outside
-// `#[cfg(test)]` until Task 4 registers `cli::resolution_accuracy_poc` in
-// `cli/mod.rs`. The repo's pre-commit hook runs bare `cargo clippy -D
-// warnings` (no `--tests`), which doesn't compile `#[cfg(test)]` code, so
-// without this every commit before Task 4 fails on dead-code errors. Remove
-// this line in Task 4 once the CLI wiring makes the whole chain reachable
-// from a non-test entry point — `cargo clippy -- -D warnings` passing clean
-// afterward confirms every item here is genuinely used.
-#![cfg_attr(not(test), allow(dead_code))]
-
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use tower_lsp::lsp_types::{Location, Position, Url};
@@ -261,7 +251,7 @@ impl ResolutionAccuracyAggregator {
     /// path (workspace-relative, e.g. `"src/Foo.kt"`) used only for sample
     /// locations in the reports below.
     pub(crate) fn add(&mut self, file_label: &str, outcome: &ReferenceOutcome) {
-        let sample_location = format!("{file_label}:{}", outcome.line + 1);
+        let sample_location = format!("{file_label}:{}:{}", outcome.line + 1, outcome.col + 1);
         let is_member = outcome.receiver_type.is_some();
         match &outcome.outcome {
             ResolutionOutcome::Success { tier, locations } => {

--- a/src/features/unresolved_symbol_diagnostics_tests.rs
+++ b/src/features/unresolved_symbol_diagnostics_tests.rs
@@ -257,7 +257,7 @@ fn recall_summary_counts_member_and_bare_lanes_separately() {
     assert_eq!(gaps.len(), 1);
     assert_eq!(gaps[0].0, "missing");
     assert_eq!(gaps[0].1.count, 1);
-    assert_eq!(gaps[0].1.sample_location, "A.kt:2");
+    assert_eq!(gaps[0].1.sample_location, "A.kt:2:1");
 }
 
 #[test]

--- a/src/features/unresolved_symbol_diagnostics_tests.rs
+++ b/src/features/unresolved_symbol_diagnostics_tests.rs
@@ -20,7 +20,7 @@ fn member_call_on_jar_receiver_resolves_cst_resolved() {
     use crate::types::{FileData, SourceSet, SymbolEntry, Visibility};
     use std::sync::Arc;
 
-    let idx = Indexer::new();
+    let indexer = Indexer::new();
     let uri = Url::parse("file:///t/Flow.kt").unwrap();
     // Deliberately no same-file `collect` declaration here — that collision
     // scenario is `same_file_shape_mismatched_self_declaration_is_filtered_candidate_not_gap`'s
@@ -36,8 +36,8 @@ fn member_call_on_jar_receiver_resolves_cst_resolved() {
                fun useTriggers(triggers: Flow<String>) {\n\
                    triggers.collect { trigger -> println(trigger) }\n\
                }\n";
-    idx.index_content(&uri, src);
-    idx.store_live_tree(&uri, src);
+    indexer.index_content(&uri, src);
+    indexer.store_live_tree(&uri, src);
 
     let jar_uri_str = "jar:file:///fake-coroutines.jar!/Flow.kt".to_string();
     let jar_uri = Url::parse(&jar_uri_str).unwrap();
@@ -77,7 +77,7 @@ fn member_call_on_jar_receiver_resolves_cst_resolved() {
         trailing_lambda: false,
         deprecated: false,
     };
-    idx.jar_files.insert(
+    indexer.jar_files.insert(
         jar_uri_str.clone(),
         Arc::new(FileData {
             symbols: vec![flow_type, member],
@@ -87,7 +87,8 @@ fn member_call_on_jar_receiver_resolves_cst_resolved() {
             ..Default::default()
         }),
     );
-    idx.jar_definitions
+    indexer
+        .jar_definitions
         .entry("Flow".to_owned())
         .or_default()
         .push(tower_lsp::lsp_types::Location {
@@ -96,7 +97,7 @@ fn member_call_on_jar_receiver_resolves_cst_resolved() {
         });
 
     let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
-    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcomes = collect_resolution_outcomes(&indexer, &uri, &doc);
     let outcome = outcome_at(&outcomes, "collect", 3);
     match &outcome.outcome {
         ResolutionOutcome::Success { tier, locations } => {
@@ -110,7 +111,7 @@ fn member_call_on_jar_receiver_resolves_cst_resolved() {
 
 #[test]
 fn same_file_shape_mismatched_self_declaration_is_filtered_candidate_not_gap() {
-    let idx = Indexer::new();
+    let indexer = Indexer::new();
     let uri = Url::parse("file:///t/Flow.kt").unwrap();
     let src = "package com.example\n\
                class Flow<T>\n\
@@ -120,11 +121,11 @@ fn same_file_shape_mismatched_self_declaration_is_filtered_candidate_not_gap() {
                fun useTriggers(triggers: Flow<String>, scope: CoroutineScope) {\n\
                    triggers.collect { trigger -> println(trigger) }\n\
                }\n";
-    idx.index_content(&uri, src);
-    idx.store_live_tree(&uri, src);
+    indexer.index_content(&uri, src);
+    indexer.store_live_tree(&uri, src);
 
     let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
-    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcomes = collect_resolution_outcomes(&indexer, &uri, &doc);
     let outcome = outcome_at(&outcomes, "collect", 6);
     assert!(
         matches!(outcome.outcome, ResolutionOutcome::FilteredCandidate),
@@ -135,18 +136,18 @@ fn same_file_shape_mismatched_self_declaration_is_filtered_candidate_not_gap() {
 
 #[test]
 fn undeclared_member_reference_is_gap() {
-    let idx = Indexer::new();
+    let indexer = Indexer::new();
     let uri = Url::parse("file:///t/Foo.kt").unwrap();
     let src = "package com.example\n\
                class Foo\n\
                fun useFoo(foo: Foo) {\n\
                    foo.totallyUndeclaredMethod()\n\
                }\n";
-    idx.index_content(&uri, src);
-    idx.store_live_tree(&uri, src);
+    indexer.index_content(&uri, src);
+    indexer.store_live_tree(&uri, src);
 
     let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
-    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcomes = collect_resolution_outcomes(&indexer, &uri, &doc);
     let outcome = outcome_at(&outcomes, "totallyUndeclaredMethod", 3);
     assert!(
         matches!(outcome.outcome, ResolutionOutcome::Gap),
@@ -157,18 +158,18 @@ fn undeclared_member_reference_is_gap() {
 
 #[test]
 fn bare_call_to_top_level_function_resolves_name_scan_success() {
-    let idx = Indexer::new();
+    let indexer = Indexer::new();
     let uri = Url::parse("file:///t/Helper.kt").unwrap();
     let src = "package com.example\n\
                fun helper(): Int = 5\n\
                fun useHelper() {\n\
                    val result = helper()\n\
                }\n";
-    idx.index_content(&uri, src);
-    idx.store_live_tree(&uri, src);
+    indexer.index_content(&uri, src);
+    indexer.store_live_tree(&uri, src);
 
     let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
-    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcomes = collect_resolution_outcomes(&indexer, &uri, &doc);
     let outcome = outcome_at(&outcomes, "helper", 3);
     match &outcome.outcome {
         ResolutionOutcome::Success { tier, locations } => {
@@ -187,12 +188,12 @@ fn collect_resolution_outcomes_survives_a_pathologically_deep_expression() {
         src.push_str("+1");
     }
     src.push_str("\n}\n");
-    let idx = Indexer::new();
+    let indexer = Indexer::new();
     let uri = Url::parse("file:///t/Deep.kt").unwrap();
-    idx.index_content(&uri, &src);
-    idx.store_live_tree(&uri, &src);
+    indexer.index_content(&uri, &src);
+    indexer.store_live_tree(&uri, &src);
     let doc = crate::indexer::live_tree::parse_live(&src, tree_sitter_kotlin::language()).unwrap();
-    let _ = collect_resolution_outcomes(&idx, &uri, &doc);
+    let _ = collect_resolution_outcomes(&indexer, &uri, &doc);
 }
 
 fn test_location(line: u32) -> tower_lsp::lsp_types::Location {
@@ -379,7 +380,7 @@ fn filtered_candidate_outcome_appears_in_top_filtered_candidates() {
 
 #[test]
 fn package_header_segments_are_not_flagged_as_gaps() {
-    let idx = Indexer::new();
+    let indexer = Indexer::new();
     let uri = Url::parse("file:///t/Pkg.kt").unwrap();
     // `com`/`example` are package-header path segments, not references —
     // walking into `package_header` would classify them as bare references
@@ -389,11 +390,11 @@ fn package_header_segments_are_not_flagged_as_gaps() {
                fun useIt(list: List<Int>) {\n\
                    println(list)\n\
                }\n";
-    idx.index_content(&uri, src);
-    idx.store_live_tree(&uri, src);
+    indexer.index_content(&uri, src);
+    indexer.store_live_tree(&uri, src);
 
     let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
-    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcomes = collect_resolution_outcomes(&indexer, &uri, &doc);
     assert!(
         !outcomes
             .iter()

--- a/src/features/unresolved_symbol_diagnostics_tests.rs
+++ b/src/features/unresolved_symbol_diagnostics_tests.rs
@@ -253,11 +253,17 @@ fn recall_summary_counts_member_and_bare_lanes_separately() {
     assert_eq!(recall.bare_success, 1);
     assert_eq!(recall.bare_recall_pct(), 100.0);
 
-    let gaps = agg.top_gaps(10);
-    assert_eq!(gaps.len(), 1);
-    assert_eq!(gaps[0].0, "missing");
-    assert_eq!(gaps[0].1.count, 1);
-    assert_eq!(gaps[0].1.sample_location, "A.kt:2:1");
+    // The `missing` outcome above has `receiver_type: Some("Bar")`, i.e. a
+    // member-ref Gap — it must land in `top_member_gaps`, not `top_bare_gaps`.
+    let member_gaps = agg.top_member_gaps(10);
+    assert_eq!(member_gaps.len(), 1);
+    assert_eq!(member_gaps[0].0, "missing");
+    assert_eq!(member_gaps[0].1.count, 1);
+    assert_eq!(member_gaps[0].1.sample_location, "A.kt:2:1");
+    assert_eq!(recall.member_gap_total, 1);
+    assert_eq!(recall.bare_gap_total, 0);
+
+    assert!(agg.top_bare_gaps(10).is_empty());
 }
 
 #[test]
@@ -305,4 +311,93 @@ fn cache_candidate_grouping_separates_stable_from_unstable_keys() {
     assert_eq!(unstable[0].name, "shadowed");
     assert_eq!(unstable[0].count, 2);
     assert_eq!(unstable[0].distinct_locations, 2);
+}
+
+/// `CacheCandidate.location` must be the resolved target's location, not the
+/// reference site where the symbol was first seen — `sample_location`-style
+/// formatting (`"{file}:{line}:{col}"` of the *reference*) would silently
+/// pass the old assertion shape, so this pins the actual resolved-location
+/// string instead. Fixture picks a reference site (`A.kt:1:1`, from
+/// `outcome.line`/`col` both `0`) that's clearly distinct from the resolved
+/// target (`file:///t/Target.kt`, line 11) so the test fails pre-fix
+/// (would've asserted on `"A.kt:1:1"`) and passes post-fix.
+#[test]
+fn cache_candidate_location_is_the_resolved_target_not_the_reference_site() {
+    let mut agg = ResolutionAccuracyAggregator::default();
+    let target = test_location(10); // resolved target: Target.kt, line 11 (0-indexed 10)
+    agg.add(
+        "A.kt",
+        &ReferenceOutcome {
+            name: "widelyUsed".to_owned(),
+            receiver_type: Some("Bar".to_owned()),
+            line: 0,
+            col: 0,
+            outcome: ResolutionOutcome::Success {
+                tier: SuccessTier::CstResolved,
+                locations: vec![target.clone()],
+            },
+        },
+    );
+
+    let candidates = agg.cache_candidates(10);
+    assert_eq!(candidates.len(), 1);
+    let location = &candidates[0].location;
+    assert!(
+        location.contains("Target.kt") && location.contains("10"),
+        "expected the resolved target's location (Target.kt, line 10), got: {location}"
+    );
+    assert!(
+        !location.contains("A.kt"),
+        "location must not be the reference site (A.kt), got: {location}"
+    );
+}
+
+#[test]
+fn filtered_candidate_outcome_is_tracked_and_reported() {
+    let mut agg = ResolutionAccuracyAggregator::default();
+    agg.add(
+        "A.kt",
+        &ReferenceOutcome {
+            name: "ambiguousMember".to_owned(),
+            receiver_type: Some("Bar".to_owned()),
+            line: 4,
+            col: 2,
+            outcome: ResolutionOutcome::FilteredCandidate,
+        },
+    );
+
+    let recall = agg.recall();
+    assert_eq!(recall.member_total, 1);
+    assert_eq!(recall.filtered_candidate_total, 1);
+
+    let filtered = agg.top_filtered_candidates(10);
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].0, "ambiguousMember");
+    assert_eq!(filtered[0].1.count, 1);
+    assert_eq!(filtered[0].1.sample_location, "A.kt:5:3");
+}
+
+#[test]
+fn package_header_segments_are_not_flagged_as_gaps() {
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Pkg.kt").unwrap();
+    // `com`/`example` are package-header path segments, not references —
+    // walking into `package_header` would classify them as bare references
+    // that never resolve, producing spurious Gaps for every file.
+    let src = "package com.example\n\
+               import kotlin.collections.List\n\
+               fun useIt(list: List<Int>) {\n\
+                   println(list)\n\
+               }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+
+    let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    assert!(
+        !outcomes
+            .iter()
+            .any(|o| o.name == "com" || o.name == "example"),
+        "package-header segments must not appear as classified outcomes at all, got: {outcomes:?}"
+    );
 }

--- a/src/features/unresolved_symbol_diagnostics_tests.rs
+++ b/src/features/unresolved_symbol_diagnostics_tests.rs
@@ -206,7 +206,7 @@ fn test_location(line: u32) -> tower_lsp::lsp_types::Location {
 }
 
 #[test]
-fn recall_summary_counts_member_and_bare_lanes_separately() {
+fn recall_summary_keeps_member_lane_separate_from_bare_lane() {
     let mut agg = ResolutionAccuracyAggregator::default();
     agg.add(
         "A.kt",
@@ -353,7 +353,7 @@ fn cache_candidate_location_is_the_resolved_target_not_the_reference_site() {
 }
 
 #[test]
-fn filtered_candidate_outcome_is_tracked_and_reported() {
+fn filtered_candidate_outcome_appears_in_top_filtered_candidates() {
     let mut agg = ResolutionAccuracyAggregator::default();
     agg.add(
         "A.kt",

--- a/src/features/unresolved_symbol_diagnostics_tests.rs
+++ b/src/features/unresolved_symbol_diagnostics_tests.rs
@@ -194,3 +194,115 @@ fn collect_resolution_outcomes_survives_a_pathologically_deep_expression() {
     let doc = crate::indexer::live_tree::parse_live(&src, tree_sitter_kotlin::language()).unwrap();
     let _ = collect_resolution_outcomes(&idx, &uri, &doc);
 }
+
+fn test_location(line: u32) -> tower_lsp::lsp_types::Location {
+    tower_lsp::lsp_types::Location {
+        uri: Url::parse("file:///t/Target.kt").unwrap(),
+        range: tower_lsp::lsp_types::Range {
+            start: Position::new(line, 0),
+            end: Position::new(line, 5),
+        },
+    }
+}
+
+#[test]
+fn recall_summary_counts_member_and_bare_lanes_separately() {
+    let mut agg = ResolutionAccuracyAggregator::default();
+    agg.add(
+        "A.kt",
+        &ReferenceOutcome {
+            name: "foo".to_owned(),
+            receiver_type: Some("Bar".to_owned()),
+            line: 0,
+            col: 0,
+            outcome: ResolutionOutcome::Success {
+                tier: SuccessTier::CstResolved,
+                locations: vec![test_location(0)],
+            },
+        },
+    );
+    agg.add(
+        "A.kt",
+        &ReferenceOutcome {
+            name: "missing".to_owned(),
+            receiver_type: Some("Bar".to_owned()),
+            line: 1,
+            col: 0,
+            outcome: ResolutionOutcome::Gap,
+        },
+    );
+    agg.add(
+        "A.kt",
+        &ReferenceOutcome {
+            name: "helper".to_owned(),
+            receiver_type: None,
+            line: 2,
+            col: 0,
+            outcome: ResolutionOutcome::Success {
+                tier: SuccessTier::NameScan,
+                locations: vec![test_location(0)],
+            },
+        },
+    );
+
+    let recall = agg.recall();
+    assert_eq!(recall.member_total, 2);
+    assert_eq!(recall.member_cst_resolved, 1);
+    assert!((recall.member_recall_pct() - 50.0).abs() < 0.01);
+    assert_eq!(recall.bare_total, 1);
+    assert_eq!(recall.bare_success, 1);
+    assert_eq!(recall.bare_recall_pct(), 100.0);
+
+    let gaps = agg.top_gaps(10);
+    assert_eq!(gaps.len(), 1);
+    assert_eq!(gaps[0].0, "missing");
+    assert_eq!(gaps[0].1.count, 1);
+    assert_eq!(gaps[0].1.sample_location, "A.kt:2");
+}
+
+#[test]
+fn cache_candidate_grouping_separates_stable_from_unstable_keys() {
+    let mut agg = ResolutionAccuracyAggregator::default();
+    let stable_loc = test_location(10);
+    for line in 0..5u32 {
+        agg.add(
+            "A.kt",
+            &ReferenceOutcome {
+                name: "widelyUsed".to_owned(),
+                receiver_type: Some("Bar".to_owned()),
+                line,
+                col: 0,
+                outcome: ResolutionOutcome::Success {
+                    tier: SuccessTier::CstResolved,
+                    locations: vec![stable_loc.clone()],
+                },
+            },
+        );
+    }
+    for (line, loc_line) in [(0u32, 1u32), (1, 2)] {
+        agg.add(
+            "B.kt",
+            &ReferenceOutcome {
+                name: "shadowed".to_owned(),
+                receiver_type: None,
+                line,
+                col: 0,
+                outcome: ResolutionOutcome::Success {
+                    tier: SuccessTier::NameScan,
+                    locations: vec![test_location(loc_line)],
+                },
+            },
+        );
+    }
+
+    let candidates = agg.cache_candidates(10);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].name, "widelyUsed");
+    assert_eq!(candidates[0].count, 5);
+
+    let unstable = agg.unstable_hot_keys(10);
+    assert_eq!(unstable.len(), 1);
+    assert_eq!(unstable[0].name, "shadowed");
+    assert_eq!(unstable[0].count, 2);
+    assert_eq!(unstable[0].distinct_locations, 2);
+}

--- a/src/features/unresolved_symbol_diagnostics_tests.rs
+++ b/src/features/unresolved_symbol_diagnostics_tests.rs
@@ -1,0 +1,196 @@
+use super::*;
+use crate::indexer::Indexer;
+use tower_lsp::lsp_types::{Position, Url};
+
+/// Find the one outcome for `name` at 0-indexed `line` — fixtures below
+/// sometimes have the same name appear more than once on different lines
+/// (a declaration site, a self-shadowed bare call, an explicit-receiver
+/// call), so matching by name alone would be ambiguous.
+fn outcome_at<'a>(outcomes: &'a [ReferenceOutcome], name: &str, line: u32) -> &'a ReferenceOutcome {
+    outcomes
+        .iter()
+        .find(|o| o.name == name && o.line == line)
+        .unwrap_or_else(|| {
+            panic!("no reference outcome named `{name}` at line {line}, got: {outcomes:?}")
+        })
+}
+
+#[test]
+fn member_call_on_jar_receiver_resolves_cst_resolved() {
+    use crate::types::{FileData, SourceSet, SymbolEntry, Visibility};
+    use std::sync::Arc;
+
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Flow.kt").unwrap();
+    // Deliberately no same-file `collect` declaration here — that collision
+    // scenario is `same_file_shape_mismatched_self_declaration_is_filtered_candidate_not_gap`'s
+    // own job below. `resolve_qualified`'s uppercase-root branch tries
+    // `resolve_extension_in_scope` before the member/jar lookup and returns
+    // immediately on any name match there, with no arity check — so a
+    // same-file same-named extension would short-circuit before this jar
+    // member is ever reached, regardless of this test's call shape. This
+    // fixture isolates the claim this test actually makes: an unambiguous
+    // JAR-member reference resolves via `resolve_identity` alone.
+    let src = "package com.example\n\
+               import kotlinx.coroutines.flow.Flow\n\
+               fun useTriggers(triggers: Flow<String>) {\n\
+                   triggers.collect { trigger -> println(trigger) }\n\
+               }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+
+    let jar_uri_str = "jar:file:///fake-coroutines.jar!/Flow.kt".to_string();
+    let jar_uri = Url::parse(&jar_uri_str).unwrap();
+    let type_range = tower_lsp::lsp_types::Range {
+        start: Position::new(0, 0),
+        end: Position::new(0, 4),
+    };
+    let member_range = tower_lsp::lsp_types::Range {
+        start: Position::new(1, 0),
+        end: Position::new(1, 7),
+    };
+    let member = SymbolEntry {
+        name: "collect".to_owned(),
+        kind: tower_lsp::lsp_types::SymbolKind::METHOD,
+        visibility: Visibility::Public,
+        range: member_range,
+        selection_range: member_range,
+        detail: "suspend fun collect(collector: FlowCollector<T>)".to_owned(),
+        container: Some("Flow".to_owned()),
+        params: "collector: FlowCollector<T>".to_owned(),
+        param_counts: (1, 1),
+        cold: crate::types::pack_cold_fields(vec![], String::new(), String::new(), String::new()),
+        trailing_lambda: false,
+        deprecated: false,
+    };
+    let flow_type = SymbolEntry {
+        name: "Flow".to_owned(),
+        kind: tower_lsp::lsp_types::SymbolKind::INTERFACE,
+        visibility: Visibility::Public,
+        range: type_range,
+        selection_range: type_range,
+        detail: "interface Flow<T>".to_owned(),
+        container: None,
+        params: String::new(),
+        param_counts: (0, 0),
+        cold: crate::types::pack_cold_fields(vec![], String::new(), String::new(), String::new()),
+        trailing_lambda: false,
+        deprecated: false,
+    };
+    idx.jar_files.insert(
+        jar_uri_str.clone(),
+        Arc::new(FileData {
+            symbols: vec![flow_type, member],
+            source_set: SourceSet::Library,
+            package: Some("kotlinx.coroutines.flow".to_owned()),
+            lines: Arc::new(vec![]),
+            ..Default::default()
+        }),
+    );
+    idx.jar_definitions
+        .entry("Flow".to_owned())
+        .or_default()
+        .push(tower_lsp::lsp_types::Location {
+            uri: jar_uri.clone(),
+            range: type_range,
+        });
+
+    let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcome = outcome_at(&outcomes, "collect", 3);
+    match &outcome.outcome {
+        ResolutionOutcome::Success { tier, locations } => {
+            assert_eq!(*tier, SuccessTier::CstResolved);
+            assert_eq!(locations.len(), 1);
+            assert_eq!(locations[0].uri, jar_uri);
+        }
+        other => panic!("expected Success/CstResolved, got: {other:?}"),
+    }
+}
+
+#[test]
+fn same_file_shape_mismatched_self_declaration_is_filtered_candidate_not_gap() {
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Flow.kt").unwrap();
+    let src = "package com.example\n\
+               class Flow<T>\n\
+               class CoroutineScope\n\
+               fun <T> Flow<T>.collect(scope: CoroutineScope, block: (T) -> Unit) {\n\
+               }\n\
+               fun useTriggers(triggers: Flow<String>, scope: CoroutineScope) {\n\
+                   triggers.collect { trigger -> println(trigger) }\n\
+               }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+
+    let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcome = outcome_at(&outcomes, "collect", 6);
+    assert!(
+        matches!(outcome.outcome, ResolutionOutcome::FilteredCandidate),
+        "expected FilteredCandidate (a same-file wrong-arity self-declaration exists), got: {:?}",
+        outcome.outcome
+    );
+}
+
+#[test]
+fn undeclared_member_reference_is_gap() {
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Foo.kt").unwrap();
+    let src = "package com.example\n\
+               class Foo\n\
+               fun useFoo(foo: Foo) {\n\
+                   foo.totallyUndeclaredMethod()\n\
+               }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+
+    let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcome = outcome_at(&outcomes, "totallyUndeclaredMethod", 3);
+    assert!(
+        matches!(outcome.outcome, ResolutionOutcome::Gap),
+        "expected Gap, got: {:?}",
+        outcome.outcome
+    );
+}
+
+#[test]
+fn bare_call_to_top_level_function_resolves_name_scan_success() {
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Helper.kt").unwrap();
+    let src = "package com.example\n\
+               fun helper(): Int = 5\n\
+               fun useHelper() {\n\
+                   val result = helper()\n\
+               }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+
+    let doc = crate::indexer::live_tree::parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let outcomes = collect_resolution_outcomes(&idx, &uri, &doc);
+    let outcome = outcome_at(&outcomes, "helper", 3);
+    match &outcome.outcome {
+        ResolutionOutcome::Success { tier, locations } => {
+            assert_eq!(*tier, SuccessTier::NameScan);
+            assert_eq!(locations.len(), 1);
+        }
+        other => panic!("expected Success/NameScan, got: {other:?}"),
+    }
+}
+
+#[test]
+fn collect_resolution_outcomes_survives_a_pathologically_deep_expression() {
+    let n = 5_000; // several times MAX_CST_DESCENT_DEPTH (512)
+    let mut src = String::from("package app\nfun f() {\n    val x = 1");
+    for _ in 0..n {
+        src.push_str("+1");
+    }
+    src.push_str("\n}\n");
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Deep.kt").unwrap();
+    idx.index_content(&uri, &src);
+    idx.store_live_tree(&uri, &src);
+    let doc = crate::indexer::live_tree::parse_live(&src, tree_sitter_kotlin::language()).unwrap();
+    let _ = collect_resolution_outcomes(&idx, &uri, &doc);
+}

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -295,6 +295,13 @@ pub(crate) struct Indexer {
     /// Updated synchronously on every `did_open` / `did_change`; removed on `did_close`.
     /// Not cleared on `reset_index_state` — open-file trees survive workspace reindex.
     pub(crate) live_trees: DashMap<String, Arc<LiveDoc>>,
+    /// URI string → memoized append-only brace-repair candidate trees (see
+    /// `indexer::infer::speculative`'s `repair_candidates_for`). Content-derived,
+    /// not cursor-derived — the same up-to-`MAX_BRACE_REPAIRS` re-parses answer
+    /// every identifier's repair attempt within one file, so this avoids
+    /// rebuilding them per call. Cleared alongside `live_trees` in
+    /// `store_live_tree`/`remove_live_tree` whenever it could go stale.
+    pub(crate) repair_candidates: DashMap<String, Arc<Vec<LiveDoc>>>,
     /// Per-session cache for function signature lookups.
     /// Key: (fn_name, uri_string) → cached params text.
     /// Cleared on reindex to avoid stale results.
@@ -737,6 +744,7 @@ impl Indexer {
             extracted_jar_sources: DashMap::new(),
             importable_fqns: std::sync::RwLock::new(std::collections::HashMap::new()),
             live_trees: DashMap::new(),
+            repair_candidates: DashMap::new(),
             sig_cache: DashMap::new(),
             sig_fast_cache: DashMap::new(),
             enrichment: std::sync::RwLock::new(EnrichmentHandle::noop()),

--- a/src/indexer/infer/speculative.rs
+++ b/src/indexer/infer/speculative.rs
@@ -207,29 +207,77 @@ fn lambda_tree_gate(node: tree_sitter::Node<'_>, tree_has_error: bool) -> Lambda
     }
 }
 
-/// Append-only brace repair for a tree whose cursor sits under an ERROR node.
+/// Whether `lang`'s grammar can ever produce a `lambda_literal` node.
 ///
-/// Appending `\n}` at end-of-file shifts no existing byte offsets, so `pos`
-/// remains a valid position in every repaired candidate. Each attempt appends
-/// one more closing brace, reparses (a transient parse — never cached), and
-/// self-verifies by checking that the cursor now has an enclosing
-/// `lambda_literal`; unverified candidates are discarded. Bounded by
-/// [`MAX_BRACE_REPAIRS`]; when no candidate verifies, the caller returns the
-/// authoritative `None`.
-fn repaired_doc_at(doc: &LiveDoc, uri: &Url, pos: CursorPos) -> Option<LiveDoc> {
-    let lang = lang_for_path(uri.path())?;
-    let mut source = std::str::from_utf8(&doc.bytes).ok()?.to_owned();
+/// [`build_repair_candidates`]'s self-verification requires an enclosing one
+/// to accept a candidate — when a grammar has no such node kind at all,
+/// every repair attempt is guaranteed to fail regardless of input, so
+/// [`lambda_doc_at`] skips repair entirely rather than burning
+/// [`MAX_BRACE_REPAIRS`] full re-parses on a foregone conclusion. Verified
+/// directly against each grammar's own `node-types.json` (never assume this
+/// from a bare "not Kotlin" check): Java has no `lambda_literal` node kind at
+/// all, but Swift's closure-expression grammar defines its own (distinct)
+/// `lambda_literal` node — so this must stay a per-language grammar query,
+/// not a hardcoded language list.
+fn grammar_has_lambda_literal(lang: &tree_sitter::Language) -> bool {
+    lang.id_for_node_kind(KIND_LAMBDA_LIT, true) != 0
+}
+
+/// Build the sequence of up to [`MAX_BRACE_REPAIRS`] append-only brace-repair
+/// candidate reparses for `doc`.
+///
+/// Appending `\n}` at end-of-file shifts no existing byte offsets, so any
+/// `pos` valid in `doc` remains valid in every candidate. Depends only on
+/// `doc`'s content, not on any particular cursor position — safe to compute
+/// once per file and reuse across every position checked against it (see
+/// [`repair_candidates_for`]). Stops early if a reparse fails.
+fn build_repair_candidates(doc: &LiveDoc, lang: &tree_sitter::Language) -> Vec<LiveDoc> {
+    let Ok(base) = std::str::from_utf8(&doc.bytes) else {
+        return Vec::new();
+    };
+    let mut source = base.to_owned();
+    let mut candidates = Vec::with_capacity(MAX_BRACE_REPAIRS);
     for _ in 0..MAX_BRACE_REPAIRS {
         source.push_str("\n}");
-        let candidate = parse_live(&source, lang.clone())?;
-        let cursor_in_lambda = cursor_node_at(&candidate, pos)
-            .and_then(|node| node.enclosing_lambda_literal())
-            .is_some();
-        if cursor_in_lambda {
-            return Some(candidate);
-        }
+        let Some(candidate) = parse_live(&source, lang.clone()) else {
+            break;
+        };
+        candidates.push(candidate);
     }
-    None
+    candidates
+}
+
+/// [`build_repair_candidates`], memoized per `uri` on `indexer`.
+///
+/// The candidate sequence is file-content-derived, not cursor-derived, so
+/// every identifier's repair attempt within the same file reuses the same
+/// up-to-[`MAX_BRACE_REPAIRS`] re-parses instead of rebuilding them from
+/// scratch each time — the dominant cost `classify_cursor` pays when called
+/// once per identifier across a whole file with any parse error.
+/// `store_live_tree`/`remove_live_tree` clear this cache alongside
+/// `live_trees` so a stale candidate list can never survive an edit.
+fn repair_candidates_for(
+    indexer: &Indexer,
+    uri: &Url,
+    doc: &LiveDoc,
+    lang: &tree_sitter::Language,
+) -> Arc<Vec<LiveDoc>> {
+    if let Some(cached) = indexer.repair_candidates.get(uri.as_str()) {
+        return Arc::clone(&*cached);
+    }
+    let candidates = Arc::new(build_repair_candidates(doc, lang));
+    indexer
+        .repair_candidates
+        .insert(uri.to_string(), Arc::clone(&candidates));
+    candidates
+}
+
+/// Whether the cursor at `pos` verifies against `candidate` — has an
+/// enclosing `lambda_literal`.
+fn verify_repair_candidate(candidate: &LiveDoc, pos: CursorPos) -> bool {
+    cursor_node_at(candidate, pos)
+        .and_then(|node| node.enclosing_lambda_literal())
+        .is_some()
 }
 
 /// Pick the tree to resolve `it`/`this` against at `pos`.
@@ -240,7 +288,8 @@ fn repaired_doc_at(doc: &LiveDoc, uri: &Url, pos: CursorPos) -> Option<LiveDoc> 
 /// `lambda_literal` for an unclosed `{`; the brace opens an ERROR node instead
 /// (`it` in `items.forEach { it.name` parses as `simple_identifier` →
 /// `navigation_expression` → `statements` → ERROR → `source_file`). In that
-/// case resolve against an append-only brace repair (see [`repaired_doc_at`]).
+/// case resolve against an append-only brace repair (see
+/// [`repair_candidates_for`]).
 pub(crate) fn lambda_doc_at(indexer: &Indexer, uri: &Url, pos: CursorPos) -> Option<ResolutionDoc> {
     let doc = indexer.live_doc_or_parse(uri)?;
     let node = cursor_node_at(&doc, pos)?;
@@ -248,7 +297,16 @@ pub(crate) fn lambda_doc_at(indexer: &Indexer, uri: &Url, pos: CursorPos) -> Opt
     match lambda_tree_gate(node, tree_has_error) {
         LambdaTreeGate::Resolvable => Some(ResolutionDoc::Parsed(doc)),
         LambdaTreeGate::BrokenSyntax => {
-            repaired_doc_at(&doc, uri, pos).map(ResolutionDoc::Repaired)
+            let lang = lang_for_path(uri.path())?;
+            if !grammar_has_lambda_literal(&lang) {
+                return None;
+            }
+            let candidates = repair_candidates_for(indexer, uri, &doc, &lang);
+            candidates
+                .iter()
+                .find(|candidate| verify_repair_candidate(candidate, pos))
+                .cloned()
+                .map(ResolutionDoc::Repaired)
         }
     }
 }
@@ -496,5 +554,132 @@ mod tests {
         let (kind, text) = receiver_of("fun f() { a?.b?.| }").unwrap();
         assert_eq!(kind, "navigation_expression");
         assert_eq!(text, "a?.b");
+    }
+
+    // ─── brace-repair grammar gating + memoization ──────────────────────────
+
+    #[test]
+    fn kotlin_grammar_has_a_lambda_literal_node_kind() {
+        assert!(grammar_has_lambda_literal(&tree_sitter_kotlin::language()));
+    }
+
+    #[test]
+    fn swift_grammar_has_a_lambda_literal_node_kind() {
+        // Swift's own closure-expression grammar defines a distinct
+        // `lambda_literal` node — this must NOT be treated as "not Kotlin,
+        // so skip repair," which would silently break Swift lambda/closure
+        // resolution mid-typing.
+        assert!(grammar_has_lambda_literal(
+            &tree_sitter_swift_bundled::language()
+        ));
+    }
+
+    #[test]
+    fn java_grammar_has_no_lambda_literal_node_kind() {
+        assert!(!grammar_has_lambda_literal(&tree_sitter_java::language()));
+    }
+
+    #[test]
+    fn lambda_doc_at_repairs_an_unclosed_lambda() {
+        let indexer = Indexer::new();
+        let uri = Url::parse("file:///t/Unclosed.kt").unwrap();
+        // No closing braces at all — both the function body's `{` and the
+        // lambda's `{` are open at EOF, matching lambda_doc_at's own doc
+        // comment example. Append-only repair supplies exactly what's
+        // missing (one `}` for the lambda, one more for the function).
+        let src = "fun f(items: List<String>) {\n    items.forEach { it.name\n";
+        indexer.store_live_tree(&uri, src);
+        let Some(line) = src.lines().nth(1) else {
+            panic!("fixture must have a line 1");
+        };
+        let Some(col) = line.find("it.name") else {
+            panic!("fixture line 1 must contain `it.name`");
+        };
+        let pos = CursorPos {
+            line: 1,
+            utf16_col: col,
+        };
+
+        let Some(resolution) = lambda_doc_at(&indexer, &uri, pos) else {
+            panic!("expected a repaired resolution");
+        };
+        assert!(
+            matches!(resolution, ResolutionDoc::Repaired(_)),
+            "expected the ERROR-node/no-lambda-literal case to go through repair"
+        );
+    }
+
+    #[test]
+    fn lambda_doc_at_skips_repair_for_broken_java() {
+        let indexer = Indexer::new();
+        let uri = Url::parse("file:///t/Broken.java").unwrap();
+        // A stray unmatched closing brace gives the tree a parse error
+        // somewhere; Java has no `lambda_literal` node kind at all, so
+        // repair could never verify regardless of where the cursor sits.
+        let src = "class Broken {\n    void f() {\n        int x = 1;\n    }\n}\n}\n";
+        indexer.store_live_tree(&uri, src);
+        let Some(doc) = indexer.live_doc_or_parse(&uri) else {
+            panic!("expected a live doc for the just-stored uri");
+        };
+        assert!(
+            doc.tree.root_node().has_error(),
+            "fixture must actually have a parse error for this test to be meaningful"
+        );
+
+        let pos = CursorPos {
+            line: 2,
+            utf16_col: 12,
+        }; // inside `int x = 1;`, nowhere near the stray brace
+        assert!(lambda_doc_at(&indexer, &uri, pos).is_none());
+        assert!(
+            indexer.repair_candidates.get(uri.as_str()).is_none(),
+            "Java must never populate the repair-candidates cache — repair is skipped \
+             before any candidate is ever built"
+        );
+    }
+
+    #[test]
+    fn repair_candidates_are_memoized_across_calls_for_the_same_file() {
+        let indexer = Indexer::new();
+        let uri = Url::parse("file:///t/Broken.kt").unwrap();
+        let src = "fun f(items: List<String>) {\n    items.forEach { it.name\n}\n";
+        indexer.store_live_tree(&uri, src);
+        let Some(doc) = indexer.live_doc_or_parse(&uri) else {
+            panic!("expected a live doc for the just-stored uri");
+        };
+        let lang = tree_sitter_kotlin::language();
+
+        let first = repair_candidates_for(&indexer, &uri, &doc, &lang);
+        let second = repair_candidates_for(&indexer, &uri, &doc, &lang);
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "second call should reuse the cached candidates, not rebuild them"
+        );
+        assert!(
+            !first.is_empty(),
+            "expected at least one repair candidate to be built for this unclosed-lambda fixture"
+        );
+    }
+
+    #[test]
+    fn storing_a_new_live_tree_clears_the_stale_repair_candidate_cache() {
+        let indexer = Indexer::new();
+        let uri = Url::parse("file:///t/Broken.kt").unwrap();
+        let src = "fun f(items: List<String>) {\n    items.forEach { it.name\n}\n";
+        indexer.store_live_tree(&uri, src);
+        let Some(doc) = indexer.live_doc_or_parse(&uri) else {
+            panic!("expected a live doc for the just-stored uri");
+        };
+        let lang = tree_sitter_kotlin::language();
+        let _ = repair_candidates_for(&indexer, &uri, &doc, &lang);
+        assert!(indexer.repair_candidates.get(uri.as_str()).is_some());
+
+        // Re-store the same URI with different (now well-formed) content.
+        indexer.store_live_tree(&uri, "fun f() {}\n");
+        assert!(
+            indexer.repair_candidates.get(uri.as_str()).is_none(),
+            "a fresh store_live_tree call must invalidate any memoized repair \
+             candidates from the previous content"
+        );
     }
 }

--- a/src/indexer/live_tree.rs
+++ b/src/indexer/live_tree.rs
@@ -1,5 +1,6 @@
 use tree_sitter::{Language as TsLanguage, Parser, Tree};
 
+#[derive(Clone)]
 pub(crate) struct LiveDoc {
     pub bytes: Vec<u8>,
     pub tree: Tree,

--- a/src/indexer/live_tree_impl.rs
+++ b/src/indexer/live_tree_impl.rs
@@ -19,6 +19,10 @@ impl Indexer {
                 self.live_trees.remove(uri.as_str());
             }
         }
+        // The new content invalidates any memoized brace-repair candidates —
+        // they're derived from the old bytes and would silently answer every
+        // repair attempt against stale text otherwise.
+        self.repair_candidates.remove(uri.as_str());
     }
 
     /// Return the `LiveDoc` for `uri`, or `None` if the file is not open.
@@ -65,5 +69,6 @@ impl Indexer {
     /// Remove the live parse tree for `uri` (called on `textDocument/didClose`).
     pub(crate) fn remove_live_tree(&self, uri: &Url) {
         self.live_trees.remove(uri.as_str());
+        self.repair_candidates.remove(uri.as_str());
     }
 }


### PR DESCRIPTION
## Summary

Adds a new `kmp-lsp resolution-accuracy [root]` CLI subcommand — the mirror statistic to the existing `missing-imports`/`unused-imports` precision benchmarks. Instead of measuring false positives on a known-clean project, this measures **recall**: of every reference in a workspace, what fraction can the resolver actually find via `classify_cursor`+`resolve_identity` alone (never `find_definition`'s full pipeline, whose `rg`-grep fallback would mask real resolver regressions)?

It also surfaces a secondary **repeat-resolution / cache-candidate** signal: which `(name, receiver_type)` keys resolve identically, over and over, across a corpus — a proxy for where a resolver-level memoization cache would pay off (the pattern behind e.g. syntax highlighting re-resolving an already-known symbol on every occurrence).

No compiler ground truth exists for recall, so this is explicitly framed (in both the design doc and the tool's own printed output) as a **trend metric** — compare the same corpus before/after a resolver change — not an absolute accuracy score.

## Architecture

- `src/features/unresolved_symbol_diagnostics.rs` (new) — pure classification (`collect_resolution_outcomes`, bucketing each reference into `Success{CstResolved|NameScan}` / `FilteredCandidate` / `Gap`) + a pure, streaming `ResolutionAccuracyAggregator`. Named/positioned like its `missing_import_diagnostics`/`unused_import_diagnostics` siblings so a later live diagnostic can reuse it without restructuring (explicitly deferred this pass — CLI only).
- `src/cli/resolution_accuracy_poc.rs` (new) — I/O wrapper mirroring `missing_import_poc.rs`'s structure: build the index, warm the JAR index, walk the workspace, aggregate, print.
- `src/cli/{mod,args,run}.rs` — wire the new subcommand.

## Process notes

Built via brainstorming → design doc → implementation plan → subagent-driven execution (5 tasks, each with an independent implementer + task-scoped review) → a final whole-branch review that caught real cross-task integration issues a per-task view couldn't see (package-header segments wrongly counted as gaps, a cache-candidate report that printed the reference site instead of the resolved target, missing FilteredCandidate/Gap totals, no floor/trend-metric caveat in the actual CLI output, no progress visibility on a real corpus scan) — all fixed and re-reviewed clean in a single fix wave.

Along the way, Task 1's implementer correctly caught a bug in the plan's own test fixture (it entangled a same-file self-shadow collision into a test meant to prove plain JAR-member resolution) — fixed by simplifying the fixture, not by touching production resolver code.

## Test plan

- [x] `cargo test --bin kmp-lsp` — 1753 passed, 0 failed, 3 ignored
- [x] `cargo test --tests` — full suite across all test binaries green
- [x] `cargo clippy -- -D warnings` (matches this repo's pre-commit hook exactly) — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Smoke run: `cargo run --bin kmp-lsp -- resolution-accuracy tests/fixtures` — exits 0, prints a well-formed report
- [x] Real-corpus run against nowInAndroid (338 files, ~25K references): member refs 70.7% recall (2168/3068 CstResolved), bare refs 74.0% recall (16129/21799 resolved), 263 FilteredCandidate, 637 actionable member-ref Gaps. Cache-candidate report correctly surfaced stable high-frequency keys (`Modifier` ×251, `Test` ×247, `dp` ×220, all single-location) separately from unstable ones (`String` ×393 across 8 distinct locations) — the report reads as designed.

## Throughput fix: skip/memoize speculative brace-repair (commit `f3c6bf5`)

The 30-minute/~1084-file monorepo bottleneck above was root-caused (a research-only "scout" pass, independently confirmed by an unrelated critique from a second model) to a *pre-existing* mechanism, not something this PR's own code introduced: `classify_symbol_at` → `lambda_doc_at`'s speculative brace-repair path was invoked once **per identifier** rather than once per file, and each invocation could do up to `MAX_BRACE_REPAIRS = 8` full non-incremental re-parses of the whole file whenever the tree has any parse error anywhere. Only ~2.5% of a real monorepo's files trip this, but for those the cost is catastrophic — one measured ~56KB Kotlin file cost an estimated ~7.6 minutes by itself.

Two fixes, both verified behavior-preserving:
1. **Skip repair when the file's grammar can never produce a `lambda_literal` node** — repair's self-verification requires one, so on such a grammar every attempt is guaranteed to fail regardless of input. Verified directly against each grammar's own `node-types.json` rather than assumed: Java's grammar has no `lambda_literal` node kind at all, but **Swift's closure-expression grammar defines its own (distinct) one** — an earlier "just skip for non-Kotlin" framing from both the scout and the independent critique would have silently broken Swift closure resolution mid-typing; caught before landing by checking the actual grammar via `tree_sitter::Language::id_for_node_kind`, not a hardcoded language list.
2. **Memoize the up-to-8 repair candidate trees per file** (`Indexer::repair_candidates`, invalidated alongside `live_trees` on every edit) instead of rebuilding them per identifier — the candidate sequence depends only on file content, never on the cursor position being checked against it.

**Empirically verified end-to-end**: the exact worst-case file from the scout's estimate (~454s predicted) now completes in ~13s total including JAR-warming. A full nowInAndroid run dropped from several minutes to ~101s.

**Also discovered while validating** (pre-existing, unrelated to this fix, not addressed here): the CLI's absolute reference counts vary slightly run-to-run even on the *unmodified* pre-fix binary against the same unchanged corpus (e.g. 3068 vs 3079 member refs across two runs) — almost certainly the resolver's existing bounded per-request JAR-symbol promotion budget interacting with thousands of sequential lookups in one CLI run. Reproduced on the pre-fix binary specifically to rule out this fix as the cause. This reinforces why the design doc already frames the tool's output as a trend metric rather than an absolute score; a fuller investigation is a separate follow-up.

Full ~13,200-file monorepo run not yet re-attempted end-to-end post-fix (still a multi-file-error-outlier-bound cost, just far smaller now) — the single-worst-case-file and full-nowInAndroid measurements above are the validation evidence for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfD4ymPvPDKgoHSuNUMp4x

