### PR TITLE
fix(when-diagnostic): resolve chained smart-cast subjects reachability-first

### DIFF
--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -10,11 +10,9 @@ use tower_lsp::lsp_types::*;
 use crate::indexer::live_tree::utf16_col_to_byte;
 use crate::indexer::Indexer;
 use crate::queries::{
-    KIND_BOOLEAN_LITERAL, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_ELSE, KIND_FUN_DECL,
-    KIND_FUN_VALUE_PARAMS, KIND_LBRACE, KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_NULLABLE_TYPE,
-    KIND_PARAMETER, KIND_PRIMARY_CTOR, KIND_PROP_DECL, KIND_RBRACE, KIND_SIMPLE_IDENT,
-    KIND_STATEMENTS, KIND_TYPE_IDENT, KIND_TYPE_TEST, KIND_USER_TYPE, KIND_VAR_DECL,
-    KIND_WHEN_CONDITION, KIND_WHEN_ENTRY, KIND_WHEN_EXPR, KIND_WHEN_SUBJECT,
+    KIND_BOOLEAN_LITERAL, KIND_ELSE, KIND_LBRACE, KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_RBRACE,
+    KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_TYPE_TEST, KIND_USER_TYPE, KIND_WHEN_CONDITION,
+    KIND_WHEN_ENTRY, KIND_WHEN_EXPR, KIND_WHEN_SUBJECT,
 };
 use crate::StrExt;
 
@@ -24,8 +22,14 @@ type SealedMembersCache =
     std::collections::HashMap<(String, String, u32, u32, u32, u32), Vec<WhenMember>>;
 
 /// Memoizes `resolve_type_members` results within a single pass.
-/// Key: subject type name. Safe because the index doesn't change mid-pass.
-type TypeMembersCache = std::collections::HashMap<String, Option<(TypeKind, Vec<WhenMember>)>>;
+/// Key: `(subject type name, reachability uri)` — a bare type name alone
+/// isn't enough to key on: two `when`s in the same file can resolve the same
+/// name through different reachability anchors (a chained subject's leaf type
+/// is resolved from *its own* declaring file, not necessarily this file's —
+/// see `infer::infer_field_chain_type`), and a same-named-but-different type
+/// from the wrong anchor must not be served from the other's cache entry.
+type TypeMembersCache =
+    std::collections::HashMap<(String, String), Option<(TypeKind, Vec<WhenMember>)>>;
 
 /// Analysis result for incomplete when expressions — shared by code actions and diagnostics.
 struct WhenAnalysis<'a> {
@@ -48,7 +52,7 @@ fn analyze_when<'a>(
         .children(&mut when_node.walk())
         .find(|c| c.kind() == KIND_WHEN_SUBJECT)?;
 
-    let subject_segments = extract_subject_segments(&subject_node, source_bytes)?;
+    let subject_segments = crate::resolver::infer::subject_segments(subject_node, source_bytes)?;
 
     let existing = collect_existing_branches(&when_node, source_bytes);
 
@@ -56,19 +60,46 @@ fn analyze_when<'a>(
         return None;
     }
 
-    let subject_type = match subject_segments.as_slice() {
+    // The file whose imports/package should be used to resolve `subject_type`'s
+    // own members below. For a plain `when (var)` it's always the caller's own
+    // file. For a chained `when (var.field)` it must be the *leaf field's own
+    // declaring file* instead — the leaf type can be a class duplicated
+    // workspace-wide and reachable only through the chain, never imported by
+    // the caller directly (see `infer::infer_field_chain_type`'s doc comment).
+    let (subject_type, members_uri) = match subject_segments.as_slice() {
         // A local or parameter: prefer the declaration the CST can see over a
         // whole-file name scan.
-        [subject_var] => resolve_subject_type_from_cst(&when_node, subject_var, source_bytes)
+        [subject_var] => (
+            crate::resolver::infer::resolve_declared_type_from_cst(
+                when_node,
+                subject_var,
+                source_bytes,
+            )
             .or_else(|| crate::resolver::infer::infer_variable_type(indexer, subject_var, uri))?,
+            uri.clone(),
+        ),
         // `userData.themeBrand` — walk the field chain to its leaf type.
-        chain => crate::resolver::infer::infer_field_chain_type(indexer, chain, uri)?.qualified,
+        // `infer_field_chain_type` itself finds the longest smart-cast-narrowed
+        // prefix of the chain from the CST (Kotlin narrows whole stable
+        // paths, not just the root variable — see its own doc comment) and
+        // walks any remaining fields from there.
+        chain => {
+            let line = when_node.start_position().row as u32;
+            let (receiver_type, declaring_uri) = crate::resolver::infer::infer_field_chain_type(
+                indexer,
+                chain,
+                uri,
+                line,
+                Some((when_node, source_bytes)),
+            )?;
+            (receiver_type.qualified, declaring_uri)
+        }
     };
     let subject_type = subject_type.strip_nullable().to_string();
 
     let (type_kind, members) = resolve_type_members(
         indexer,
-        uri,
+        &members_uri,
         &subject_type,
         sealed_cache,
         type_members_cache,
@@ -307,240 +338,6 @@ fn find_enclosing_when<'a>(
     None
 }
 
-/// Resolve the when subject's type from the CST by searching:
-/// 1. Sibling property_declarations in the same statements block (local vals)
-/// 2. Enclosing function's parameters
-/// 3. Enclosing class constructor parameters
-fn resolve_subject_type_from_cst(
-    when_node: &tree_sitter::Node,
-    var_name: &str,
-    source: &[u8],
-) -> Option<String> {
-    // Walk up to find statements block or function_declaration
-    let mut current = when_node.parent();
-    while let Some(node) = current {
-        match node.kind() {
-            KIND_STATEMENTS => {
-                if let Some(ty) = find_type_in_sibling_declarations(&node, var_name, source) {
-                    return Some(ty);
-                }
-            }
-            KIND_FUN_DECL => {
-                if let Some(ty) = find_type_in_parameters(&node, var_name, source) {
-                    return Some(ty);
-                }
-            }
-            KIND_CLASS_DECL => {
-                if let Some(ty) = find_type_in_constructor(&node, var_name, source) {
-                    return Some(ty);
-                }
-            }
-            _ => {}
-        }
-        current = node.parent();
-    }
-    None
-}
-
-/// Search sibling property_declarations for `val <var_name> : Type`
-fn find_type_in_sibling_declarations(
-    statements: &tree_sitter::Node,
-    var_name: &str,
-    source: &[u8],
-) -> Option<String> {
-    for child in statements.children(&mut statements.walk()) {
-        if child.kind() != KIND_PROP_DECL {
-            continue;
-        }
-        if let Some(ty) = extract_var_type_from_declaration(&child, var_name, source) {
-            return Some(ty);
-        }
-    }
-    None
-}
-
-/// Search function parameters for `<var_name>: Type`
-fn find_type_in_parameters(
-    func_node: &tree_sitter::Node,
-    var_name: &str,
-    source: &[u8],
-) -> Option<String> {
-    for child in func_node.children(&mut func_node.walk()) {
-        if child.kind() != KIND_FUN_VALUE_PARAMS {
-            continue;
-        }
-        for param in child.children(&mut child.walk()) {
-            if param.kind() != KIND_PARAMETER {
-                continue;
-            }
-            if let Some(ty) = extract_param_type(&param, var_name, source) {
-                return Some(ty);
-            }
-        }
-    }
-    None
-}
-
-/// Search class constructor parameters
-fn find_type_in_constructor(
-    class_node: &tree_sitter::Node,
-    var_name: &str,
-    source: &[u8],
-) -> Option<String> {
-    for child in class_node.children(&mut class_node.walk()) {
-        if child.kind() != KIND_PRIMARY_CTOR {
-            continue;
-        }
-        for param in child.children(&mut child.walk()) {
-            if param.kind() != KIND_CLASS_PARAM {
-                continue;
-            }
-            if let Some(ty) = extract_param_type(&param, var_name, source) {
-                return Some(ty);
-            }
-        }
-    }
-    None
-}
-
-/// Extract type from `variable_declaration` inside a property_declaration.
-/// CST: property_declaration → variable_declaration → simple_identifier + ":" + user_type
-/// Also handles inferred Boolean from literal: `val x = false` → Boolean
-fn extract_var_type_from_declaration(
-    prop: &tree_sitter::Node,
-    var_name: &str,
-    source: &[u8],
-) -> Option<String> {
-    let mut name_matched = false;
-    for child in prop.children(&mut prop.walk()) {
-        if child.kind() == KIND_VAR_DECL {
-            for vc in child.children(&mut child.walk()) {
-                if vc.kind() == KIND_SIMPLE_IDENT && vc.utf8_text(source).ok() == Some(var_name) {
-                    name_matched = true;
-                }
-                if name_matched {
-                    if vc.kind() == KIND_USER_TYPE {
-                        return extract_full_type_name(&vc, source);
-                    }
-                    if vc.kind() == KIND_NULLABLE_TYPE {
-                        return extract_user_type_from_nullable(&vc, source);
-                    }
-                }
-            }
-        }
-        if name_matched && child.kind() == KIND_BOOLEAN_LITERAL {
-            return Some("Boolean".to_string());
-        }
-    }
-    None
-}
-
-/// Extract type from a `parameter` or `class_parameter` node.
-/// CST: parameter → simple_identifier + ":" + user_type | nullable_type
-fn extract_param_type(param: &tree_sitter::Node, var_name: &str, source: &[u8]) -> Option<String> {
-    let mut found_name = false;
-    for child in param.children(&mut param.walk()) {
-        if child.kind() == KIND_SIMPLE_IDENT && child.utf8_text(source).ok() == Some(var_name) {
-            found_name = true;
-        }
-        if found_name {
-            if child.kind() == KIND_USER_TYPE {
-                return extract_full_type_name(&child, source);
-            }
-            if child.kind() == KIND_NULLABLE_TYPE {
-                return extract_user_type_from_nullable(&child, source);
-            }
-        }
-    }
-    None
-}
-
-/// Extract user_type from a nullable_type node (nullable_type → user_type + "?").
-fn extract_user_type_from_nullable(nullable: &tree_sitter::Node, source: &[u8]) -> Option<String> {
-    for child in nullable.children(&mut nullable.walk()) {
-        if child.kind() == KIND_USER_TYPE {
-            return extract_full_type_name(&child, source);
-        }
-    }
-    None
-}
-
-/// Extract the full type name from a user_type node (e.g. "TipsResult", "Effect").
-/// For dotted types like `Outer.Inner`, concatenates with dots.
-fn extract_full_type_name(user_type: &tree_sitter::Node, source: &[u8]) -> Option<String> {
-    let mut parts = Vec::new();
-    for child in user_type.children(&mut user_type.walk()) {
-        if child.kind() == KIND_TYPE_IDENT {
-            if let Ok(text) = child.utf8_text(source) {
-                parts.push(text.to_string());
-            }
-        }
-    }
-    if parts.is_empty() {
-        None
-    } else {
-        Some(parts.join("."))
-    }
-}
-
-/// The subject expression's identifier chain: `state` → `["state"]`,
-/// `userData.themeBrand` → `["userData", "themeBrand"]`.
-///
-/// `None` for any subject that isn't a plain identifier or field access — a
-/// call, an index, a literal — since those need real expression inference
-/// rather than a name chain.
-fn extract_subject_segments(
-    subject_node: &tree_sitter::Node,
-    source: &[u8],
-) -> Option<Vec<String>> {
-    // when_subject → "(" <expression> ")"
-    for child in subject_node.children(&mut subject_node.walk()) {
-        match child.kind() {
-            KIND_SIMPLE_IDENT => {
-                return Some(vec![child.utf8_text(source).ok()?.to_owned()]);
-            }
-            KIND_NAV_EXPR => {
-                let mut segments = Vec::new();
-                collect_navigation_segments(&child, source, &mut segments, 0)?;
-                return Some(segments);
-            }
-            _ => {}
-        }
-    }
-    None
-}
-
-/// Flatten a `navigation_expression` into its identifier segments, failing on
-/// anything that isn't a plain field access (a call in the chain, say).
-///
-/// Kind-bounded (only descends through `KIND_NAV_EXPR`/`KIND_NAV_SUFFIX`), but
-/// an arbitrarily long `a.b.c.d…` chain is still an arbitrarily deep
-/// recursion — `depth` caps it. See `crate::util::MAX_CST_DESCENT_DEPTH`.
-fn collect_navigation_segments(
-    node: &tree_sitter::Node,
-    source: &[u8],
-    out: &mut Vec<String>,
-    depth: usize,
-) -> Option<()> {
-    if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
-        crate::util::report_cst_depth_exceeded!("collect_navigation_segments", *node);
-        return None;
-    }
-    match node.kind() {
-        KIND_SIMPLE_IDENT => out.push(node.utf8_text(source).ok()?.to_owned()),
-        KIND_NAV_EXPR | KIND_NAV_SUFFIX => {
-            for child in node.children(&mut node.walk()) {
-                // The `.` separator carries no segment of its own.
-                if child.kind() != "." {
-                    collect_navigation_segments(&child, source, out, depth + 1)?;
-                }
-            }
-        }
-        _ => return None,
-    }
-    Some(())
-}
-
 /// Resolve whether the type is an enum, sealed class, or Boolean, and return its members.
 fn resolve_type_members(
     indexer: &Indexer,
@@ -549,16 +346,18 @@ fn resolve_type_members(
     sealed_cache: &mut SealedMembersCache,
     type_members_cache: &mut TypeMembersCache,
 ) -> Option<(TypeKind, Vec<WhenMember>)> {
-    // Fast path: same type was already resolved earlier in this pass.
-    // We cache with empty existing_branches so the result is independent of
-    // which `when` node queries first — branches_fit_members would otherwise
-    // select different homonymous types depending on call order.
-    // `analyze_when` applies its own missing-branch filter after this call.
-    if let Some(cached) = type_members_cache.get(type_name) {
+    // Fast path: same (type, reachability anchor) was already resolved
+    // earlier in this pass. We cache with empty existing_branches so the
+    // result is independent of which `when` node queries first —
+    // branches_fit_members would otherwise select different homonymous types
+    // depending on call order. `analyze_when` applies its own missing-branch
+    // filter after this call.
+    let cache_key = (type_name.to_string(), from_uri.to_string());
+    if let Some(cached) = type_members_cache.get(&cache_key) {
         return cached.clone();
     }
     let result = resolve_type_members_inner(indexer, from_uri, type_name, &[], sealed_cache);
-    type_members_cache.insert(type_name.to_string(), result.clone());
+    type_members_cache.insert(cache_key, result.clone());
     result
 }
 

--- a/src/features/fill_when_tests.rs
+++ b/src/features/fill_when_tests.rs
@@ -989,6 +989,144 @@ fun test(): String = when (pick()) {
     );
 }
 
+// Regression: a nested `when (event.event)` inside a smart-cast branch of an
+// outer `when (event)`. Mirrors the real Moneta bug (DashboardProductsReducer.kt):
+// `event`'s declared type is the outer sealed `Event`, but inside
+// `is Event.OverdraftInput -> when (event.event) { ... }` the subject is
+// smart-cast to `Event.OverdraftInput`, whose own `event` field is a narrower,
+// unrelated sealed type (`OverdraftEvent`). `infer_field_chain_type`'s root-type
+// resolution ignores smart-cast narrowing, so it uses the un-narrowed declared
+// type "Event". `find_field_type_in_class` then does an unscoped bare-name
+// search across every workspace class literally named "Event" for one with an
+// "event"-named field — an unrelated decoy class (elsewhere, also named
+// "Event", also happening to declare something called "event") can be picked
+// over the real nested field. Reproducing this needs that decoy: a single
+// self-contained file with only one workspace-wide "Event" doesn't trigger the
+// bug, since the bare-name lookup then has only the correct candidate to find.
+#[test]
+fn diagnostics_no_false_positive_for_nested_when_on_smart_cast_narrowed_field() {
+    // Member names are deliberately distinct across `RegularEvent` and
+    // `OverdraftEvent` (no shared "OnClick") — otherwise a wrong root-type
+    // resolution that lands on the *other* sibling sealed type could still
+    // accidentally report zero missing branches by name coincidence, giving
+    // false confidence in this test regardless of whether the real fix works.
+    let reducer_src = "\
+sealed interface Event {
+    data class RegularInput(val event: RegularEvent) : Event
+    data class OverdraftInput(val event: OverdraftEvent) : Event
+}
+sealed interface RegularEvent {
+    object RegularOnClick : RegularEvent
+}
+sealed interface OverdraftEvent {
+    object OverdraftOnClick : OverdraftEvent
+    object OverdraftOnCallUsClick : OverdraftEvent
+}
+class Reducer {
+    fun reduce(event: Event) {
+        when (event) {
+            is Event.RegularInput -> when (event.event) {
+                is RegularEvent.RegularOnClick -> println(\"r\")
+            }
+            is Event.OverdraftInput -> when (event.event) {
+                is OverdraftEvent.OverdraftOnClick -> println(\"1\")
+                is OverdraftEvent.OverdraftOnCallUsClick -> println(\"2\")
+            }
+        }
+    }
+}
+";
+    // Unrelated feature elsewhere in the workspace: a totally different
+    // sealed `Event` whose own reducer parameter is also named `event`, with
+    // many members — the decoy an unscoped bare-name lookup can land on.
+    let decoy_src = "\
+sealed interface Event {
+    object ToggleSbCore : Event
+    object ToggleMaintenance : Event
+    object OpenDetail : Event
+}
+class OtherReducer {
+    fun reduce(event: Event) {}
+}
+";
+    let idx = setup(&[
+        ("/reducer/Reducer.kt", reducer_src),
+        ("/other/OtherReducer.kt", decoy_src),
+    ]);
+    let diags = when_diagnostics(&idx, &uri("/reducer/Reducer.kt"));
+    assert!(
+        diags.is_empty(),
+        "both nested whens are exhaustive for their smart-cast-narrowed `event` \
+         field type and must not report an unrelated same-named Event's members \
+         as missing: {diags:?}"
+    );
+}
+
+// Regression: the chain's SECOND hop (the field's own type, not just the root)
+// is *also* a same-named class duplicated workspace-wide, and the file that
+// declares it is only reached transitively — never imported by name anywhere.
+// Mirrors the real Moneta bug (PersonalDetailViewModel.kt):
+// `a.info.OtherInfoContract.kt` and `a.info_extended.OtherInfoExtendedContract.kt`
+// each declare their own `Event`/`SelectionVariantsEvents`/`SelectionVariantsEvent`
+// trio with different `SelectionVariantsEvent` members. The ViewModel (a third,
+// unrelated package) imports only `Event` from the `info` package — never
+// `SelectionVariantsEvents` or `SelectionVariantsEvent` by name — so resolving
+// the chain's second segment can only succeed by anchoring reachability on
+// `SelectionVariantsEvents`'s OWN declaring file (same package as its sibling
+// `SelectionVariantsEvent`), not the caller's.
+#[test]
+fn diagnostics_no_false_positive_when_chained_field_type_is_reached_transitively() {
+    let info_contract_src = "\
+package a.info
+sealed interface Event {
+    data class SelectionVariantsEvents(val selectionEvent: SelectionVariantsEvent) : Event
+}
+sealed interface SelectionVariantsEvent {
+    object DocumentTypeEvents : SelectionVariantsEvent
+}
+";
+    // Decoy: same names, different (larger) membership, different package —
+    // an unscoped bare-name lookup for either "SelectionVariantsEvents" or
+    // "SelectionVariantsEvent" could land here instead.
+    let info_extended_contract_src = "\
+package a.info_extended
+sealed interface Event {
+    data class SelectionVariantsEvents(val selectionEvent: SelectionVariantsEvent) : Event
+}
+sealed interface SelectionVariantsEvent {
+    object DocumentTypeEvents : SelectionVariantsEvent
+    object HousingEvents : SelectionVariantsEvent
+}
+";
+    let view_model_src = "\
+package b
+import a.info.Event
+
+fun reduce(event: Event) {
+    when (event) {
+        is Event.SelectionVariantsEvents -> when (event.selectionEvent) {
+            is SelectionVariantsEvent.DocumentTypeEvents -> println(\"doc\")
+        }
+    }
+}
+";
+    let idx = setup(&[
+        (
+            "/a/info_extended/OtherInfoExtendedContract.kt",
+            info_extended_contract_src,
+        ),
+        ("/a/info/OtherInfoContract.kt", info_contract_src),
+        ("/b/ViewModel.kt", view_model_src),
+    ]);
+    let diags = when_diagnostics(&idx, &uri("/b/ViewModel.kt"));
+    assert!(
+        diags.is_empty(),
+        "the nested when is exhaustive for a.info's SelectionVariantsEvent \
+         (the one reachable via SelectionVariantsEvents' own declaring file) \
+         and must not report a.info_extended's HousingEvents as missing: {diags:?}"
+    );
+}
+
 /// Regression: `collect_navigation_segments` only descends through
 /// navigation-expression node kinds, so it bails immediately on anything
 /// else — but a long, entirely ordinary field-access chain (`a.b.c.d…`)

--- a/src/features/hover_tests.rs
+++ b/src/features/hover_tests.rs
@@ -252,3 +252,67 @@ fn hover_shows_same_arity_self_recursion() {
         "same-arity self-recursion must still hover to itself, got: {text:?}"
     );
 }
+
+/// Regression: hovering a smart-cast-narrowed field access (`event.event`
+/// inside `is Event.OverdraftInput -> when (event.event) { ... }`) must show
+/// the *specific* nested variant's own field, not a same-named sibling's.
+///
+/// `CursorContext::build` correctly narrows the root to `Event.OverdraftInput`
+/// (confirmed via smart-cast inference), but the member lookup
+/// (`resolve_qualified`'s uppercase-qualifier branch, in `resolver/resolve.rs`)
+/// only anchored the search on the *outer* type's (`Event`'s) own declaration
+/// line, then took whichever same-named field was textually closest —
+/// `RegularInput`'s `event` field, declared before `OverdraftInput`'s in the
+/// same sealed interface, not the one actually being hovered. `RegularInput`
+/// is the decoy that makes this test fail without the fix; a single-variant
+/// fixture would pass by accident regardless.
+#[test]
+fn hover_on_smart_cast_narrowed_field_shows_the_specific_variant_not_a_sibling() {
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Reducer.kt").unwrap();
+    let src = "\
+sealed interface Event {
+    data class RegularInput(val event: RegularEvent) : Event
+    data class OverdraftInput(val event: OverdraftEvent) : Event
+}
+sealed interface RegularEvent {
+    object RegularOnClick : RegularEvent
+}
+sealed interface OverdraftEvent {
+    object OverdraftOnClick : OverdraftEvent
+}
+class Reducer {
+    fun reduce(event: Event) {
+        when (event) {
+            is Event.OverdraftInput -> when (event.event) {
+                is OverdraftEvent.OverdraftOnClick -> println(\"1\")
+            }
+            else -> {}
+        }
+    }
+}
+";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+    let target_line = src
+        .lines()
+        .position(|line| line.contains("when (event.event)"))
+        .unwrap();
+    // The second `event` — the field access, not the smart-cast root.
+    let col = src
+        .lines()
+        .nth(target_line)
+        .unwrap()
+        .rfind("event")
+        .unwrap() as u32;
+    let position = Position::new(target_line as u32, col);
+    let ctx = CursorContext::build(&idx, &uri, position).unwrap();
+
+    let hover = compute_hover(&idx, &ctx, &uri, position).expect("expected a hover result");
+    let text = hover_text(&hover);
+    assert!(
+        text.contains("OverdraftInput") && !text.contains("RegularInput"),
+        "must show OverdraftInput's own `event` field, not RegularEvent's \
+         sibling field found by proximity to Event's own declaration, got: {text:?}"
+    );
+}

--- a/src/features/nullable_call_diagnostics.rs
+++ b/src/features/nullable_call_diagnostics.rs
@@ -186,7 +186,20 @@ fn resolve_receiver(
             if chain.len() < 2 || chain[0] == "this" || chain[0] == "super" {
                 return None;
             }
-            let receiver_type = indexer.infer_field_chain_type(&chain, uri)?;
+            // No CST point: unlike `fill_when` (one call per `when` node),
+            // this runs once per `navigation_expression` in the whole file —
+            // for a long field-access chain that's one call per segment, and
+            // `enclosing_smart_cast_type`'s ancestor walk is only safe to
+            // call this often because it bounds *segment count*, which does
+            // NOT bound tree depth for the receiver nodes closest to the
+            // chain's root (see `MAX_SMART_CAST_CHAIN_LEN`'s doc comment).
+            // Falls back to the line-scanning `smart_cast_narrowed_type`
+            // (root-only) inside `infer_field_chain_type` instead — no
+            // regression from before this file started passing a CST point,
+            // since it never did.
+            let line = receiver_node.start_position().row as u32;
+            let (receiver_type, _declaring_uri) =
+                indexer.infer_field_chain_type(&chain, uri, line, None)?;
             Some((chain.join("."), receiver_type))
         }
         _ => None,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -417,11 +417,12 @@ impl InferDeps for Indexer {
         infer_variable_type_raw(self, var_name, uri)
             .or_else(|| infer_variable_type_from_cst(self, var_name, uri))
     }
-    fn find_field_type(&self, class_name: &str, field_name: &str) -> Option<String> {
+    fn find_field_type(&self, class_name: &str, field_name: &str, uri: &Url) -> Option<String> {
         if let Some(type_name) = synthetic_enum_field(self, class_name, field_name) {
             return Some(type_name);
         }
-        crate::resolver::infer::find_field_type_in_class(self, class_name, field_name)
+        crate::resolver::infer::find_field_type_in_class(self, class_name, field_name, uri)
+            .map(|(field_type, _declaring_uri)| field_type)
     }
     fn find_fun_return_type(&self, fn_name: &str, uri: &Url) -> Option<String> {
         crate::resolver::infer::find_fun_return_type_by_name(self, fn_name, uri)

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -444,7 +444,7 @@ pub(super) fn resolve_member_type_on(
     } else {
         return None;
     };
-    if let Some(field_ty) = deps.find_field_type(&effective_type, member) {
+    if let Some(field_ty) = deps.find_field_type(&effective_type, member, uri) {
         let subst = build_type_arg_subst(deps, &effective_type, current_type);
         let applied = crate::indexer::apply_type_subst(&field_ty, &subst);
         if is_generic_param(applied.strip_nullable()) {

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -174,15 +174,18 @@ pub(crate) trait InferDeps {
     }
 
     /// Look up the raw declared type of `field_name` inside class `class_name`,
-    /// searching across indexed files.  Preserves generic parameters so that
-    /// `extract_collection_element_type` can extract the element type.
+    /// preferring the declaration reachable from `uri`'s own imports/package
+    /// over an arbitrary same-named class elsewhere in the workspace (same
+    /// reachability rule as `find_fun_return_type`). Preserves generic
+    /// parameters so that `extract_collection_element_type` can extract the
+    /// element type.
     ///
     /// Example: `class_name = "ResponseBody"`, `field_name = "availableBanks"` →
     /// `Some("MutableList<MultibankingBank>")`.
     ///
     /// Returns `None` when the class or field is not found.
     /// Default implementation returns `None`; overridden by `Indexer`.
-    fn find_field_type(&self, _class_name: &str, _field_name: &str) -> Option<String> {
+    fn find_field_type(&self, _class_name: &str, _field_name: &str, _uri: &Url) -> Option<String> {
         None
     }
 
@@ -445,7 +448,7 @@ impl InferDeps for TestDeps {
             .get(&(uri.to_string(), var_name.to_string()))
             .cloned()
     }
-    fn find_field_type(&self, class_name: &str, field_name: &str) -> Option<String> {
+    fn find_field_type(&self, class_name: &str, field_name: &str, _uri: &Url) -> Option<String> {
         self.field_types
             .get(&(class_name.to_string(), field_name.to_string()))
             .cloned()

--- a/src/indexer/infer/expr_type.rs
+++ b/src/indexer/infer/expr_type.rs
@@ -224,7 +224,7 @@ fn infer_navigation_expr_type(
             .or_else(|| deps.find_fun_return_type(&member, uri));
     }
 
-    deps.find_field_type(&receiver_type, &member)
+    deps.find_field_type(&receiver_type, &member, uri)
 }
 
 // ─── navigation tree-walking helpers ─────────────────────────────────────────

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -2230,8 +2230,15 @@ fn lambda_param_dotted_nested_class_chain() {
     );
 
     // Step 2: find_field_type_in_class("Success", "value") should return "T"
-    let field_type = crate::resolver::infer::find_field_type_in_class(&idx, "Success", "value");
-    assert_eq!(field_type.as_deref(), Some("T"), "step2: raw field type");
+    let field_type =
+        crate::resolver::infer::find_field_type_in_class(&idx, "Success", "value", &vm_uri);
+    assert_eq!(
+        field_type
+            .map(|(field_type, _declaring_uri)| field_type)
+            .as_deref(),
+        Some("T"),
+        "step2: raw field type"
+    );
 
     // Step 3: find_method_return_type("Optional", "getOrNull") returns "T" (? stripped by extract_type_with_generics)
     let method_ret =
@@ -2574,21 +2581,21 @@ fn cst_named_lambda_param_scope_fun_substitutes_receiver() {
 #[test]
 fn synthetic_enum_entries_field_type() {
     let (_, idx) = indexed("/Color.kt", "enum class Color { RED, GREEN, BLUE }");
-    let ty = idx.find_field_type("Color", "entries");
+    let ty = idx.find_field_type("Color", "entries", &uri("/Color.kt"));
     assert_eq!(ty.as_deref(), Some("List<Color>"));
 }
 
 #[test]
 fn synthetic_enum_name_field_type() {
     let (_, idx) = indexed("/Color.kt", "enum class Color { RED, GREEN, BLUE }");
-    let ty = idx.find_field_type("Color", "name");
+    let ty = idx.find_field_type("Color", "name", &uri("/Color.kt"));
     assert_eq!(ty.as_deref(), Some("String"));
 }
 
 #[test]
 fn synthetic_enum_ordinal_field_type() {
     let (_, idx) = indexed("/Color.kt", "enum class Color { RED, GREEN, BLUE }");
-    let ty = idx.find_field_type("Color", "ordinal");
+    let ty = idx.find_field_type("Color", "ordinal", &uri("/Color.kt"));
     assert_eq!(ty.as_deref(), Some("Int"));
 }
 
@@ -2609,7 +2616,7 @@ fn synthetic_enum_valueof_method() {
 #[test]
 fn synthetic_not_applied_to_non_enum() {
     let (_, idx) = indexed("/Foo.kt", "class Foo { val entries: String = \"\" }");
-    let ty = idx.find_field_type("Foo", "entries");
+    let ty = idx.find_field_type("Foo", "entries", &uri("/Foo.kt"));
     // Should resolve from actual source, not synthetic
     assert_ne!(ty.as_deref(), Some("List<Foo>"));
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,21 +7,22 @@ use tree_sitter::{Node, Parser, Query, QueryCursor, StreamingIterator};
 
 use crate::indexer::NodeExt;
 use crate::queries::{
-    self, KIND_ANNOTATION_TYPE_DECL, KIND_CALLABLE_REF, KIND_CALL_EXPR, KIND_CALL_SUFFIX,
-    KIND_CLASS_BODY, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ, KIND_COMPUTED_PROPERTY,
-    KIND_CTOR_DECL, KIND_DELEGATION_SPEC, KIND_ENUM_CONSTANT, KIND_ENUM_DECL, KIND_EQ,
-    KIND_EXTENDS_INTERFACES, KIND_EXTENSION_KW, KIND_FIELD_DECL, KIND_FORMAL_PARAM,
-    KIND_FORMAL_PARAMS, KIND_FUNCTION_TYPE, KIND_FUN_BODY, KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS,
-    KIND_IDENTIFIER, KIND_IMPORT_ALIAS, KIND_IMPORT_DECL, KIND_IMPORT_HEADER, KIND_IMPORT_LIST,
-    KIND_INFIX_EXPR, KIND_INHERITANCE_SPEC, KIND_INHERITANCE_SPECS, KIND_INIT_DECL,
-    KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_LPAREN, KIND_METHOD_DECL, KIND_MODIFIERS,
-    KIND_MOD_FINAL, KIND_MOD_STATIC, KIND_NAV_EXPR, KIND_NULLABLE_TYPE, KIND_OBJECT_DECL,
-    KIND_PACKAGE_DECL, KIND_PACKAGE_HEADER, KIND_PARAMETER, KIND_PREFIX_EXPR, KIND_PRIMARY_CTOR,
-    KIND_PROP_DECL, KIND_PROP_DELEGATE, KIND_PROTOCOL_DECL, KIND_PROTOCOL_FUNC_DECL,
-    KIND_RECEIVER_TYPE, KIND_RECORD_DECL, KIND_SCOPED_IDENT, KIND_SECONDARY_CTOR,
-    KIND_SIMPLE_IDENT, KIND_SOURCE_FILE, KIND_STATEMENTS, KIND_SUPERCLASS, KIND_SUPER_INTERFACES,
-    KIND_TYPE_IDENT, KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VALUE_ARGS, KIND_VAR_DECL,
-    KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
+    self, KIND_ANNOTATION_TYPE_DECL, KIND_BINDING_PATTERN_KIND, KIND_CALLABLE_REF, KIND_CALL_EXPR,
+    KIND_CALL_SUFFIX, KIND_CLASS_BODY, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ,
+    KIND_COMPUTED_PROPERTY, KIND_CTOR_DECL, KIND_DELEGATION_SPEC, KIND_ENUM_CONSTANT,
+    KIND_ENUM_DECL, KIND_EQ, KIND_EXTENDS_INTERFACES, KIND_EXTENSION_KW, KIND_FIELD_DECL,
+    KIND_FORMAL_PARAM, KIND_FORMAL_PARAMS, KIND_FUNCTION_TYPE, KIND_FUN_BODY, KIND_FUN_DECL,
+    KIND_FUN_VALUE_PARAMS, KIND_IDENTIFIER, KIND_IMPORT_ALIAS, KIND_IMPORT_DECL,
+    KIND_IMPORT_HEADER, KIND_IMPORT_LIST, KIND_INFIX_EXPR, KIND_INHERITANCE_SPEC,
+    KIND_INHERITANCE_SPECS, KIND_INIT_DECL, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_LPAREN,
+    KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MOD_FINAL, KIND_MOD_STATIC, KIND_NAV_EXPR,
+    KIND_NULLABLE_TYPE, KIND_OBJECT_DECL, KIND_PACKAGE_DECL, KIND_PACKAGE_HEADER, KIND_PARAMETER,
+    KIND_PREFIX_EXPR, KIND_PRIMARY_CTOR, KIND_PROP_DECL, KIND_PROP_DELEGATE, KIND_PROTOCOL_DECL,
+    KIND_PROTOCOL_FUNC_DECL, KIND_RECEIVER_TYPE, KIND_RECORD_DECL, KIND_SCOPED_IDENT,
+    KIND_SECONDARY_CTOR, KIND_SIMPLE_IDENT, KIND_SOURCE_FILE, KIND_STATEMENTS, KIND_SUPERCLASS,
+    KIND_SUPER_INTERFACES, KIND_TYPE_IDENT, KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VALUE_ARGS,
+    KIND_VAR_DECL, KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT, KOTLIN_DEFINITIONS,
+    SWIFT_DEFINITIONS,
 };
 use crate::StrExt;
 
@@ -2337,6 +2338,35 @@ impl crate::types::FileData {
     fn extract_rhs_types_kotlin(&mut self, root: Node, bytes: &[u8]) {
         let mut stack = vec![root];
         while let Some(node) = stack.pop() {
+            if node.kind() == KIND_CLASS_PARAM {
+                // A primary-constructor `val`/`var` param is a real field, same as a
+                // `property_declaration` — record it into `type_annotations` too, on
+                // its own line, so `find_field_type_in_class` can prefer the field
+                // declared on the specific class location it was asked about over an
+                // unrelated same-named field on some other class earlier in the file
+                // (data classes are typically one-liners, so a plain first-match scan
+                // over the whole file picks whichever sibling happens to come first —
+                // see `infer::infer_field_type_raw`'s `near_line` parameter).
+                if node
+                    .first_child_of_kind(KIND_BINDING_PATTERN_KIND)
+                    .is_some()
+                {
+                    if let Some(name) = node
+                        .first_child_of_kind(KIND_SIMPLE_IDENT)
+                        .and_then(|identifier| identifier.utf8_text_owned(bytes))
+                    {
+                        let type_node = node
+                            .first_child_of_kind(KIND_USER_TYPE)
+                            .or_else(|| node.first_child_of_kind(KIND_NULLABLE_TYPE));
+                        if let Some(type_node) = type_node {
+                            if let Some(type_text) = type_node.utf8_text_owned(bytes) {
+                                let line = node.start_position().row as u32;
+                                self.type_annotations.push((line, name, type_text));
+                            }
+                        }
+                    }
+                }
+            }
             if node.kind() == KIND_PROP_DECL {
                 if let Some(var_decl) = node.first_child_of_kind(KIND_VAR_DECL) {
                     if var_decl.named_child_count() == 1 {

--- a/src/resolver/api.rs
+++ b/src/resolver/api.rs
@@ -103,9 +103,24 @@ pub(crate) trait Resolver {
     /// each declared field type. The leaf field's trailing `?` is preserved in
     /// [`ReceiverType::nullable`].
     ///
+    /// `line` is a fallback used only when `cst_point` is `None` or no prefix
+    /// of `chain` is smart-cast-narrowed. `cst_point`, when given, is the
+    /// chain expression's own CST node plus source bytes, used to find
+    /// smart-cast narrowing over the *whole stable path* (not just the root
+    /// variable) — see `infer::infer_field_chain_type`.
+    ///
     /// Returns `None` if the chain has fewer than two segments or any segment's
-    /// type cannot be resolved.
-    fn infer_field_chain_type(&self, chain: &[String], uri: &Url) -> Option<ReceiverType>;
+    /// type cannot be resolved. The returned `Url` is the file that declares
+    /// the leaf type — see `infer::infer_field_chain_type` for why a caller
+    /// resolving anything further about the returned type must use it instead
+    /// of its own `uri`.
+    fn infer_field_chain_type<'tree>(
+        &self,
+        chain: &[String],
+        uri: &Url,
+        line: u32,
+        cst_point: Option<(tree_sitter::Node<'tree>, &'tree [u8])>,
+    ) -> Option<(ReceiverType, Url)>;
 
     /// Resolve `member` accessed through `qualifier` — a variable name
     /// (`"repo"`) or a pure field chain (`"arg.texts"`) — to its declaration
@@ -172,8 +187,14 @@ impl Resolver for Indexer {
         infer_receiver_type(self, receiver, uri)
     }
 
-    fn infer_field_chain_type(&self, chain: &[String], uri: &Url) -> Option<ReceiverType> {
-        infer_field_chain_type(self, chain, uri)
+    fn infer_field_chain_type<'tree>(
+        &self,
+        chain: &[String],
+        uri: &Url,
+        line: u32,
+        cst_point: Option<(tree_sitter::Node<'tree>, &'tree [u8])>,
+    ) -> Option<(ReceiverType, Url)> {
+        infer_field_chain_type(self, chain, uri, line, cst_point)
     }
 
     fn resolve_member(&self, member: &str, qualifier: &str, uri: &Url) -> Definitions {

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -437,10 +437,17 @@ pub(crate) fn subject_segments(node: tree_sitter::Node, source: &[u8]) -> Option
         Some(())
     }
 
-    // `when_subject` wraps its expression in `"(" <expression> ")"`; a bare
-    // identifier/nav-expression node (as passed by other callers) has no such
-    // wrapper, so just try every child plus the node itself.
-    for candidate in node.children(&mut node.walk()).chain(std::iter::once(node)) {
+    // A bare identifier/nav-expression node (as passed by a caller that
+    // already resolved down to the expression itself) needs no unwrapping —
+    // check it before its children. Only `when_subject` wraps its expression
+    // in `"(" <expression> ")"`, so its own kind never matches here and the
+    // loop below finds the wrapped expression among its children instead.
+    // Checking the node first (not last) matters: a `navigation_expression`
+    // node's *own* children include its receiver sub-expression, which can
+    // itself be `KIND_SIMPLE_IDENT`/`KIND_NAV_EXPR` — finding that child
+    // first would silently return just the receiver's segments, a prefix of
+    // the real chain, instead of the whole thing.
+    for candidate in std::iter::once(node).chain(node.children(&mut node.walk())) {
         if matches!(candidate.kind(), KIND_SIMPLE_IDENT | KIND_NAV_EXPR) {
             let mut segments = Vec::new();
             collect(candidate, source, &mut segments, 0)?;

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -1,6 +1,6 @@
 use tower_lsp::lsp_types::{Location, Position, SymbolKind, Url};
 
-use crate::indexer::{Indexer, InferDeps};
+use crate::indexer::{Indexer, InferDeps, NodeExt};
 use crate::types::FileData;
 use crate::LinesExt;
 use crate::StrExt;
@@ -134,20 +134,79 @@ pub(crate) fn infer_receiver_type(
 ///
 /// Returns `None` if the chain has no field segment (`segments.len() < 2`) or
 /// any segment's type can't be resolved. Used by the nullable-dot-call
-/// diagnostic to flag `holder.repo.load()` where `repo` is a nullable field.
+/// diagnostic to flag `holder.repo.load()` where `repo` is a nullable field,
+/// and by the `when`-exhaustiveness diagnostic for a chained subject like
+/// `event.event`.
+///
+/// `line` is the 0-based line of the chain expression itself, used only as a
+/// fallback (see below). `cst_point`, when given, is the chain expression's
+/// own CST node plus source bytes — Kotlin smart-casts a whole *stable path*,
+/// not just a simple variable (`when (event.events) { is X -> when
+/// (event.events) { ... } }` narrows the entire path `event.events`, not just
+/// `event`), so with a CST node this finds whatever prefix of `segments` an
+/// enclosing `when` narrows via [`enclosing_smart_cast_type`] and starts the
+/// field walk from there (an exact whole-chain match walks zero further
+/// fields). Without a CST node — or when no prefix matches — falls back to
+/// the much narrower line-scanning `smart_cast_narrowed_type` (root only) and
+/// then the plain declared type.
+///
+/// The returned `Url` is the file that declares the *leaf* type — the correct
+/// reachability context for resolving anything about that type further (e.g.
+/// its own members via `resolve::resolve_type_index_only`). A caller that
+/// keeps using its own `uri` for that instead reintroduces exactly the bug
+/// this function exists to avoid: the leaf type can be a class duplicated
+/// workspace-wide, reachable only through the chain (never imported by the
+/// original caller directly), so only the leaf's own declaring file's
+/// imports/package can disambiguate it.
 pub(crate) fn infer_field_chain_type(
     indexer: &Indexer,
     segments: &[String],
     uri: &Url,
-) -> Option<ReceiverType> {
+    line: u32,
+    cst_point: Option<(tree_sitter::Node, &[u8])>,
+) -> Option<(ReceiverType, Url)> {
     if segments.len() < 2 {
         return None;
     }
-    let root = segments.first()?;
-    // Root variable's base type (generics + `?` already stripped), e.g. "Holder".
-    let mut current = infer_variable_type(indexer, root, uri)?;
+    // Find the prefix of `segments` that's smart-cast-narrowed (if any), and
+    // the type it narrows to — the un-narrowed declared type would send the
+    // field lookup below down the wrong, far more collision-prone bare-name
+    // class (see `smart_cast_narrowed_type` doc comment).
+    let (narrowed_prefix_len, mut current) = 'narrowed: {
+        if let Some((point, source)) = cst_point {
+            if let Some((narrowed_type, prefix_len)) =
+                enclosing_smart_cast_type(point, segments, source)
+            {
+                break 'narrowed (prefix_len, narrowed_type);
+            }
+        }
+        // No prefix is smart-cast-narrowed — fall back to the root's plain
+        // declared type. With a CST node, prefer the scope-correct
+        // `resolve_declared_type_from_cst` (a whole-file scan can find an
+        // unrelated same-named parameter/local in a *different* function —
+        // see its own doc comment) before the line-scanning smart-cast check
+        // and the unscoped whole-file scan.
+        let root = segments.first()?;
+        let declared_type = match cst_point {
+            Some((point, source)) => resolve_declared_type_from_cst(point, root, source)
+                .or_else(|| smart_cast_narrowed_type(indexer, root, uri, line))
+                .or_else(|| infer_variable_type(indexer, root, uri))?,
+            None => smart_cast_narrowed_type(indexer, root, uri, line)
+                .or_else(|| infer_variable_type(indexer, root, uri))?,
+        };
+        (1, declared_type)
+    };
+    // The file whose imports/package govern the *next* lookup's reachability.
+    // Starts as the caller's own file (correct for the root: its declared type
+    // is reachable from wherever it's declared/used) and is updated to each
+    // resolved class's own declaring file as the chain descends — a field's
+    // type must resolve through the *declaring class's* imports, not the
+    // original caller's (see `find_field_type_in_class`). A *qualified*
+    // narrowed type (`Event.OverdraftInput`) carries its own reachability
+    // signal, resolved here up front.
+    let mut reachability_uri = declaring_uri_for_type(indexer, &current, uri);
     let mut leaf_raw = current.clone();
-    for field in &segments[1..] {
+    for field in &segments[narrowed_prefix_len..] {
         // Reduce the running type to a bare class name for the field lookup:
         // drop generics, any package/outer qualifier, and a trailing `?`.
         let class_base = current
@@ -158,11 +217,13 @@ pub(crate) fn infer_field_chain_type(
             .next()
             .unwrap_or(&current)
             .strip_nullable();
-        let field_raw = find_field_type_in_class(indexer, class_base, field)?;
+        let (field_raw, declaring_uri) =
+            find_field_type_in_class(indexer, class_base, field, &reachability_uri)?;
         current = field_raw.clone();
         leaf_raw = field_raw;
+        reachability_uri = declaring_uri;
     }
-    Some(ReceiverType::from_raw(leaf_raw))
+    Some((ReceiverType::from_raw(leaf_raw), reachability_uri))
 }
 
 /// Like [`infer_receiver_type`] but checks smart-cast narrowing at the given
@@ -174,31 +235,363 @@ pub(crate) fn infer_receiver_type_at(
     uri: &Url,
     position: Position,
 ) -> Option<ReceiverType> {
+    if let Some(narrowed) = smart_cast_narrowed_type(indexer, name, uri, position.line) {
+        return Some(ReceiverType::from_raw(narrowed));
+    }
+    // Fallback to normal inference
+    infer_receiver_type(indexer, ReceiverKind::Variable(name), uri)
+}
+
+/// If `name` is the subject of an enclosing `when (name) { is Type -> ... }`
+/// branch or `if (name is Type)` block at `line`, returns the narrowed type —
+/// the *static* declared type of `name` (e.g. a sealed interface) is wrong
+/// inside such a branch, and callers that skip this and use the declared type
+/// instead risk a far more collision-prone bare-name class lookup downstream
+/// (a common sealed-interface name like `Event` can match dozens of unrelated
+/// classes workspace-wide; the narrowed subtype name rarely does).
+fn smart_cast_narrowed_type(indexer: &Indexer, name: &str, uri: &Url, line: u32) -> Option<String> {
     use super::infer_lines::SmartCast;
 
-    // Try smart cast narrowing first when lines are available.
     let lines = indexer
         .live_lines
         .get(uri.as_str())
         .map(|ll| (*ll).clone())
-        .or_else(|| indexer.files.get(uri.as_str()).map(|d| d.lines.clone()));
-    if let Some(lines) = lines {
-        let narrowed =
-            match super::infer_lines::smart_cast_type_at_line(&lines, name, position.line) {
-                Some(SmartCast::TypeTest(type_name)) => Some(type_name),
-                // Only an object's own name is also a type; an enum entry or a
-                // constant matches by value and leaves the subject's type alone.
-                Some(SmartCast::ObjectEquality(label)) => {
-                    names_object_declaration(indexer, &label, uri).then_some(label)
-                }
-                None => None,
-            };
-        if let Some(narrowed) = narrowed {
-            return Some(ReceiverType::from_raw(narrowed));
+        .or_else(|| indexer.files.get(uri.as_str()).map(|d| d.lines.clone()))?;
+    match super::infer_lines::smart_cast_type_at_line(&lines, name, line)? {
+        SmartCast::TypeTest(type_name) => Some(type_name),
+        // Only an object's own name is also a type; an enum entry or a
+        // constant matches by value and leaves the subject's type alone.
+        SmartCast::ObjectEquality(label) => {
+            names_object_declaration(indexer, &label, uri).then_some(label)
         }
     }
-    // Fallback to normal inference
-    infer_receiver_type(indexer, ReceiverKind::Variable(name), uri)
+}
+
+/// Real Kotlin smart-cast subjects (`event`, `event.events`) are never more
+/// than a handful of segments, so bailing out for anything longer is free —
+/// a defensive bound on [`enclosing_smart_cast_type`]'s input, independent of
+/// the tree-depth cost documented on its own `Node::parent()` warning: a
+/// long segment count does *not* imply `point` is deeply nested (for a
+/// left-recursive chain `a.b0.b1…`, it's the *opposite* — the longest-chain
+/// node is the outermost, shallowest one), so this bound alone would not
+/// have protected the pathological-chain case that motivated it. That case
+/// was fixed at the call site instead (`nullable_call_diagnostics` stopped
+/// passing a CST point) — see `enclosing_smart_cast_type`'s doc comment.
+const MAX_SMART_CAST_CHAIN_LEN: usize = 16;
+
+/// CST-based counterpart to [`smart_cast_narrowed_type`]: if `point` sits
+/// inside an immediately-enclosing `when (subject) { is Type -> ... }` branch
+/// whose subject is exactly `target_segments` (a bare variable `["event"]` or
+/// a stable dotted path `["event", "events"]` — Kotlin smart-casts a whole
+/// property path, not just a simple variable), returns `Type` in full (e.g.
+/// `"Event.OverdraftInput"` from `is Event.OverdraftInput ->`) — the
+/// qualifier matters: it lets `resolve_type_index_only` resolve `Event`
+/// reachability-first, then find `OverdraftInput` scoped to *that* file,
+/// rather than a flat bare-name scan for `OverdraftInput` alone (which can't
+/// disambiguate if the enclosing `Event` itself is duplicated under two
+/// same-named outer types in different packages, e.g. two contracts each
+/// declaring their own `Event`).
+///
+/// Unlike the line-scanning heuristic in `infer_lines::smart_cast_type_at_line`
+/// — which recovers `when`-branch nesting from indented text and can be fooled
+/// by a *sibling* branch that also happens to contain its own nested
+/// `when (...)` sharing the same subject — this walks real tree-sitter parent
+/// pointers, which only ever reach `point`'s true ancestors. Callers with a
+/// CST node in hand should prefer this over `smart_cast_narrowed_type`.
+///
+/// Handles only a `when (subject) { is Type -> ... }` type test — not
+/// `if (subject is Type)` or object-equality branches — matching the shape
+/// every current caller needs; extend if a caller needs those too.
+///
+/// Walks *multiple* enclosing `when` levels outward, not just the immediate
+/// one: a `when`'s own subject can be a *different, unrelated* path than
+/// `target_segments` (e.g. an ancestor `when (foo)` while querying
+/// `["event", "events"]`), in which case that level doesn't narrow
+/// `target_segments` at all and the search must continue past it to whichever
+/// ancestor `when` actually has (a prefix of) `target_segments` as its
+/// subject (real shape this guards: `is Banner -> when (event.events) { is X
+/// -> when (event.events) { ... } }` — the innermost level's own subject
+/// `event.events` already matches the whole 2-segment target directly; a
+/// query for just `["event"]` from a *different* nested spot would instead
+/// need to see through an `event.events`-subject level in between to reach an
+/// outer `when (event)`'s narrowing).
+///
+/// Each ancestor level is checked exactly once — a level's subject is
+/// whatever length it naturally is, so it can only ever match the
+/// correspondingly-sized prefix of `target_segments`; there's no need to
+/// separately try shorter prefixes at the same level (an earlier version of
+/// this function did, making the walk `O(depth × segments.len())` per call).
+///
+/// **Costly per call from a deep node — `Node::parent()` is not a stored
+/// pointer.** Unlike a bounded-recursion walk (`pure_field_chain_at`,
+/// `collect_navigation_segments`), tree-sitter's `Node::parent()` is
+/// `O(depth from root)` internally, every call, regardless of how many hops
+/// the caller intends to make (see `Node::parent` in tree-sitter's
+/// `node.c`). One call from a node 5,000 levels deep already costs
+/// `O(5000)`; a caller that calls this once per node while walking a whole
+/// deep tree pays that cost once per node, making the *whole walk*
+/// quadratic. `MAX_SMART_CAST_CHAIN_LEN` bounds `target_segments.len()` as a
+/// cheap sanity check, but does **not** by itself bound `point`'s depth — a
+/// short segment count doesn't imply a shallow node (see that constant's own
+/// doc comment). **Only call this from a position that's known to be
+/// shallow** (e.g. `fill_when`'s one call per `when` node — a `when`
+/// expression itself is never deeply nested even when its subject chain is);
+/// a caller that might invoke this once per node of a deep chain must not
+/// pass a CST point at all (`nullable_call_diagnostics` doesn't, precisely
+/// for this reason) — see `nullable_diagnostics_survives_a_pathologically_deep_field_chain`,
+/// the regression test that caught this the first time it was tried.
+///
+/// Returns the narrowed type together with how many leading segments of
+/// `target_segments` it covers, so the caller knows how many (if any) remain
+/// to walk as plain fields.
+pub(crate) fn enclosing_smart_cast_type(
+    point: tree_sitter::Node,
+    target_segments: &[String],
+    source: &[u8],
+) -> Option<(String, usize)> {
+    use crate::queries::{
+        KIND_TYPE_IDENT, KIND_TYPE_TEST, KIND_USER_TYPE, KIND_WHEN_CONDITION, KIND_WHEN_ENTRY,
+        KIND_WHEN_EXPR, KIND_WHEN_SUBJECT,
+    };
+
+    if target_segments.len() > MAX_SMART_CAST_CHAIN_LEN {
+        return None;
+    }
+
+    let mut current = point;
+    for _ in 0..crate::util::MAX_CST_DESCENT_DEPTH {
+        let when_entry = ancestor_of_kind(current, KIND_WHEN_ENTRY)?;
+        let owning_when = ancestor_of_kind(when_entry, KIND_WHEN_EXPR)?;
+        let subject = owning_when
+            .children(&mut owning_when.walk())
+            .find(|child| child.kind() == KIND_WHEN_SUBJECT)?;
+
+        let consumed = subject_segments(subject, source).filter(|subject_segments| {
+            !subject_segments.is_empty()
+                && subject_segments.len() <= target_segments.len()
+                && subject_segments.as_slice() == &target_segments[..subject_segments.len()]
+        });
+        if let Some(consumed) = consumed {
+            let condition = when_entry
+                .children(&mut when_entry.walk())
+                .find(|child| child.kind() == KIND_WHEN_CONDITION)?;
+            let type_test = condition
+                .children(&mut condition.walk())
+                .find(|child| child.kind() == KIND_TYPE_TEST)?;
+            let user_type = type_test.first_child_of_kind(KIND_USER_TYPE)?;
+            let identifiers: Vec<&str> = user_type
+                .children(&mut user_type.walk())
+                .filter(|child| child.kind() == KIND_TYPE_IDENT)
+                .map(|child| child.utf8_text(source))
+                .collect::<Result<_, _>>()
+                .ok()?;
+            if identifiers.is_empty() {
+                return None;
+            }
+            return Some((identifiers.join("."), consumed.len()));
+        }
+
+        // This level's subject isn't a prefix of `target_segments` (a
+        // different variable, or a different path) — it doesn't narrow it;
+        // keep looking further out.
+        current = owning_when;
+    }
+    crate::util::report_cst_depth_exceeded!("enclosing_smart_cast_type", point);
+    None
+}
+
+/// The identifier chain of a `when_subject` (or any node wrapping a plain
+/// identifier / dotted navigation expression): `state` → `["state"]`,
+/// `event.events` → `["event", "events"]`. `None` for anything else (a call,
+/// an index, a literal) — those need real expression inference, not a name
+/// chain. Depth-bounded like [`enclosing_smart_cast_type`]'s own walk.
+///
+/// The one shared implementation — `fill_when::analyze_when` uses this
+/// directly for its own subject-segment extraction rather than re-deriving
+/// it, so there's a single CST chain-flattening walk instead of two.
+pub(crate) fn subject_segments(node: tree_sitter::Node, source: &[u8]) -> Option<Vec<String>> {
+    use crate::queries::{KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_SIMPLE_IDENT};
+
+    fn collect(
+        node: tree_sitter::Node,
+        source: &[u8],
+        out: &mut Vec<String>,
+        depth: usize,
+    ) -> Option<()> {
+        if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
+            crate::util::report_cst_depth_exceeded!("subject_segments", node);
+            return None;
+        }
+        match node.kind() {
+            KIND_SIMPLE_IDENT => out.push(node.utf8_text(source).ok()?.to_owned()),
+            KIND_NAV_EXPR | KIND_NAV_SUFFIX => {
+                for child in node.children(&mut node.walk()) {
+                    // The `.` separator carries no segment of its own.
+                    if child.kind() != "." {
+                        collect(child, source, out, depth + 1)?;
+                    }
+                }
+            }
+            _ => return None,
+        }
+        Some(())
+    }
+
+    // `when_subject` wraps its expression in `"(" <expression> ")"`; a bare
+    // identifier/nav-expression node (as passed by other callers) has no such
+    // wrapper, so just try every child plus the node itself.
+    for candidate in node.children(&mut node.walk()).chain(std::iter::once(node)) {
+        if matches!(candidate.kind(), KIND_SIMPLE_IDENT | KIND_NAV_EXPR) {
+            let mut segments = Vec::new();
+            collect(candidate, source, &mut segments, 0)?;
+            return Some(segments);
+        }
+    }
+    None
+}
+
+/// Walk `node`'s ancestors (not itself) for the nearest one of `kind`.
+fn ancestor_of_kind<'tree>(
+    node: tree_sitter::Node<'tree>,
+    kind: &str,
+) -> Option<tree_sitter::Node<'tree>> {
+    let mut current = node.parent();
+    while let Some(candidate) = current {
+        if candidate.kind() == kind {
+            return Some(candidate);
+        }
+        current = candidate.parent();
+    }
+    None
+}
+
+/// Resolve `var_name`'s *declared* type by walking up from `point` through the
+/// CST — sibling `val`/`var` declarations in the same statement block, then
+/// the enclosing function's parameters, then the enclosing class's primary
+/// constructor parameters — stopping at the first match.
+///
+/// This is scope-correct where a whole-file text/line scan (`infer_variable_type`)
+/// is not: a file with many functions can have several unrelated parameters or
+/// locals named the same thing (`event`, `state`, …), and a whole-file scan has
+/// no way to prefer the one actually in scope at `point`. Callers with a CST
+/// node in hand should try this first and fall back to `infer_variable_type`
+/// only when it finds nothing (e.g. `var_name` comes from an outer/captured
+/// scope this walk doesn't reach).
+pub(crate) fn resolve_declared_type_from_cst(
+    point: tree_sitter::Node,
+    var_name: &str,
+    source: &[u8],
+) -> Option<String> {
+    use crate::queries::{
+        KIND_BOOLEAN_LITERAL, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_FUN_DECL,
+        KIND_FUN_VALUE_PARAMS, KIND_NULLABLE_TYPE, KIND_PARAMETER, KIND_PRIMARY_CTOR,
+        KIND_PROP_DECL, KIND_SIMPLE_IDENT, KIND_STATEMENTS, KIND_TYPE_IDENT, KIND_USER_TYPE,
+        KIND_VAR_DECL,
+    };
+
+    fn full_type_name(user_type: tree_sitter::Node, source: &[u8]) -> Option<String> {
+        let parts: Vec<&str> = user_type
+            .children(&mut user_type.walk())
+            .filter(|child| child.kind() == KIND_TYPE_IDENT)
+            .map(|child| child.utf8_text(source))
+            .collect::<Result<_, _>>()
+            .ok()?;
+        (!parts.is_empty()).then(|| parts.join("."))
+    }
+
+    fn type_from_nullable(nullable: tree_sitter::Node, source: &[u8]) -> Option<String> {
+        nullable
+            .first_child_of_kind(KIND_USER_TYPE)
+            .and_then(|user_type| full_type_name(user_type, source))
+    }
+
+    // Shared by a `parameter`/`class_parameter` node (`name: Type`) and a
+    // `variable_declaration` node (same shape, plus an inferred-Boolean case
+    // for `val x = false`/`true` handled by the caller).
+    fn type_after_matching_name(
+        node: tree_sitter::Node,
+        var_name: &str,
+        source: &[u8],
+    ) -> Option<String> {
+        let mut name_matched = false;
+        for child in node.children(&mut node.walk()) {
+            if child.kind() == KIND_SIMPLE_IDENT && child.utf8_text(source).ok() == Some(var_name) {
+                name_matched = true;
+            }
+            if name_matched {
+                if child.kind() == KIND_USER_TYPE {
+                    return full_type_name(child, source);
+                }
+                if child.kind() == KIND_NULLABLE_TYPE {
+                    return type_from_nullable(child, source);
+                }
+            }
+        }
+        None
+    }
+
+    fn find_in_sibling_declarations(
+        statements: tree_sitter::Node,
+        var_name: &str,
+        source: &[u8],
+    ) -> Option<String> {
+        statements
+            .children(&mut statements.walk())
+            .filter(|child| child.kind() == KIND_PROP_DECL)
+            .find_map(|prop| {
+                let var_decl = prop.first_child_of_kind(KIND_VAR_DECL)?;
+                type_after_matching_name(var_decl, var_name, source).or_else(|| {
+                    // `val x = false`/`true` — no annotation, inferred Boolean.
+                    let name_matches = var_decl
+                        .first_child_of_kind(KIND_SIMPLE_IDENT)
+                        .and_then(|ident| ident.utf8_text(source).ok())
+                        == Some(var_name);
+                    let has_boolean_literal = prop
+                        .children(&mut prop.walk())
+                        .any(|child| child.kind() == KIND_BOOLEAN_LITERAL);
+                    (name_matches && has_boolean_literal).then(|| "Boolean".to_owned())
+                })
+            })
+    }
+
+    fn find_in_parameters(
+        function_declaration: tree_sitter::Node,
+        var_name: &str,
+        source: &[u8],
+    ) -> Option<String> {
+        let params = function_declaration.first_child_of_kind(KIND_FUN_VALUE_PARAMS)?;
+        params
+            .children(&mut params.walk())
+            .filter(|child| child.kind() == KIND_PARAMETER)
+            .find_map(|param| type_after_matching_name(param, var_name, source))
+    }
+
+    fn find_in_constructor(
+        class_declaration: tree_sitter::Node,
+        var_name: &str,
+        source: &[u8],
+    ) -> Option<String> {
+        let primary_constructor = class_declaration.first_child_of_kind(KIND_PRIMARY_CTOR)?;
+        primary_constructor
+            .children(&mut primary_constructor.walk())
+            .filter(|child| child.kind() == KIND_CLASS_PARAM)
+            .find_map(|param| type_after_matching_name(param, var_name, source))
+    }
+
+    let mut current = point.parent();
+    while let Some(node) = current {
+        let found = match node.kind() {
+            KIND_STATEMENTS => find_in_sibling_declarations(node, var_name, source),
+            KIND_FUN_DECL => find_in_parameters(node, var_name, source),
+            KIND_CLASS_DECL => find_in_constructor(node, var_name, source),
+            _ => None,
+        };
+        if found.is_some() {
+            return found;
+        }
+        current = node.parent();
+    }
+    None
 }
 
 /// Whether the qualified `label` (e.g. `Ui.Loading`) names an `object`
@@ -399,7 +792,9 @@ fn infer_var_from_rhs_data(
                 .next()
                 .unwrap_or(recv_stripped)
                 .strip_nullable();
-            if let Some(field_type) = find_field_type_in_class(indexer, recv_base, &field) {
+            if let Some((field_type, _declaring_uri)) =
+                find_field_type_in_class(indexer, recv_base, &field, uri)
+            {
                 return Some(field_type);
             }
         }
@@ -584,31 +979,50 @@ pub(crate) fn infer_field_type(
 ///
 /// Returns `"MutableList<MbAccount>"` rather than `"MutableList"`, which is
 /// needed for collection element type extraction via `extract_collection_element_type`.
-/// Checks live editor lines first (most up-to-date), then CST type annotations,
-/// then falls back to indexed lines and finally to a disk read for un-indexed files.
+/// Checks live editor lines first (most up-to-date), then CST type
+/// annotations, then falls back to indexed lines and finally to a disk read
+/// for un-indexed files.
+///
+/// `near_line` is the 0-based line of the class declaration whose field is
+/// being looked up. `type_annotations` and every line-scan fallback here
+/// cover every field/parameter in the *whole file*, not just the one class —
+/// a sibling sealed-type member declared elsewhere in the same file with a
+/// field of the same name (a common MVI pattern: many `data class
+/// Foo(val event: FooEvent) : Event` variants side by side) would otherwise
+/// shadow the real field via first-match. Every source here is disambiguated
+/// against `near_line`: `type_annotations` (precise, per-declaration lines)
+/// by picking the entry closest to it; the line-scan fallbacks by bounding
+/// the scan to a window around it. Freshness still governs the *order*
+/// (`live_lines` — updated synchronously on every keystroke — before the
+/// debounced-reindex `type_annotations`/`data.lines`), so an edit to a
+/// field's own declaration is visible immediately rather than only after the
+/// next reindex settles; near_line-scoping on both sides is what keeps that
+/// freshness-first order from reintroducing the sibling-shadowing bug this
+/// function exists to avoid.
 pub(crate) fn infer_field_type_raw(
     indexer: &Indexer,
     file_uri: &str,
     field_name: &str,
+    near_line: u32,
 ) -> Option<String> {
     if let Some(live) = indexer.live_lines.get(file_uri) {
-        if let Some(result) = live.infer_type_raw(field_name) {
+        if let Some(result) = windowed_infer_type_raw(&live, field_name, near_line) {
             return Some(result);
         }
-        // Fall through — live lines didn't have a type annotation;
-        // check the indexed snapshot (indexer.files) which may have declarations
-        // from a different source set (e.g. sig vs code in tests, or a file
-        // that was indexed before the editor opened it live).
     }
     if let Some(data) = indexer.files.get(file_uri) {
         if let Some(ann) = data
             .type_annotations
             .iter()
-            .find(|(_, n, _)| n == field_name)
+            .filter(|(_, n, _)| n == field_name)
+            .min_by_key(|(line, _, _)| line.abs_diff(near_line))
         {
             return Some(ann.2.clone());
         }
-        return data.lines.infer_type_raw(field_name);
+        if let Some(result) = windowed_infer_type_raw(&data.lines, field_name, near_line) {
+            return Some(result);
+        }
+        return None;
     }
     let path = tower_lsp::lsp_types::Url::parse(file_uri)
         .ok()?
@@ -616,27 +1030,110 @@ pub(crate) fn infer_field_type_raw(
         .ok()?;
     let content = std::fs::read_to_string(&path).ok()?;
     let lines: Vec<String> = content.lines().map(String::from).collect();
-    lines.infer_type_raw(field_name)
+    windowed_infer_type_raw(&lines, field_name, near_line)
 }
 
+/// How far (in lines) around a class's own declaration to search for a field
+/// via plain text scanning — generous enough for a multi-line constructor or
+/// class body, far tighter than a whole file (where an unrelated sibling
+/// class's same-named field would otherwise win by proximity too, just less
+/// often than by first-match).
+const FIELD_LOOKUP_WINDOW: u32 = 20;
+
+fn windowed_infer_type_raw(lines: &[String], field_name: &str, near_line: u32) -> Option<String> {
+    let start = near_line.saturating_sub(FIELD_LOOKUP_WINDOW) as usize;
+    let end = ((near_line + FIELD_LOOKUP_WINDOW + 1) as usize).min(lines.len());
+    if start >= end {
+        return None;
+    }
+    // `infer_type_raw` (a pure per-line scan — no cross-line state, verified
+    // by `infer_type_in_lines_raw`'s own implementation) returns the FIRST
+    // match in the slice's order, not the closest one to `near_line`. Order
+    // the window by distance first so the first match found is the closest
+    // one — otherwise a sibling declaration earlier in the window (but
+    // farther from `near_line` than the real field) wins by file order, the
+    // exact sibling-shadowing bug this windowing exists to prevent. Mirrors
+    // the `type_annotations` path's `min_by_key` disambiguation.
+    let mut window_lines: Vec<usize> = (start..end).collect();
+    window_lines.sort_by_key(|&line| (line as u32).abs_diff(near_line));
+    let ordered: Vec<String> = window_lines
+        .into_iter()
+        .map(|line| lines[line].clone())
+        .collect();
+    ordered.infer_type_raw(field_name)
+}
+
+/// The file that declares `type_name`, resolved reachability-first from
+/// `from_uri`'s own imports/package (see `resolve::resolve_type_index_only`;
+/// handles a qualified `Outer.Inner` name too). Falls back to `from_uri`
+/// itself when `type_name` isn't qualified (nothing to resolve) or
+/// reachability resolution finds no candidate — a type genuinely declared in
+/// `from_uri`'s own file, or one with no useful reachability signal at all,
+/// is no worse off treated as anchored on the caller.
+///
+/// Shared by [`infer_field_chain_type`]'s root-anchoring and by callers that
+/// resolve a *whole* smart-cast-narrowed chain directly (see
+/// `enclosing_smart_cast_type`) and need the same reachability anchor for the
+/// type they get back.
+pub(crate) fn declaring_uri_for_type(indexer: &Indexer, type_name: &str, from_uri: &Url) -> Url {
+    if !type_name.contains('.') {
+        return from_uri.clone();
+    }
+    super::resolve::resolve_type_index_only(indexer, type_name, from_uri)
+        .into_iter()
+        .next()
+        .map(|location| location.uri)
+        .unwrap_or_else(|| from_uri.clone())
+}
+
+/// Resolve `field_name`'s declared type within `class_name`.
+///
+/// Candidate classes are found by name, preferring the declaration reachable
+/// from `from_uri`'s own imports/package — the same reachability chain used
+/// throughout the resolver (see `resolve::resolve_type_index_only`) — over an
+/// arbitrary same-named class elsewhere in the workspace. A common pattern
+/// this guards against: an MVI-style codebase where many unrelated features
+/// each declare their own `sealed interface Event` — a bare by-name scan
+/// picks whichever one the index happens to return first. Falls back to the
+/// unscoped by-name search (`Indexer::workspace_def_candidates`, capped) only
+/// when reachability resolution finds nothing, e.g. a class reached only
+/// through a chain with no import anywhere naming it directly.
+///
+/// Returns the field's type together with the `Url` of the file where
+/// `class_name` itself was found: the correct reachability context for
+/// resolving *that field's own* type is the class's declaring file, not
+/// necessarily `from_uri` — `Event.OverdraftInput.event: OverdraftInputEvent`
+/// must resolve `OverdraftInputEvent` via `OverdraftInput`'s own file's
+/// imports, which is why `infer_field_chain_type` re-anchors on this for the
+/// next chain segment.
 pub(crate) fn find_field_type_in_class(
     indexer: &Indexer,
     class_name: &str,
     field_name: &str,
-) -> Option<String> {
-    // Per-loc field inference is expensive; the helper scopes to workspace defs and
-    // caps the scan so a common class name with many source-JAR defs can't stall.
-    indexer
-        .find_in_workspace_defs(class_name, |loc| {
-            infer_field_type_raw(indexer, loc.uri.as_str(), field_name)
-        })
-        // Fallback: full variable inference including CST-indexed field_access_rhs
-        // and method_call_rhs data (handles unannotated `val x = recv.field`).
-        .or_else(|| {
-            indexer.find_in_workspace_defs(class_name, |loc| {
-                infer_variable_type_raw(indexer, field_name, &loc.uri)
-            })
-        })
+    from_uri: &Url,
+) -> Option<(String, Url)> {
+    let mut candidates = super::resolve::resolve_type_index_only(indexer, class_name, from_uri);
+    if candidates.is_empty() {
+        candidates = indexer.workspace_def_candidates(class_name);
+    }
+    for location in &candidates {
+        if let Some(field_type) = infer_field_type_raw(
+            indexer,
+            location.uri.as_str(),
+            field_name,
+            location.range.start.line,
+        ) {
+            return Some((field_type, location.uri.clone()));
+        }
+    }
+    // Fallback: full variable inference including CST-indexed field_access_rhs
+    // and method_call_rhs data (handles unannotated `val x = recv.field`).
+    for location in &candidates {
+        if let Some(field_type) = infer_variable_type_raw(indexer, field_name, &location.uri) {
+            return Some((field_type, location.uri.clone()));
+        }
+    }
+    None
 }
 
 // ─── Extension property type inference ───────────────────────────────────────

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -193,11 +193,14 @@ fn find_field_type_in_class_resolves_unannotated_field_access() {
     );
 
     // find_field_type_in_class should resolve through field_access_rhs fallback.
-    assert_eq!(
-        find_field_type_in_class(&idx, "RefreshDashboardInteractor", "triggers"),
-        Some("Flow<DashboardTrigger>".into()),
-        "find_field_type_in_class should resolve unannotated val with field_access_rhs"
-    );
+    let (field_type, _declaring_uri) = find_field_type_in_class(
+        &idx,
+        "RefreshDashboardInteractor",
+        "triggers",
+        &interactor_uri,
+    )
+    .expect("find_field_type_in_class should resolve unannotated val with field_access_rhs");
+    assert_eq!(field_type, "Flow<DashboardTrigger>");
 }
 
 #[test]

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -2,6 +2,43 @@ use super::super::infer_lines::{
     extract_property_type_from_detail, extract_return_type_from_detail, has_dot_after_first_call,
 };
 
+// Regression (Copilot review on PR #268): `subject_segments` checked a bare
+// node's *children* before the node itself, so a caller passing a
+// `navigation_expression` node directly (not wrapped in a `when_subject`)
+// would match on the receiver child found while iterating — returning just
+// the receiver's own segments, a truncated prefix of the real chain, instead
+// of the whole thing. Neither current caller triggers this (both always pass
+// a `when_subject`-wrapped node), but the function's own doc comment claims
+// to support a bare identifier/nav-expression node directly, so it must
+// actually work when called that way.
+#[test]
+fn subject_segments_returns_the_full_chain_for_a_bare_navigation_expression_node() {
+    use crate::indexer::Indexer;
+    use crate::queries::KIND_NAV_EXPR;
+    use tower_lsp::lsp_types::Url;
+
+    let uri = Url::parse("file:///Test.kt").unwrap();
+    let src = "fun test(event: Event) {\n    event.events\n}\n";
+    let idx = Indexer::new();
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+    let doc = idx.live_doc(&uri).expect("live doc should be stored");
+
+    // Find the (only) navigation_expression node — `event.events` — and pass
+    // it to `subject_segments` directly, bypassing any `when_subject` wrapper.
+    let nav_expr_node = crate::indexer::walk::descendants(doc.tree.root_node())
+        .find(|node| node.kind() == KIND_NAV_EXPR)
+        .expect("expected a navigation_expression node in the parsed source");
+
+    let segments = super::subject_segments(nav_expr_node, &doc.bytes)
+        .expect("a plain field-access chain should resolve to its segments");
+    assert_eq!(
+        segments,
+        vec!["event".to_string(), "events".to_string()],
+        "must return the full chain, not just the receiver's own segments"
+    );
+}
+
 #[test]
 fn return_type_simple() {
     assert_eq!(

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -968,9 +968,40 @@ fn resolve_qualified(
                 }
             }
 
-            let after_line = qual_loc.range.start.line;
-            let locs =
-                find_name_in_uri_after_line(indexer, name, qual_loc.uri.as_str(), after_line);
+            // Walk any remaining nested-type segments (`Event.OverdraftInput`
+            // has one: `OverdraftInput`) to that specific nested class's own
+            // location before searching for `name` — anchoring on `root`'s
+            // own line instead would just find whichever same-named sibling
+            // member happens to be textually closest to `root`'s declaration,
+            // not a member of the actually-requested nested type (see
+            // `find_name_in_uri_after_line`'s own doc comment: "we want the
+            // parameter/field of THAT class, not a same-named field in a
+            // different class that happens to appear earlier"). A real bug
+            // this fixes: an MVI sealed interface with many `data class Foo(val
+            // event: FooEvent) : Event`-shaped variants side by side — hovering
+            // `event.event` inside an `is Event.OverdraftInput ->` branch
+            // resolved to a *different* variant's `event` field, whichever one
+            // happened to sit closest to `Event`'s own declaration line.
+            let mut anchor = qual_loc.clone();
+            let mut nested_segments_resolved = true;
+            for &nested_segment in &segments[1..] {
+                match find_name_in_uri(indexer, nested_segment, anchor.uri.as_str())
+                    .into_iter()
+                    .next()
+                {
+                    Some(location) => anchor = location,
+                    None => {
+                        nested_segments_resolved = false;
+                        break;
+                    }
+                }
+            }
+            if !nested_segments_resolved {
+                continue;
+            }
+
+            let after_line = anchor.range.start.line;
+            let locs = find_name_in_uri_after_line(indexer, name, anchor.uri.as_str(), after_line);
             if !locs.is_empty() {
                 return locs;
             }

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -172,7 +172,12 @@ fn resolve_member_access(
                     .resolved()
             })
             .and_then(|receiver_type| {
-                member_token_type_for_receiver(indexer, receiver_type.as_type_str(), &member_name)
+                member_token_type_for_receiver(
+                    indexer,
+                    receiver_type.as_type_str(),
+                    &member_name,
+                    uri,
+                )
             });
         let method_type = type_index(&SemanticTokenType::METHOD);
         let property_type = type_index(&SemanticTokenType::PROPERTY);
@@ -393,11 +398,12 @@ fn member_token_type_for_receiver(
     indexer: &Indexer,
     receiver_type: &str,
     member_name: &str,
+    uri: &Url,
 ) -> Option<u32> {
     owner_member_token_type(indexer, receiver_type, member_name)
         .or_else(|| extension_member_token_type(indexer, receiver_type, member_name))
         .or_else(|| {
-            find_field_type_in_class(indexer, receiver_type, member_name)
+            find_field_type_in_class(indexer, receiver_type, member_name, uri)
                 .map(|_| type_index(&SemanticTokenType::PROPERTY))
         })
 }


### PR DESCRIPTION
## Summary

- A `when (event.event) { ... }` chained subject (as opposed to a plain `when (event)`) could report bogus "missing branches" warnings pulled from a same-named sealed type declared in a totally unrelated file. Root cause: a bare-name class/field lookup with no import/package scoping, compounded by the chain's root variable's smart-cast narrowing never being checked, Kotlin's whole-stable-path smart-casting (`when (event.events) { is X -> when (event.events) { ... } }`) not being recognized, and the root's declared-type fallback doing a whole-file text scan that could match an unrelated same-named parameter in a different function.
- `find_field_type_in_class` now resolves reachability-first (`resolve_type_index_only`, the same import/package-aware pattern used elsewhere in the resolver), and `infer_field_chain_type` threads a `reachability_uri` through the whole chain walk so each resolved segment re-anchors the next lookup on its *own* declaring file, not the original caller's.
- Added a shared, depth-bounded `enclosing_smart_cast_type` (checks whether an enclosing `when`'s subject is a prefix of the query chain) and `resolve_declared_type_from_cst` (scope-correct declared-type fallback), used by `fill_when.rs` and no longer duplicated per-consumer.
- Also fixes a live-edit staleness bug in `infer_field_type_raw` (live editor lines must stay checked before the debounced reindex snapshot) surfaced while reworking the field-lookup priority order, and dedupes a CST chain-segment walker that had drifted into two independent per-consumer copies.
- **Known, deliberately deferred follow-up**: the identical bare-name-collision pattern is still reachable through `indexer/infer/chain.rs`/`expr_type.rs` (hover/inlay/completion's own chain-resolution engine), which anchors every hop on the original caller's file rather than re-anchoring per segment. Not touched here — it's a separate, more complex, widely-shared walker; tracked as a follow-up.

## Test plan

- [x] `cargo test --bin kmp-lsp` — 1765 passed, 0 failed
- [x] All integration test binaries (`cli_check`, `cli_complete`, `cli_diagnose`, `cli_refs`, `lsp_smoke`, `swift_grammar`) green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Two new regression tests added, each verified to fail against the pre-fix code (via targeted reverts) before passing with the fix
- [x] Real-world verification: all 4 originally-flagged files in a large production Kotlin codebase clean with a fresh index cache, plus ~15 additional sampled files with chained `when` subjects
- [x] Previously-hanging pathological-chain regression test now completes in well under a second (fixed a genuine O(depth)-per-call quadratic blowup found during the rework)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ