### PR TITLE
refactor(resolver): scope qualified-name lookups to their container

### DIFF
--- a/docs/superpowers/specs/2026-08-24-qualified-resolution-unification-design.md
+++ b/docs/superpowers/specs/2026-08-24-qualified-resolution-unification-design.md
@@ -1,0 +1,476 @@
+# Qualified-Name Resolution Unification — Design
+
+Status: **proposed** (2026-08-24). Written after four independent bugs (three fixed, one
+newly found by this audit) surfaced the same root shape across two days of work on
+`fix/when-smart-cast-field-collision`. Builds directly on `docs/architecture/unified-resolution-strategy.md`
+(string-domain direction, proposed) and `docs/superpowers/specs/2026-06-30-cst-resolution-unification-design.md`
+(CST-domain direction, approved, partially implemented) — this document does not re-derive either;
+it slots a missing piece into both.
+
+## Context (why)
+
+Four sites answer the same question — *"given a multi-segment qualified name (nested type,
+chained field access), which specific declaration does the LAST segment refer to?"* — and three
+of them got it wrong the same way: **only the first segment was resolved reachability-first
+(imports/package-aware); every segment after it fell back to an unscoped or under-scoped
+search**, landing on an arbitrary same-named sibling instead of the one actually meant.
+
+This is not a hypothetical shape. The verification codebase is MVI-style Kotlin with hundreds of
+
+```kotlin
+sealed interface Event {
+    data class Foo(val event: FooEvent) : Event
+    data class Bar(val event: BarEvent) : Event
+    // … dozens more variants, one file, all with a field literally named `event`
+}
+```
+
+so "wrong sibling variant's same-named field" is the *default* failure mode for any lookup that
+doesn't scope every hop, not an edge case.
+
+### The five sites (four given, one found during this audit)
+
+| # | Site | Domain | Status before this doc |
+|---|---|---|---|
+| 1 | `resolver/infer.rs::find_field_type_in_class` + `infer_field_chain_type` | string | **Fixed** (this session) — reference implementation |
+| 2 | `resolver/resolve.rs::resolve_qualified` (uppercase-qualifier branch) | string | **Fixed** (this session) — ported #1's segment-walk shape in |
+| 3 | `indexer/infer/chain.rs::resolve_member_type_on` / `forward_resolve_segments` | CST | **Not fixed** — confirmed live |
+| 3b | `indexer/infer/expr_type.rs::infer_navigation_expr_type` | CST | **Not fixed — newly found by this audit**, same root cause as #3, independent function |
+| 4 | `resolver/resolve.rs::resolve_symbol` (dotted-`name` branch, ~L139–171) | string | **Not fixed — audit confirms it is NOT clean** (see below) |
+
+#### Site 1 — `find_field_type_in_class` / `infer_field_chain_type` (fixed, reference shape)
+
+`find_field_type_in_class` resolves the *class* via `resolve::resolve_type_index_only` (reachability-first:
+imports → package → hierarchy, per `ResolveIo`), then `infer_field_chain_type` threads a
+`reachability_uri` through the whole chain walk — each resolved segment's own declaring file becomes
+the anchor for the *next* segment's lookup, instead of reusing the caller's original file. This is the
+correct shape and is what the new primitive below generalizes, not reinvents.
+
+#### Site 2 — `resolve_qualified`'s uppercase branch (fixed, by porting #1's shape)
+
+Was: resolved only the outer segment (`Event`) to a file + line, then called
+`find_name_in_uri_after_line(member_name, that_line)` — which returns whichever same-named member is
+*textually closest* to `Event`'s own declaration line, never actually narrowing to a specific nested
+segment (`OverdraftInput`). Fixed by walking every remaining nested-type segment to its own location
+first (`anchor`), then searching `name` after `anchor`'s line — mirroring the lowercase branch, which
+already did per-segment field-type inference correctly.
+
+**Residual gap the fix left standing:** the nested-*type*-segment walk itself (`segments[1..]`, i.e.
+`OverdraftInput` in `Event.OverdraftInput.event`) still uses plain `find_name_in_uri` — whole-file,
+first-match, no scoping at all. Only the *final* segment (`name`) got the closest-line treatment. A
+3+-segment chain where a *middle* segment collides (two same-named nested types in the same file) is
+still under-scoped. Not hypothetical-free, but narrower blast radius than the field-collision case
+this session actually hit.
+
+#### Site 3 / 3b — the CST engine's chain walk (confirmed live, not fixed)
+
+`chain.rs::resolve_member_type_on` and `expr_type.rs::infer_navigation_expr_type` both call
+`InferDeps::find_field_type` — which (on `Indexer`, `src/indexer.rs:420-426`) delegates to
+`find_field_type_in_class` (site #1's now-correct implementation) and then **discards the declaring
+`Url` it returns**:
+
+```rust
+// src/indexer.rs:420
+fn find_field_type(&self, class_name: &str, field_name: &str, uri: &Url) -> Option<String> {
+    ...
+    crate::resolver::infer::find_field_type_in_class(self, class_name, field_name, uri)
+        .map(|(field_type, _declaring_uri)| field_type)   // <-- reachability anchor thrown away
+}
+```
+
+Every caller of `find_field_type` therefore anchors **every hop of a multi-segment chain on the
+original caller's own `uri`**, never on the declaring file of the class actually being walked into —
+even though the underlying per-class lookup is reachability-correct. Confirmed independently in two
+functions:
+
+- `chain.rs::forward_resolve_segments` (2 call sites of `resolve_member_type_on`, `src/indexer/infer/chain.rs:166,191`):
+  the loop tracks `current_type: Option<String>` across segments but never a `current_uri`; `uri` is the
+  single parameter passed in at the top and reused unchanged for every `resolve_member_type_on` call.
+- `expr_type.rs::infer_navigation_expr_type` (`src/indexer/infer/expr_type.rs:198-227`): recursively
+  resolves the receiver's type via `infer_expr_type_at_depth`, then calls
+  `deps.find_field_type(&receiver_type, &member, uri)` — again the *original* `uri`, at every level of
+  the recursion (a 3-segment chain `a.b.c` re-derives `a.b`'s type correctly but still resolves `.c` off
+  the outermost caller's file). **This is a second, independent instance of the exact same bug**, not
+  mentioned in the original brief — found by tracing `find_field_type`'s callers with
+  `find_referencing_symbols`.
+
+Both are downstream of `find_field_type`'s signature discarding information the implementation already
+computes. This narrows the fix to one seam, not two hand-patches (see Primitive 2 below).
+
+#### Site 4 — `resolve_symbol`'s dotted-`name` branch — **audit finding: not clean**
+
+The brief flagged this as "closer to correct... but never audited." It is not clean. Read in full
+(`src/resolver/resolve.rs:139-171`):
+
+```rust
+if name.contains('.') {
+    let segments: Vec<&str> = name.split('.').collect();
+    if let Some(start) = segments.iter().position(|s| s.starts_with_uppercase()) {
+        let outer_locs = resolve_symbol_inner(indexer, segments[start], from_uri, true);
+        if let Some(outer_loc) = outer_locs.first() {
+            if start + 1 == segments.len() { return outer_locs; }
+            let mut current_file = outer_loc.uri.to_string();
+            let mut resolved: Option<Vec<Location>> = None;
+            for seg in &segments[start + 1..] {
+                let locs = find_name_in_uri(indexer, seg, &current_file);   // <-- whole-file, first match
+                match locs.first() {
+                    Some(loc) => { current_file = loc.uri.to_string(); resolved = Some(locs); }
+                    None => { resolved = None; break; }
+                }
+            }
+            if let Some(locs) = resolved { return locs; }
+        }
+    }
+}
+```
+
+`find_name_in_uri` (`resolver/find.rs:13-31`) is confirmed (read in full) to be a **whole-file,
+first-symbol-match scan** — `file_data.symbols.iter().find(|s| s.name == name)` — with *zero*
+scoping, not even the line-proximity heuristic site #2's fix applies to its own final segment. Every
+segment after the first is walked this way, including the last. This is the identical bug shape,
+just with a narrower practical blast radius: this branch fires when the dotted string is itself the
+`name` parameter (a type-reference chain like `Event.OverdraftInput` written directly, or a variable's
+inferred dotted type), so its segments are typically nested *type* names rather than field names —
+lower collision odds than the MVI field-name pattern that motivated sites #1/#2, but the exact same
+structural gap. Concrete failure mode: two sibling top-level types in one file each declaring a
+same-named nested member (`sealed interface Event { object Loading : Event }` and
+`sealed interface UiEvent { object Loading : Event }` in one file) — resolving `Event.Loading` finds
+whichever `Loading` symbol appears first in `file_data.symbols`' order, not necessarily `Event`'s own.
+
+The one existing test on this path, `resolve_dotted_name_traverses_deep_nesting`
+(`resolver/tests.rs:611-627`), has **no collision decoy** — `Bar.Baz.Foo` is the only three-level chain
+in its fixture, so it passes today and would keep passing even with the bug fully intact. It does not
+prove this path correct; it only proves the happy path with nothing to collide against.
+
+## One primitive or two?
+
+**Two.** Sites #1/#2/#4 live in `resolver/` — the string domain. Sites #3/#3b live in
+`indexer/infer/` — the CST domain. Both governing docs already establish this split is deliberate and
+the two domains "should stay separate" (`2026-06-30-cst-resolution-unification-design.md`, "Context"
+section): the string domain is intentionally heuristic (works with no synced project, powers cold-start
+navigation and agent find), the CST domain is authoritative (works from a real parsed tree, backs
+diagnostics). That same document explicitly rejects "a shared cross-domain IR that both string and CST
+paths lower into... added complexity / a new domain" as a non-goal. Unifying "resolve a multi-segment
+qualified name" into one type/function spanning both domains would be exactly that rejected IR, just
+narrower in scope. Nothing about this bug's shape overrides that prior, reasoned decision — the bug
+*rhymes* across domains (both walk segments; both need reachability re-anchored per hop) but the two
+implementations have no shared runtime state, no shared node/type representation, and answer to
+different IO/authority contracts. Sharing *code* would mean threading `InferDeps` through string-domain
+callers or `Location`/`ResolveIo` through CST-domain callers — neither belongs on the other side.
+
+So: **two primitives, one shared pattern, documented once so neither is reinvented a third time.**
+
+- **Primitive 1 (string domain):** a correctly-scoped per-hop lookup, replacing three different
+  approximations of "find `name` declared specifically within/near a known anchor" that the four
+  string-domain sites currently roll separately, at varying quality.
+- **Primitive 2 (CST domain):** widen `InferDeps::find_field_type`'s signature to carry the declaring
+  `Url` it already computes internally but currently discards, and thread it through the two chain
+  walkers (#3, #3b) the same way site #1 already threads `reachability_uri`.
+
+Neither primitive is itself new *code* in the sense of a from-scratch design — primitive 1 generalizes
+site #1's already-correct shape; primitive 2 stops throwing away information site #1's own fix already
+computes. This plan is closer to "finish applying a decision already made" than "design something new."
+
+## Primitive 1 (string domain): scoped per-hop lookup
+
+### WHY
+
+Three different functions currently approximate "find `name` declared specifically within a known
+container," each at different fidelity, none exact:
+
+| Approximation | Used by | Precision |
+|---|---|---|
+| `find_name_in_uri` (`resolver/find.rs:13`) | site #4 (every hop), site #2 (mid-chain nested-type hops) | **None** — whole-file, first symbol-table match |
+| `find_name_in_uri_after_line` (`resolver/find.rs:47`) | site #2 (final segment only) | **Approximate** — closest symbol at/after a line hint |
+| `windowed_infer_type_raw` / `infer_field_type_raw`'s `near_line` (`resolver/infer.rs:1009-1071`) | site #1 (field lookup) | **Approximate** — ±20-line text window around a line hint, ordered by distance |
+
+All three exist because the container's *exact* range usually isn't threaded to the call site — only a
+`near_line` int or nothing at all. But the exact range is almost always available one hop back: every
+`Location` these functions receive came from a `SymbolEntry` that has its own full `.range` (not just
+`.selection_range`) sitting right there in the same file's symbol table — `resolve_companion_member`
+(`resolve.rs:1248-1291`) already re-fetches it this way to scope a companion-object search, and
+`enclosing_container_chain` (`resolve.rs:1207-1229`) already computes container nesting via
+`range_encloses`. The infrastructure for *exact* scoping exists; these three call sites just don't use
+it, because it wasn't factored out as a shared primitive when `resolve_companion_member` first needed
+it.
+
+### WHAT
+
+One new function, additive (does not replace the three above for their *other* existing callers —
+see Migration and Risks):
+
+```rust
+/// Find `name` declared specifically within `container`'s own body — not merely
+/// somewhere in `container`'s file. Prefers exact range-containment (re-fetching
+/// `container`'s full `SymbolEntry.range`, the way `resolve_companion_member`
+/// already does for the companion-object case); falls back to the existing
+/// closest-declaration-after-line heuristic only when `container`'s own
+/// declaration range can't be found (an un-indexed / disk-read-only file).
+///
+/// Supersedes, for its callers, three prior approximations of the same
+/// question: `find_name_in_uri` (no scoping at all), `find_name_in_uri_after_line`
+/// (line-proximity only), and `infer_field_type_raw`'s `near_line` window
+/// (text-window proximity only) — see this doc's Primitive 1 section for why
+/// none of the three is exact and why this one can be.
+pub(crate) fn find_name_scoped_to_container(
+    indexer: &Indexer,
+    name: &str,
+    container: &Location,
+) -> Option<Location>
+```
+
+Plus a trivial, explicitly-named loop shape — not because it's complex (it's ~10 lines) but because
+three call sites currently hand-roll a slightly different version of it and a fourth (site #1) rolls
+yet another variant over type-strings instead of `Location`s. Naming it stops a fifth reinvention:
+
+```rust
+/// Walk `segments` left to right, re-anchoring on each hop's own result — never
+/// falling back to an unscoped or first-segment-only search. `hop` receives the
+/// current anchor and the next segment name; returns `None` to abort the walk.
+/// Generic over the anchor type `A` because sites #1 (walks type-strings +
+/// reachability `Url`s) and sites #2/#4 (walk `Location`s) genuinely need
+/// different anchor shapes — this is the shared *loop*, not a shared *type*.
+fn walk_qualified_segments<A>(
+    segments: &[&str],
+    initial: A,
+    hop: impl Fn(&A, &str) -> Option<A>,
+) -> Option<A>
+```
+
+### HOW
+
+`find_name_scoped_to_container`'s body: look up `container`'s own `SymbolEntry` (by matching
+`selection_range` in its file's symbol table — the exact pattern `resolve_companion_member` already
+uses for a companion object) to get its full `.range`; if found, filter that file's symbols to
+`name`-matching entries with `range_encloses(container_full_range, candidate.range)` and return the
+best (there should be exactly one for a well-formed nested declaration; multiple is a genuine
+`Ambiguous`-shaped case the caller can choose to surface or pick-first, unchanged from today's
+behavior). If `container`'s own `SymbolEntry` can't be found (un-indexed file, disk fallback), fall
+back to today's `find_name_in_uri_after_line(name, container.uri, container.range.start.line)` — no
+regression versus current behavior in that fallback case, just no improvement either; acceptable
+because it's already the *best* of the three existing approximations.
+
+Lives in `resolver/find.rs`, next to (and eventually superseding, per-caller, not globally) the two
+heuristics it's built from — matching that file's existing convention of un-catalogued `pub(crate)` fns
+consumed directly by `resolve.rs`/`infer.rs`.
+
+## Primitive 2 (CST domain): reachability-carrying field lookup
+
+### WHY
+
+`InferDeps::find_field_type`'s signature (`Option<String>`) cannot represent "and here's the file this
+field's type must be further resolved *from*" — so every caller is structurally forced to reuse its
+own `uri`, which is exactly wrong past the first hop. `find_field_type_in_class`, the function
+underneath it, already computes and returns the right answer (`(String, Url)`); `Indexer`'s
+`InferDeps` impl throws the `Url` half away at the trait boundary (`src/indexer.rs:420-426`).
+
+### WHAT
+
+Widen the trait method to return what the implementation already has:
+
+```rust
+// src/indexer/infer/deps.rs — InferDeps trait
+fn find_field_type(&self, class_name: &str, field_name: &str, uri: &Url) -> Option<(String, Url)>;
+```
+
+`Indexer`'s impl becomes a straight pass-through of `find_field_type_in_class`'s existing return value
+(deletes the `.map(|(field_type, _declaring_uri)| field_type)` discard). `TestDeps`'s impl
+(`deps.rs:451`) returns `(type, uri.clone())` using its own test-fixture `uri` parameter (already
+available, currently ignored via `_uri`) unless a richer test fixture is worth adding later.
+
+### HOW
+
+Two call sites thread the returned `Url` forward as the next hop's anchor, mirroring
+`infer_field_chain_type`'s existing `reachability_uri` pattern exactly (site #1 is the reference
+implementation for this too):
+
+- `chain.rs::forward_resolve_segments` — add `current_uri: Url` alongside `current_type: Option<String>`
+  in the loop state (currently just `uri: &Url` reused unchanged); on each successful
+  `resolve_member_type_on` call, take the returned `Url` and use it for the *next* iteration's lookups.
+  `resolve_member_type_on` itself must also return `(String, Url)` instead of `Option<String>` to carry
+  this forward — it is the direct caller of `deps.find_field_type`.
+- `expr_type.rs::infer_navigation_expr_type` — same threading through its recursive
+  `infer_expr_type_at_depth` call: the receiver's resolved type must come back paired with its
+  declaring `Url`, used for the `deps.find_field_type(&receiver_type, &member, uri)` call instead of
+  the outer `uri` parameter.
+
+**Where this naturally lands architecturally:** the CST catalogue's `ResolvedType`
+(`indexer/infer/mod.rs:107-134`) is the one type both of these functions' results already flow through
+(`CstQuery::expr_type` wraps `infer_expr_type`'s `Option<String>` into `Resolution<ResolvedType>`).
+Adding a `declaring_uri: Url` field to `ResolvedType` — populated from this same threading — is the
+single place that fixes both #3 and #3b at once and gives every *future* `CstQuery` consumer the
+reachability anchor for free, rather than three call sites each carrying their own parallel `Url`
+alongside a `String`. This is also **exactly** the CST design doc's already-planned Slice 4 ("collapse
+the chain walk — `chain.rs` becomes the chain step of `expr_type`; delete the echoed chain logic") —
+see Non-goals for why this plan does not itself execute Slice 4, but the sequencing note below is
+important: land the `Url`-threading described here *as part of* Slice 4's `chain.rs` absorption, not as
+a throwaway patch to the soon-to-be-deleted standalone `chain.rs`/`expr_type.rs` functions first. If
+Slice 4 isn't imminent, the standalone patch is still correct and independently testable — it just
+duplicates work Slice 4 will otherwise redo.
+
+## Reuse inventory (existing types — do not reinvent)
+
+| Type / fn the design needs | Status | Location | Decision |
+|---|---|---|---|
+| `find_field_type_in_class` | exists, fixed | `resolver/infer.rs:1116` | Reference implementation for Primitive 1's shape; unchanged |
+| `infer_field_chain_type` | exists, fixed | `resolver/infer.rs:161` | Reference implementation for `reachability_uri` threading; unchanged |
+| `find_name_in_uri` | exists | `resolver/find.rs:13` | Superseded **for these 4 sites' per-hop lookups only** — stays for its other ~dozen callers (see Risks) |
+| `find_name_in_uri_after_line` | exists | `resolver/find.rs:47` | Becomes Primitive 1's fallback path (un-indexed-container case) |
+| `range_encloses` | exists | `resolve.rs:1236` | Reuse directly for range-containment scoping |
+| `enclosing_container_chain` | exists | `resolve.rs:1207` | Pattern precedent (re-fetch full range by `selection_range` match) — Primitive 1 follows the same shape, doesn't call this directly |
+| `resolve_companion_member` | exists | `resolve.rs:1248` | The existing precedent for "look up a container's full range, scope a name search to it"; Primitive 1 generalizes this one case into a shared fn |
+| `ResolveIo` | exists | `resolve.rs:78` | Unrelated to this fix (already unified per `unified-resolution-handler.md`) — Primitive 1 does not need its own IO policy; it's a pure index read like `find_name_in_uri` |
+| `Location` | exists (tower_lsp) | — | Reuse as Primitive 1's anchor/output type |
+| `InferDeps` trait | exists | `indexer/infer/deps.rs` | Primitive 2 widens one existing method's signature; no new trait |
+| `ResolvedType` | exists | `indexer/infer/mod.rs:109` | Natural home for Primitive 2's `declaring_uri` (see HOW) — extend, don't wrap |
+| `CstQuery` | exists | `indexer/infer/mod.rs:149` | Consumer of the widened `ResolvedType`; not itself modified by this plan |
+| `Resolver` trait | exists | `resolver/api.rs` | **Not extended by this plan** — Primitive 1 is an internal per-hop helper consumed by `resolver/*.rs` internals, not a feature-facing capability; doesn't belong on the feature catalogue |
+| `unified-resolution-strategy.md`'s `ResolvedSymbol`/`resolve()` | proposed, not implemented | `docs/architecture/unified-resolution-strategy.md` | **Distinct, larger effort** — not this plan; see Non-goals |
+| `SymbolEntry.range` vs `.selection_range` | exists | `types.rs` | Primitive 1's exact-scoping depends on this distinction (already used by `resolve_companion_member`) |
+
+Net: **zero new types**, one new function (`find_name_scoped_to_container`), one new tiny generic
+helper (`walk_qualified_segments`, and only if the migration step below finds real duplication worth
+collapsing — see Step 3's note), one widened trait method signature, one widened existing struct
+(`ResolvedType` +1 field).
+
+## Non-goals
+
+- **Not the full `unified-resolution-strategy.md` consumer-unification** (`ResolvedSymbol` + `resolve()`
+  + `IoPolicy` spanning go-to-def/diagnostics/hover/completion). That is a separate, much larger,
+  already-proposed effort targeting a different problem (candidate enumeration + overload policy across
+  five *consumers*). This plan fixes a narrower, already-identified sub-bug (multi-segment qualifier
+  walking); it does not block that effort and does not need to wait for it.
+- **Not merging the string and CST domains**, and not building a shared cross-domain IR or shared
+  walker type spanning both. The CST design doc already rejected this explicitly; nothing in this
+  bug's shape gives new reason to revisit it. Two primitives, one documented pattern, zero shared code
+  across the domain boundary.
+- **Not executing CST unification Slice 4** (`chain.rs` → `expr_type` chain-step absorption, deleting
+  echoed logic in `receiver.rs`). Primitive 2's `Url`-threading is scoped to be Slice-4-compatible (see
+  HOW's sequencing note) but this plan does not take on Slice 4's full scope (receiver.rs dedup,
+  `CstExpr` exhaustive dispatch, construction-sealing).
+- **Not eliminating line-proximity/text-window heuristics everywhere in the codebase** — only replacing
+  the three specific instances that feed these four/five call sites' per-hop disambiguation.
+  `infer_variable_type`'s general line-scanning, `windowed_infer_type_raw`'s other callers, etc. are
+  unaffected.
+- **Not touching `ResolveIo`/the resolution-chain unification** (`resolve_chain`, `resolve_symbol_no_rg`,
+  etc.) — already unified per `docs/architecture/unified-resolution-handler.md`; confirmed still in
+  place reading `resolve.rs` today. Orthogonal to this bug.
+- **Not adding `Vec<Location>`/overload-set semantics to `qualified`** — that's
+  `unified-resolution-strategy.md`'s own tracked follow-up, unrelated to per-hop scoping.
+
+## Migration (incremental, test-anchored — mirrors the CST doc's own sequencing style)
+
+Each step lands independently, is green on `cargo test --bin kmp-lsp` before the next, and is marked by
+which category it's in: **(A) refactor-onto-primitive** for sites already behaviorally correct (no
+intended output change; a decoy regression test proves it), or **(B) migration-is-the-fix** for sites
+still broken (a RED test first, green after).
+
+1. **(new, additive) Land `find_name_scoped_to_container` in `resolver/find.rs`.** No caller changes
+   yet. Unit tests directly against it: exact range-containment case, un-indexed-container fallback
+   case, ambiguous-multiple-match case (document the pick-first behavior explicitly, matching today's
+   convention elsewhere in this file).
+
+2. **(B) Site #4 — `resolve_symbol`'s dotted-`name` branch.** Write the RED decoy test first: two
+   sibling types in one file each declaring a same-named nested member (the `Event.Loading` /
+   `UiEvent.Loading` shape from the audit above), assert `resolve_symbol(idx, "Event.Loading", None,
+   uri)` returns `Event`'s own `Loading`, not `UiEvent`'s. Confirm it fails against current code. Then
+   replace the `find_name_in_uri` calls in the segment loop with `find_name_scoped_to_container`, using
+   the previous hop's `Location` as the container. Confirm the RED test goes green and
+   `resolve_dotted_name_traverses_deep_nesting` (the existing happy-path test) stays green.
+
+3. **(A) Site #2 — `resolve_qualified`'s uppercase branch.** Two sub-parts, each independently
+   testable: (a) replace the mid-chain nested-type-segment walk's `find_name_in_uri` calls with
+   `find_name_scoped_to_container` (closes the residual middle-segment gap the original fix left
+   standing — write a decoy test for a 3+-segment chain with a colliding middle nested-type name first,
+   confirm RED, then GREEN); (b) replace the final segment's `find_name_in_uri_after_line` call with
+   `find_name_scoped_to_container` too, so the whole nested-segment walk uses one consistent primitive
+   instead of two different ones. Existing sibling-field-collision regression tests from this session
+   are the behavior net for (b) — must stay green (no intended change, since exact range-containment is
+   a superset of what closest-line-after already got right for this case).
+
+   At this point, evaluate whether `walk_qualified_segments` (the generic loop helper) is worth
+   extracting: sites #2 and #4 now have near-identical "for each remaining segment, look up scoped-to-
+   previous-anchor, bail on miss" loops. If the bodies are close enough after step 2/3's edits, factor
+   the loop out; if the surrounding bail-out/fallback logic still differs enough to make the extraction
+   net-negative in clarity, leave them as two short hand-written loops calling the same leaf primitive.
+   Judge this from the actual diff, not in advance — the CST doc's own "move-don't-rewrite" discipline
+   applies here too.
+
+4. **(A, no-op refactor) Site #1 — `find_field_type_in_class`.** Already the reference shape; no
+   behavior change. Optionally replace its `infer_field_type_raw`/`near_line` window-scan with
+   `find_name_scoped_to_container` + a value-extraction step for full range-containment parity with
+   sites #2/#4 — but note this function returns a *type string*, not a `Location`, so this is a genuine
+   reshaping (find the `Location` via the new primitive, then read its declared type off that
+   `Location`'s own range) rather than a drop-in swap. Land only if step 3's evaluation shows real
+   value in a single consistent lookup path; otherwise this function is already correct and this step
+   is deferrable.
+
+5. **(B) Widen `InferDeps::find_field_type` → `Option<(String, Url)>`.** One commit: trait signature,
+   `Indexer` impl (delete the discard), `TestDeps` impl. Enumerate every `find_field_type` caller with
+   `find_referencing_symbols` first (this doc found 2: `chain.rs`, `expr_type.rs` — confirm no others
+   were missed) before touching the trait, per the CST doc's own "anti-reinvention completeness check."
+   This step alone does not fix anything yet — every caller must still be updated to consume the new
+   `Url`. Compiles green with callers doing `.map(|(t, _)| t)` at each call site as a transitional no-op,
+   OR land steps 5+6+7 as one commit if the blast radius is small enough to review as a unit (2
+   call sites, confirmed above).
+
+6. **(B) Thread the `Url` through `chain.rs::forward_resolve_segments` / `resolve_member_type_on`.**
+   RED test first: a chain-typed hover/inlay scenario mirroring the sibling-field MVI shape but reached
+   through the CST engine (e.g. `nullable_call_diagnostics` or an inlay-hints fixture with a 3-segment
+   chain `a.b.c` where `b`'s type is a same-named-sibling-prone class). Confirm current `chain.rs`
+   resolves the wrong sibling; fix by tracking `current_uri` in the loop; confirm GREEN.
+
+7. **(B) Thread the `Url` through `expr_type.rs::infer_navigation_expr_type`.** Same shape as step 6,
+   independently testable (different function, different fixture — likely a semantic-tokens or
+   completion scenario, since that's this function's actual consumer per `find_referencing_symbols`).
+   RED-then-GREEN.
+
+8. **(deferred, coordinate not execute) Note for whoever picks up CST Slice 4 next:** when `chain.rs`
+   is absorbed into `expr_type`/`CstQuery` per the existing roadmap, the `current_uri` state from steps
+   6/7 should become a field on `ResolvedType` (`declaring_uri: Url`) rather than being re-derived a
+   third time — this plan's Primitive 2 section spells out exactly where. Left as a note, not a step,
+   because Slice 4 is not scheduled by this plan.
+
+## Testing & verification
+
+- `cargo test --bin kmp-lsp` green after every step (binary-only crate; `--lib` runs 0 tests). Focused
+  loops while iterating: `-- resolver`, `-- indexer_tests`, `-- it_this`, `-- nullable_call`.
+- Every **(B)** step gets a RED-before-GREEN decoy test in the sibling-collision shape that actually
+  exposed these bugs — not a happy-path-only test (the existing
+  `resolve_dotted_name_traverses_deep_nesting` is the cautionary example of what *not* to rely on).
+- Every **(A)** step is behavior-preserving by construction; the existing regression suite from this
+  session's site #1/#2 fixes is the net. No new decoy needed unless step 3's middle-segment gap is
+  addressed, which does need its own new decoy (it's currently untested either way).
+- `find_referencing_symbols` on `find_field_type`, `find_name_in_uri`, and `find_name_in_uri_after_line`
+  before and after each migration step — confirms the primitive's callers were actually moved (not just
+  added alongside) and that no other caller of the two heuristics was silently affected.
+- Ground-truth harness (per `unified-resolution-strategy.md`'s own debugging recipe) against the real
+  MVI-shaped sample project remains the way to confirm these fixes generalize beyond hand-written
+  fixtures — unit tests alone can't reproduce the JAR/sources-jar-backed collision shapes reliably.
+
+## Risks
+
+- **`find_name_in_uri` has callers well beyond these four sites** (used throughout `resolve.rs`/
+  `resolve_qualified`'s lowercase branch, extension resolution, etc.). This plan deliberately does
+  **not** replace it globally — only the specific per-hop call sites in steps 2–4 move onto the new
+  primitive. Mitigation: `find_referencing_symbols` before and after each step (see Testing) keeps the
+  blast radius visible and bounded; no blanket rename.
+- **`InferDeps::find_field_type`'s signature widening (step 5) touches every implementor in one commit**
+  — smaller blast radius than it sounds (2 implementors: `Indexer`, `TestDeps`; 2 callers confirmed via
+  `find_referencing_symbols`), but it's a trait change, so any *future* implementor added between now
+  and this landing would need the same update. Mitigation: land steps 5–7 close together, not with a
+  long gap.
+- **Range-containment lookup cost.** `find_name_scoped_to_container`'s exact path re-scans a file's
+  symbol table twice per hop (once to find the container's full range, once to find `name` within it) —
+  same order of cost as the existing `resolve_companion_member` precedent, negligible for typical file
+  sizes, but worth a spot-check on the Moneta-scale ground-truth harness this codebase already uses for
+  perf validation, given these are hover/goto-def hot-ish paths.
+- **Site #1's reshaping (step 4) is the least mechanical step** — it returns a type string, not a
+  `Location`, so unlike steps 2/3/6/7 it can't be a pure "swap the lookup call" edit. Explicitly marked
+  optional/deferrable in the migration plan rather than forced, to avoid destabilizing the one site that
+  is already fully correct today for the sake of code-sharing purity.
+- **Duplicating Slice 4's future work (Primitive 2).** If Slice 4 lands soon after this plan, steps 6–7
+  land logic that Slice 4 then moves again. Mitigation: step 8 is written as an explicit coordination
+  note in this doc precisely so that isn't silently rediscovered later; the `Url`-threading logic itself
+  is small enough (mirroring an already-proven pattern from site #1) that redoing it once more inside
+  Slice 4 is cheap even if the timing doesn't line up.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -417,12 +417,18 @@ impl InferDeps for Indexer {
         infer_variable_type_raw(self, var_name, uri)
             .or_else(|| infer_variable_type_from_cst(self, var_name, uri))
     }
-    fn find_field_type(&self, class_name: &str, field_name: &str, uri: &Url) -> Option<String> {
+    fn find_field_type(
+        &self,
+        class_name: &str,
+        field_name: &str,
+        uri: &Url,
+    ) -> Option<(String, Url)> {
         if let Some(type_name) = synthetic_enum_field(self, class_name, field_name) {
-            return Some(type_name);
+            // No real declaration site (compiler-synthesized); the call site's
+            // own file is the closest thing to a reachability anchor.
+            return Some((type_name, uri.clone()));
         }
         crate::resolver::infer::find_field_type_in_class(self, class_name, field_name, uri)
-            .map(|(field_type, _declaring_uri)| field_type)
     }
     fn find_fun_return_type(&self, fn_name: &str, uri: &Url) -> Option<String> {
         crate::resolver::infer::find_fun_return_type_by_name(self, fn_name, uri)

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -133,6 +133,11 @@ pub(super) fn forward_resolve_segments(
     }
 
     let mut current_type: Option<String> = None;
+    // Reachability anchor for the *next* hop's lookups — starts at the
+    // caller's own file and re-anchors to each resolved field's declaring
+    // file as the chain descends, mirroring `infer_field_chain_type`'s
+    // `reachability_uri` in the string-domain resolver.
+    let mut current_uri = uri.clone();
     let mut last_suffix: Option<String> = None;
     // Track whether the last Suffix actually changed current_type.
     // Used by the CallExpr dedup check: only skip re-resolution when the Suffix
@@ -164,8 +169,11 @@ pub(super) fn forward_resolve_segments(
                 }
                 last_suffix_resolved = false;
                 if let Some(ref cur) = current_type {
-                    if let Some(resolved) = resolve_member_type_on(cur, name, deps, uri) {
+                    if let Some((resolved, declaring_uri)) =
+                        resolve_member_type_on(cur, name, deps, &current_uri)
+                    {
                         current_type = Some(resolved);
+                        current_uri = declaring_uri;
                         last_suffix_resolved = true;
                     } else if SCOPE_FUNCTIONS.contains(&name.as_str()) {
                         // Scope function: receiver type flows through.
@@ -189,8 +197,11 @@ pub(super) fn forward_resolve_segments(
                         continue;
                     }
                     if let Some(ref cur) = current_type {
-                        if let Some(resolved) = resolve_member_type_on(cur, name, deps, uri) {
+                        if let Some((resolved, declaring_uri)) =
+                            resolve_member_type_on(cur, name, deps, &current_uri)
+                        {
                             current_type = Some(resolved);
+                            current_uri = declaring_uri;
                             continue;
                         }
                     }
@@ -429,12 +440,17 @@ pub(super) fn cst_forward_resolve_receiver_type(
 /// argument from `current_type`.  This prevents `:T` from leaking through as a hover
 /// result for chains like `resultState.value.getOrNull()?.also { param -> }` when
 /// `ResultState.Success` type params are not indexed.
+/// Returns the resolved type together with the `Url` that should anchor
+/// reachability for the *next* hop — the field's declaring file when
+/// `deps.find_field_type` resolved it, or `uri` unchanged when the match came
+/// from a method return type (not yet `Url`-aware; see `find_field_type`'s
+/// own doc comment).
 pub(super) fn resolve_member_type_on(
     current_type: &str,
     member: &str,
     deps: &impl InferDeps,
     uri: &Url,
-) -> Option<String> {
+) -> Option<(String, Url)> {
     let type_name = current_type.dotted_ident_prefix();
     let type_base = type_name.last_segment();
     let effective_type = if !type_base.is_empty() && type_base.starts_with_uppercase() {
@@ -444,21 +460,21 @@ pub(super) fn resolve_member_type_on(
     } else {
         return None;
     };
-    if let Some(field_ty) = deps.find_field_type(&effective_type, member, uri) {
+    if let Some((field_ty, declaring_uri)) = deps.find_field_type(&effective_type, member, uri) {
         let subst = build_type_arg_subst(deps, &effective_type, current_type);
         let applied = crate::indexer::apply_type_subst(&field_ty, &subst);
         if is_generic_param(applied.strip_nullable()) {
-            return first_type_arg_raw(current_type);
+            return first_type_arg_raw(current_type).map(|t| (t, declaring_uri));
         }
-        return Some(applied);
+        return Some((applied, declaring_uri));
     }
     if let Some(ret_ty) = deps.find_method_return_type_for_type(&effective_type, member, uri) {
         let subst = build_type_arg_subst(deps, &effective_type, current_type);
         let applied = crate::indexer::apply_type_subst(&ret_ty, &subst);
         if is_generic_param(applied.strip_nullable()) {
-            return first_type_arg_raw(current_type);
+            return first_type_arg_raw(current_type).map(|t| (t, uri.clone()));
         }
-        return Some(applied);
+        return Some((applied, uri.clone()));
     }
     None
 }

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -387,7 +387,11 @@ impl TestDeps {
     ) -> Self {
         self.field_types.insert(
             (class_name.to_string(), field_name.to_string()),
-            (type_name.to_string(), Url::parse(declaring_uri).unwrap()),
+            (
+                type_name.to_string(),
+                // unwrap: test-only helper, always called with a literal `file://` uri.
+                Url::parse(declaring_uri).unwrap(),
+            ),
         );
         self
     }

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -389,8 +389,7 @@ impl TestDeps {
             (class_name.to_string(), field_name.to_string()),
             (
                 type_name.to_string(),
-                // unwrap: test-only helper, always called with a literal `file://` uri.
-                Url::parse(declaring_uri).unwrap(),
+                Url::parse(declaring_uri).unwrap(), // unwrap: literal file:// uri, always valid
             ),
         );
         self

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -181,11 +181,20 @@ pub(crate) trait InferDeps {
     /// element type.
     ///
     /// Example: `class_name = "ResponseBody"`, `field_name = "availableBanks"` →
-    /// `Some("MutableList<MultibankingBank>")`.
+    /// `Some(("MutableList<MultibankingBank>", <uri where ResponseBody is declared>))`.
+    ///
+    /// The `Url` is the field's own declaring file — callers walking a multi-hop
+    /// chain (`a.b.c`) need it to re-anchor reachability for the *next* hop,
+    /// the same way `resolve_qualified` and `find_field_type_in_class` already do.
     ///
     /// Returns `None` when the class or field is not found.
     /// Default implementation returns `None`; overridden by `Indexer`.
-    fn find_field_type(&self, _class_name: &str, _field_name: &str, _uri: &Url) -> Option<String> {
+    fn find_field_type(
+        &self,
+        _class_name: &str,
+        _field_name: &str,
+        _uri: &Url,
+    ) -> Option<(String, Url)> {
         None
     }
 
@@ -305,8 +314,8 @@ pub(crate) struct TestDeps {
     pub fun_sigs: std::collections::HashMap<(String, String), String>,
     /// `(uri_str, var_name)` → type name
     pub var_types: std::collections::HashMap<(String, String), String>,
-    /// `(class_name, field_name)` → raw type (with generics)
-    pub field_types: std::collections::HashMap<(String, String), String>,
+    /// `(class_name, field_name)` → (raw type with generics, declaring uri)
+    pub field_types: std::collections::HashMap<(String, String), (String, Url)>,
     /// `fn_name` → raw return type (with generics)
     pub return_types: std::collections::HashMap<String, String>,
     /// `class_name` → list of type parameter names, e.g. `"Result"` → `["T"]`
@@ -356,16 +365,29 @@ impl TestDeps {
         self
     }
 
-    /// Register `field_name` in `class_name` → raw type (with generics).
-    pub(crate) fn with_field(
+    /// Register `field_name` in `class_name` → raw type (with generics), with
+    /// a placeholder declaring uri. Use `with_field_at` when a test needs to
+    /// assert on the declaring uri itself.
+    pub(crate) fn with_field(self, class_name: &str, field_name: &str, type_name: &str) -> Self {
+        self.with_field_at(
+            class_name,
+            field_name,
+            type_name,
+            "file:///test-field-owner.kt",
+        )
+    }
+
+    /// Register `field_name` in `class_name` → (raw type, declaring uri).
+    pub(crate) fn with_field_at(
         mut self,
         class_name: &str,
         field_name: &str,
         type_name: &str,
+        declaring_uri: &str,
     ) -> Self {
         self.field_types.insert(
             (class_name.to_string(), field_name.to_string()),
-            type_name.to_string(),
+            (type_name.to_string(), Url::parse(declaring_uri).unwrap()),
         );
         self
     }
@@ -448,7 +470,12 @@ impl InferDeps for TestDeps {
             .get(&(uri.to_string(), var_name.to_string()))
             .cloned()
     }
-    fn find_field_type(&self, class_name: &str, field_name: &str, _uri: &Url) -> Option<String> {
+    fn find_field_type(
+        &self,
+        class_name: &str,
+        field_name: &str,
+        _uri: &Url,
+    ) -> Option<(String, Url)> {
         self.field_types
             .get(&(class_name.to_string(), field_name.to_string()))
             .cloned()

--- a/src/indexer/infer/expr_type.rs
+++ b/src/indexer/infer/expr_type.rs
@@ -75,6 +75,7 @@ pub(crate) fn infer_expr_type(
 /// `infer_variable_type_from_cst` (the CST fallback `InferDeps::find_var_type`
 /// uses). Bail out (not error) past the cap, same trade-off every other
 /// capped walker makes.
+///
 /// Returns the inferred type together with the `Url` that should anchor
 /// reachability for a member access on that type — the receiver's own
 /// declaring file when known (currently only `infer_navigation_expr_type`'s

--- a/src/indexer/infer/expr_type.rs
+++ b/src/indexer/infer/expr_type.rs
@@ -57,7 +57,7 @@ pub(crate) fn infer_expr_type(
     deps: &impl InferDeps,
     uri: &Url,
 ) -> Option<String> {
-    infer_expr_type_at_depth(node, bytes, deps, uri, 0).map(|(ty, _)| ty)
+    infer_expr_type_at_depth(node, bytes, deps, uri, 0).map(|(type_name, _)| type_name)
 }
 
 /// Depth-guarded implementation of [`infer_expr_type`].
@@ -94,7 +94,9 @@ fn infer_expr_type_at_depth(
     match node.kind() {
         KIND_INTEGER_LITERAL => Some(("Int".to_owned(), uri.clone())),
         KIND_LONG_LITERAL => Some(("Long".to_owned(), uri.clone())),
-        KIND_REAL_LITERAL => infer_real_literal(node, bytes).map(|ty| (ty, uri.clone())),
+        KIND_REAL_LITERAL => {
+            infer_real_literal(node, bytes).map(|type_name| (type_name, uri.clone()))
+        }
         KIND_STRING_LITERAL | KIND_MULTILINE_STRING_LITERAL => {
             Some(("String".to_owned(), uri.clone()))
         }
@@ -102,14 +104,14 @@ fn infer_expr_type_at_depth(
         KIND_NULL_LITERAL => Some(("Nothing?".to_owned(), uri.clone())),
         KIND_CHARACTER_LITERAL => Some(("Char".to_owned(), uri.clone())),
         k if k == KIND_SIMPLE_IDENT || k == KIND_TYPE_IDENT => {
-            infer_ident_type(node, bytes, deps, uri).map(|ty| (ty, uri.clone()))
+            infer_ident_type(node, bytes, deps, uri).map(|type_name| (type_name, uri.clone()))
         }
         k if k == KIND_THIS_EXPR => {
-            infer_this_expr_type(node, bytes, deps, uri).map(|ty| (ty, uri.clone()))
+            infer_this_expr_type(node, bytes, deps, uri).map(|type_name| (type_name, uri.clone()))
         }
         k if k == KIND_NAV_EXPR => infer_navigation_expr_type(node, bytes, deps, uri, depth),
         k if k == KIND_CALL_EXPR => {
-            infer_call_expr_type(node, bytes, deps, uri).map(|ty| (ty, uri.clone()))
+            infer_call_expr_type(node, bytes, deps, uri).map(|type_name| (type_name, uri.clone()))
         }
         k if k == KIND_CHECK_EXPR
             || k == KIND_COMPARISON_EXPR
@@ -119,19 +121,19 @@ fn infer_expr_type_at_depth(
             Some(("Boolean".to_owned(), uri.clone()))
         }
         k if k == KIND_PREFIX_EXPR => {
-            infer_prefix_expr_type(node, bytes).map(|ty| (ty, uri.clone()))
+            infer_prefix_expr_type(node, bytes).map(|type_name| (type_name, uri.clone()))
         }
-        k if k == KIND_IF_EXPR => {
-            infer_if_expr_type(node, bytes, deps, uri, depth).map(|ty| (ty, uri.clone()))
-        }
-        k if k == KIND_RANGE_EXPR => {
-            infer_range_expr_type(node, bytes, deps, uri, depth).map(|ty| (ty, uri.clone()))
-        }
+        k if k == KIND_IF_EXPR => infer_if_expr_type(node, bytes, deps, uri, depth)
+            .map(|type_name| (type_name, uri.clone())),
+        k if k == KIND_RANGE_EXPR => infer_range_expr_type(node, bytes, deps, uri, depth)
+            .map(|type_name| (type_name, uri.clone())),
         k if k == KIND_ADDITIVE_EXPR || k == KIND_MULTIPLICATIVE_EXPR => {
-            infer_arithmetic_expr_type(node, bytes, deps, uri, depth).map(|ty| (ty, uri.clone()))
+            infer_arithmetic_expr_type(node, bytes, deps, uri, depth)
+                .map(|type_name| (type_name, uri.clone()))
         }
         k if k == KIND_PARENTHESIZED_EXPR => {
-            infer_parenthesized_expr_type(node, bytes, deps, uri, depth).map(|ty| (ty, uri.clone()))
+            infer_parenthesized_expr_type(node, bytes, deps, uri, depth)
+                .map(|type_name| (type_name, uri.clone()))
         }
         _ => None,
     }
@@ -239,11 +241,11 @@ fn infer_navigation_expr_type(
         // `Resolver` trait directly.  Together they are equivalent to the original
         // `indexer.function_return_type(&member, uri)` call in `navigation_expression_type`.
         // Neither is `Url`-aware yet, so the anchor doesn't advance past this hop.
-        let ty = deps
+        let type_name = deps
             .find_method_return_type_for_type(&receiver_type, &member, &receiver_uri)
             .or_else(|| deps.find_fun_return_type_reachable(&member, uri))
             .or_else(|| deps.find_fun_return_type(&member, uri))?;
-        return Some((ty, receiver_uri));
+        return Some((type_name, receiver_uri));
     }
 
     deps.find_field_type(&receiver_type, &member, &receiver_uri)
@@ -365,7 +367,7 @@ fn infer_parenthesized_expr_type<D: InferDeps>(
     depth: usize,
 ) -> Option<String> {
     let inner = node.named_child(0)?;
-    infer_expr_type_at_depth(inner, bytes, deps, uri, depth + 1).map(|(ty, _)| ty)
+    infer_expr_type_at_depth(inner, bytes, deps, uri, depth + 1).map(|(type_name, _)| type_name)
 }
 
 /// Numeric rank for Kotlin's arithmetic operand-promotion, highest wins

--- a/src/indexer/infer/expr_type.rs
+++ b/src/indexer/infer/expr_type.rs
@@ -57,7 +57,7 @@ pub(crate) fn infer_expr_type(
     deps: &impl InferDeps,
     uri: &Url,
 ) -> Option<String> {
-    infer_expr_type_at_depth(node, bytes, deps, uri, 0)
+    infer_expr_type_at_depth(node, bytes, deps, uri, 0).map(|(ty, _)| ty)
 }
 
 /// Depth-guarded implementation of [`infer_expr_type`].
@@ -75,46 +75,62 @@ pub(crate) fn infer_expr_type(
 /// `infer_variable_type_from_cst` (the CST fallback `InferDeps::find_var_type`
 /// uses). Bail out (not error) past the cap, same trade-off every other
 /// capped walker makes.
+/// Returns the inferred type together with the `Url` that should anchor
+/// reachability for a member access on that type — the receiver's own
+/// declaring file when known (currently only `infer_navigation_expr_type`'s
+/// field case produces one), `uri` unchanged otherwise.
 fn infer_expr_type_at_depth(
     node: Node<'_>,
     bytes: &[u8],
     deps: &impl InferDeps,
     uri: &Url,
     depth: usize,
-) -> Option<String> {
+) -> Option<(String, Url)> {
     if depth >= crate::util::MAX_CST_DESCENT_DEPTH {
         crate::util::report_cst_depth_exceeded!("infer_expr_type_at_depth", node);
         return None;
     }
     match node.kind() {
-        KIND_INTEGER_LITERAL => Some("Int".to_owned()),
-        KIND_LONG_LITERAL => Some("Long".to_owned()),
-        KIND_REAL_LITERAL => infer_real_literal(node, bytes),
-        KIND_STRING_LITERAL | KIND_MULTILINE_STRING_LITERAL => Some("String".to_owned()),
-        KIND_BOOLEAN_LITERAL => Some("Boolean".to_owned()),
-        KIND_NULL_LITERAL => Some("Nothing?".to_owned()),
-        KIND_CHARACTER_LITERAL => Some("Char".to_owned()),
-        k if k == KIND_SIMPLE_IDENT || k == KIND_TYPE_IDENT => {
-            infer_ident_type(node, bytes, deps, uri)
+        KIND_INTEGER_LITERAL => Some(("Int".to_owned(), uri.clone())),
+        KIND_LONG_LITERAL => Some(("Long".to_owned(), uri.clone())),
+        KIND_REAL_LITERAL => infer_real_literal(node, bytes).map(|ty| (ty, uri.clone())),
+        KIND_STRING_LITERAL | KIND_MULTILINE_STRING_LITERAL => {
+            Some(("String".to_owned(), uri.clone()))
         }
-        k if k == KIND_THIS_EXPR => infer_this_expr_type(node, bytes, deps, uri),
+        KIND_BOOLEAN_LITERAL => Some(("Boolean".to_owned(), uri.clone())),
+        KIND_NULL_LITERAL => Some(("Nothing?".to_owned(), uri.clone())),
+        KIND_CHARACTER_LITERAL => Some(("Char".to_owned(), uri.clone())),
+        k if k == KIND_SIMPLE_IDENT || k == KIND_TYPE_IDENT => {
+            infer_ident_type(node, bytes, deps, uri).map(|ty| (ty, uri.clone()))
+        }
+        k if k == KIND_THIS_EXPR => {
+            infer_this_expr_type(node, bytes, deps, uri).map(|ty| (ty, uri.clone()))
+        }
         k if k == KIND_NAV_EXPR => infer_navigation_expr_type(node, bytes, deps, uri, depth),
-        k if k == KIND_CALL_EXPR => infer_call_expr_type(node, bytes, deps, uri),
+        k if k == KIND_CALL_EXPR => {
+            infer_call_expr_type(node, bytes, deps, uri).map(|ty| (ty, uri.clone()))
+        }
         k if k == KIND_CHECK_EXPR
             || k == KIND_COMPARISON_EXPR
             || k == KIND_DISJUNCTION_EXPR
             || k == KIND_CONJUNCTION_EXPR =>
         {
-            Some("Boolean".to_owned())
+            Some(("Boolean".to_owned(), uri.clone()))
         }
-        k if k == KIND_PREFIX_EXPR => infer_prefix_expr_type(node, bytes),
-        k if k == KIND_IF_EXPR => infer_if_expr_type(node, bytes, deps, uri, depth),
-        k if k == KIND_RANGE_EXPR => infer_range_expr_type(node, bytes, deps, uri, depth),
+        k if k == KIND_PREFIX_EXPR => {
+            infer_prefix_expr_type(node, bytes).map(|ty| (ty, uri.clone()))
+        }
+        k if k == KIND_IF_EXPR => {
+            infer_if_expr_type(node, bytes, deps, uri, depth).map(|ty| (ty, uri.clone()))
+        }
+        k if k == KIND_RANGE_EXPR => {
+            infer_range_expr_type(node, bytes, deps, uri, depth).map(|ty| (ty, uri.clone()))
+        }
         k if k == KIND_ADDITIVE_EXPR || k == KIND_MULTIPLICATIVE_EXPR => {
-            infer_arithmetic_expr_type(node, bytes, deps, uri, depth)
+            infer_arithmetic_expr_type(node, bytes, deps, uri, depth).map(|ty| (ty, uri.clone()))
         }
         k if k == KIND_PARENTHESIZED_EXPR => {
-            infer_parenthesized_expr_type(node, bytes, deps, uri, depth)
+            infer_parenthesized_expr_type(node, bytes, deps, uri, depth).map(|ty| (ty, uri.clone()))
         }
         _ => None,
     }
@@ -199,18 +215,21 @@ fn infer_this_expr_type(
 /// Resolve the type of a `navigation_expression` node (e.g. `obj.field`).
 ///
 /// Adapted from `semantic_tokens::resolve::navigation_expression_type`.
-/// Recursively resolves the receiver through `infer_expr_type`, then looks up
-/// the member as a field or (when the expression is a call callee) a method.
+/// Recursively resolves the receiver through `infer_expr_type`, re-anchoring
+/// reachability on the receiver's own declaring file (not the outermost
+/// caller's) so a multi-segment chain like `a.b.c` resolves `.c` through
+/// `a.b`'s file, not `a`'s — see `find_field_type`'s own doc comment.
 fn infer_navigation_expr_type(
     node: Node<'_>,
     bytes: &[u8],
     deps: &impl InferDeps,
     uri: &Url,
     depth: usize,
-) -> Option<String> {
+) -> Option<(String, Url)> {
     let receiver = nav_receiver_node(node)?;
     let member = nav_member_ident(node)?.utf8_text_owned(bytes)?;
-    let receiver_type = infer_expr_type_at_depth(receiver, bytes, deps, uri, depth + 1)?;
+    let (receiver_type, receiver_uri) =
+        infer_expr_type_at_depth(receiver, bytes, deps, uri, depth + 1)?;
 
     if nav_is_call_callee(node) {
         // The two-step `find_fun_return_type_reachable` → `find_fun_return_type` replicates
@@ -218,13 +237,15 @@ fn infer_navigation_expr_type(
         // `src/resolver/api.rs`) through the `InferDeps` seam rather than calling the
         // `Resolver` trait directly.  Together they are equivalent to the original
         // `indexer.function_return_type(&member, uri)` call in `navigation_expression_type`.
-        return deps
-            .find_method_return_type_for_type(&receiver_type, &member, uri)
+        // Neither is `Url`-aware yet, so the anchor doesn't advance past this hop.
+        let ty = deps
+            .find_method_return_type_for_type(&receiver_type, &member, &receiver_uri)
             .or_else(|| deps.find_fun_return_type_reachable(&member, uri))
-            .or_else(|| deps.find_fun_return_type(&member, uri));
+            .or_else(|| deps.find_fun_return_type(&member, uri))?;
+        return Some((ty, receiver_uri));
     }
 
-    deps.find_field_type(&receiver_type, &member, uri)
+    deps.find_field_type(&receiver_type, &member, &receiver_uri)
 }
 
 // ─── navigation tree-walking helpers ─────────────────────────────────────────
@@ -305,8 +326,8 @@ fn infer_if_expr_type<D: InferDeps>(
         .into_iter();
     let then_expr = bodies.next()?.child(0)?;
     let else_expr = bodies.next()?.child(0)?;
-    let then_type = infer_expr_type_at_depth(then_expr, bytes, deps, uri, depth + 1)?;
-    let else_type = infer_expr_type_at_depth(else_expr, bytes, deps, uri, depth + 1)?;
+    let then_type = infer_expr_type_at_depth(then_expr, bytes, deps, uri, depth + 1)?.0;
+    let else_type = infer_expr_type_at_depth(else_expr, bytes, deps, uri, depth + 1)?.0;
     (then_type == else_type).then_some(then_type)
 }
 
@@ -322,8 +343,8 @@ fn infer_range_expr_type<D: InferDeps>(
     let lhs = node.child(0)?;
     let rhs_idx = (node.child_count() as u32).checked_sub(1)?;
     let rhs = node.child(rhs_idx)?;
-    let lhs_ty = infer_expr_type_at_depth(lhs, bytes, deps, uri, depth + 1)?;
-    let rhs_ty = infer_expr_type_at_depth(rhs, bytes, deps, uri, depth + 1)?;
+    let lhs_ty = infer_expr_type_at_depth(lhs, bytes, deps, uri, depth + 1)?.0;
+    let rhs_ty = infer_expr_type_at_depth(rhs, bytes, deps, uri, depth + 1)?.0;
     match (lhs_ty.as_str(), rhs_ty.as_str()) {
         ("Int", "Int") => Some("IntRange".to_owned()),
         ("Long", "Long") | ("Int", "Long") | ("Long", "Int") => Some("LongRange".to_owned()),
@@ -343,7 +364,7 @@ fn infer_parenthesized_expr_type<D: InferDeps>(
     depth: usize,
 ) -> Option<String> {
     let inner = node.named_child(0)?;
-    infer_expr_type_at_depth(inner, bytes, deps, uri, depth + 1)
+    infer_expr_type_at_depth(inner, bytes, deps, uri, depth + 1).map(|(ty, _)| ty)
 }
 
 /// Numeric rank for Kotlin's arithmetic operand-promotion, highest wins
@@ -383,11 +404,11 @@ fn infer_arithmetic_expr_type<D: InferDeps>(
     let lhs = node.child(0)?;
     let op = node.child(1)?.utf8_text(bytes).ok()?;
     let rhs = node.child(2)?;
-    let lhs_ty = infer_expr_type_at_depth(lhs, bytes, deps, uri, depth + 1)?;
+    let lhs_ty = infer_expr_type_at_depth(lhs, bytes, deps, uri, depth + 1)?.0;
     if op == "+" && lhs_ty == "String" {
         return Some("String".to_owned());
     }
-    let rhs_ty = infer_expr_type_at_depth(rhs, bytes, deps, uri, depth + 1)?;
+    let rhs_ty = infer_expr_type_at_depth(rhs, bytes, deps, uri, depth + 1)?.0;
     let lhs_rank = numeric_rank(&lhs_ty)?;
     let rhs_rank = numeric_rank(&rhs_ty)?;
     // Kotlin has no same-rank arithmetic overload for `Byte`/`Short`: unlike

--- a/src/indexer/infer/expr_type_tests.rs
+++ b/src/indexer/infer/expr_type_tests.rs
@@ -589,10 +589,15 @@ fn infer_expr_type_survives_a_pathologically_deep_parenthesization() {
     for _ in 0..n {
         src.push(')');
     }
-    // Past the cap the walk simply bails (returns `None`) — same trade-off
-    // every other capped walker makes — so no specific value is asserted,
-    // only that inference runs to completion without crashing.
-    let _ = infer(&src);
+    // Past the cap the walk simply bails (returns `None`) — no specific
+    // value is asserted, only that inference completes without crashing.
+    // Spawned on an 8 MiB-stack thread: the default test-thread stack is
+    // smaller than that (see `the_initializer_search_survives_a_pathologically_deep_file`).
+    let handle = std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || infer(&src))
+        .unwrap();
+    let _ = handle.join().expect("must not overflow the stack");
 }
 
 /// Same regression, via a deeply nested navigation chain (`a.b.c.d…`)
@@ -605,5 +610,10 @@ fn infer_expr_type_survives_a_pathologically_deep_navigation_chain() {
     for _ in 0..n {
         src.push_str(".b");
     }
-    let _ = infer(&src);
+    // See the stack-size note on the parenthesization test above.
+    let handle = std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || infer(&src))
+        .unwrap();
+    let _ = handle.join().expect("must not overflow the stack");
 }

--- a/src/indexer/infer/expr_type_tests.rs
+++ b/src/indexer/infer/expr_type_tests.rs
@@ -505,6 +505,55 @@ fn infer_expr_type_resolves_navigation_chain_receiver() {
 }
 
 #[test]
+fn infer_navigation_expr_type_reanchors_reachability_on_receiver_declaring_file() {
+    // `holder.other.value` where `holder: Holder` (declared in package `lib`,
+    // same package as the real `Other`) must resolve `.value` through
+    // `Holder`'s own declaring file, not the caller's — otherwise an
+    // unrelated same-named `Other`, reachable only from the caller's own
+    // file, wins instead. Real `Indexer` (not `TestDeps`) because this
+    // depends on `resolve_type_index_only`'s package-reachability rules.
+    use crate::indexer::Indexer;
+    use crate::queries::KIND_NAV_EXPR;
+
+    fn find_outermost_nav_expr(node: tree_sitter::Node) -> Option<tree_sitter::Node> {
+        if node.kind() == KIND_NAV_EXPR {
+            return Some(node);
+        }
+        let mut cursor = node.walk();
+        let found = node.children(&mut cursor).find_map(find_outermost_nav_expr);
+        found
+    }
+
+    let idx = Indexer::new();
+    idx.index_content(
+        &Url::parse("file:///unrelated/Other.kt").unwrap(),
+        "package unrelated\nclass Other { val value: String = \"wrong\" }\n",
+    );
+    idx.index_content(
+        &Url::parse("file:///lib/Other.kt").unwrap(),
+        "package lib\nclass Other { val value: Int = 1 }\n",
+    );
+    idx.index_content(
+        &Url::parse("file:///lib/Holder.kt").unwrap(),
+        "package lib\nclass Holder { val other: Other = Other() }\n",
+    );
+    let caller_uri = Url::parse("file:///app/Caller.kt").unwrap();
+    let caller_src =
+        "package app\nimport lib.Holder\nfun use(holder: Holder) = holder.other.value\n";
+    idx.index_content(&caller_uri, caller_src);
+
+    let (tree, bytes) = fun_body_expr_node(caller_src);
+    let expr = find_outermost_nav_expr(tree.root_node()).expect("holder.other.value not parsed");
+
+    assert_eq!(
+        infer_expr_type(expr, &bytes, &idx, &caller_uri).as_deref(),
+        Some("Int"),
+        "must resolve .value through Holder's own file (lib.Other.value: Int), \
+         not an unrelated same-named Other reachable from the caller"
+    );
+}
+
+#[test]
 fn unknown_identifier_returns_none() {
     // An unregistered variable → no type known
     assert_eq!(

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -1283,9 +1283,59 @@ fn resolve_member_type_on_fallback_when_class_params_unindexed() {
         &tower_lsp::lsp_types::Url::parse("file:///test/T.kt").unwrap(),
     );
     assert_eq!(
-        result.as_deref(),
+        result.map(|(ty, _)| ty).as_deref(),
         Some("Optional<FamilyAccount>"),
         "unindexed class params: field 'T' with empty subst must fall back to first type arg"
+    );
+}
+
+#[test]
+fn forward_resolve_segments_second_hop_uses_first_hops_declaring_file() {
+    // `holder.other.value` walked as a CST navigation chain: `.value` must
+    // resolve through `Other`'s own declaring file (reached from `Holder`,
+    // package `lib`), not the caller's — otherwise an unrelated same-named
+    // `Other`, reachable only from the caller's own file, wins instead. Real
+    // `Indexer` (not `TestDeps`) because this depends on
+    // `resolve_type_index_only`'s package-reachability rules.
+    use super::super::chain::{collect_nav_segments, resolve_segments_type, SuffixStrictness};
+    use crate::indexer::Indexer;
+    use crate::queries::KIND_NAV_EXPR;
+
+    let idx = Indexer::new();
+    idx.index_content(
+        &Url::parse("file:///unrelated/Other.kt").unwrap(),
+        "package unrelated\nclass Other { val value: String = \"wrong\" }\n",
+    );
+    idx.index_content(
+        &Url::parse("file:///lib/Other.kt").unwrap(),
+        "package lib\nclass Other { val value: Int = 1 }\n",
+    );
+    idx.index_content(
+        &Url::parse("file:///lib/Holder.kt").unwrap(),
+        "package lib\nclass Holder { val other: Other = Other() }\n",
+    );
+    let caller_uri = Url::parse("file:///app/Caller.kt").unwrap();
+    idx.index_content(&caller_uri, "package app\nimport lib.Holder\n");
+
+    let src = "fun use(holder: Holder) = holder.other.value";
+    let bytes = src.as_bytes();
+    let tree = parse_kotlin(src);
+    let nav_expr =
+        find_node_kind(tree.root_node(), KIND_NAV_EXPR).expect("holder.other.value not parsed");
+    let segments = collect_nav_segments(nav_expr, bytes);
+
+    let result = resolve_segments_type(
+        &segments,
+        bytes,
+        &idx,
+        &caller_uri,
+        SuffixStrictness::LeakReceiver,
+    );
+    assert_eq!(
+        result.as_deref(),
+        Some("Int"),
+        "must resolve .value through Holder's own file (lib.Other.value: Int), \
+         not an unrelated same-named Other reachable from the caller"
     );
 }
 
@@ -1307,7 +1357,7 @@ fn resolve_member_type_on_fallback_method_return_unindexed() {
         &tower_lsp::lsp_types::Url::parse("file:///test/T.kt").unwrap(),
     );
     assert_eq!(
-        result.as_deref(),
+        result.map(|(ty, _)| ty).as_deref(),
         Some("FamilyAccount"),
         "unindexed Optional params: getOrNull returning T? must fall back to FamilyAccount"
     );

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -2582,21 +2582,21 @@ fn cst_named_lambda_param_scope_fun_substitutes_receiver() {
 fn synthetic_enum_entries_field_type() {
     let (_, idx) = indexed("/Color.kt", "enum class Color { RED, GREEN, BLUE }");
     let ty = idx.find_field_type("Color", "entries", &uri("/Color.kt"));
-    assert_eq!(ty.as_deref(), Some("List<Color>"));
+    assert_eq!(ty.map(|(t, _)| t).as_deref(), Some("List<Color>"));
 }
 
 #[test]
 fn synthetic_enum_name_field_type() {
     let (_, idx) = indexed("/Color.kt", "enum class Color { RED, GREEN, BLUE }");
     let ty = idx.find_field_type("Color", "name", &uri("/Color.kt"));
-    assert_eq!(ty.as_deref(), Some("String"));
+    assert_eq!(ty.map(|(t, _)| t).as_deref(), Some("String"));
 }
 
 #[test]
 fn synthetic_enum_ordinal_field_type() {
     let (_, idx) = indexed("/Color.kt", "enum class Color { RED, GREEN, BLUE }");
     let ty = idx.find_field_type("Color", "ordinal", &uri("/Color.kt"));
-    assert_eq!(ty.as_deref(), Some("Int"));
+    assert_eq!(ty.map(|(t, _)| t).as_deref(), Some("Int"));
 }
 
 #[test]
@@ -2618,7 +2618,7 @@ fn synthetic_not_applied_to_non_enum() {
     let (_, idx) = indexed("/Foo.kt", "class Foo { val entries: String = \"\" }");
     let ty = idx.find_field_type("Foo", "entries", &uri("/Foo.kt"));
     // Should resolve from actual source, not synthetic
-    assert_ne!(ty.as_deref(), Some("List<Foo>"));
+    assert_ne!(ty.map(|(t, _)| t).as_deref(), Some("List<Foo>"));
 }
 
 #[test]

--- a/src/resolver/find.rs
+++ b/src/resolver/find.rs
@@ -104,25 +104,28 @@ pub(crate) fn find_name_scoped_to_container(
 ) -> Option<Location> {
     let file_data = ensure_file_data(idx, &container.uri)?;
 
-    if let Some(container_symbol) = file_data
+    let contained = file_data
         .symbols
         .iter()
         .find(|symbol| symbol.selection_range == container.range)
-    {
-        return file_data
-            .symbols
-            .iter()
-            .find(|symbol| {
+        .and_then(|container_symbol| {
+            file_data.symbols.iter().find(|symbol| {
                 symbol.name == name
                     && symbol.range != container_symbol.range
                     && range_encloses(container_symbol.range, symbol.range)
             })
-            .map(|found| Location {
-                uri: container.uri.clone(),
-                range: found.selection_range,
-            });
+        })
+        .map(|found| Location {
+            uri: container.uri.clone(),
+            range: found.selection_range,
+        });
+    if contained.is_some() {
+        return contained;
     }
 
+    // Range-containment misses degenerate containers whose declaration range
+    // doesn't actually span their members — e.g. JAR-derived stub symbols,
+    // which record only a name's line, not a real body range.
     find_name_in_uri_after_line(
         idx,
         name,

--- a/src/resolver/find.rs
+++ b/src/resolver/find.rs
@@ -95,8 +95,10 @@ pub(crate) fn find_name_in_uri_after_line(
 }
 
 /// Find `name` declared within `container`'s own body via exact
-/// range-containment, falling back to `find_name_in_uri_after_line` only
-/// when `container`'s own symbol entry can't be located.
+/// range-containment, falling back to `find_name_in_uri_after_line` when
+/// `container`'s own symbol entry can't be located, or when it's located but
+/// its recorded range doesn't enclose any matching member (e.g. degenerate
+/// JAR stub ranges — see the fallback call site below).
 pub(crate) fn find_name_scoped_to_container(
     idx: &Indexer,
     name: &str,

--- a/src/resolver/find.rs
+++ b/src/resolver/find.rs
@@ -5,6 +5,7 @@ use crate::indexer::Indexer;
 use crate::LinesExt;
 
 use super::ensure_file_data;
+use super::resolve::range_encloses;
 
 /// Search for `name` in a specific file identified by its URI string.
 ///
@@ -93,6 +94,45 @@ pub(crate) fn find_name_in_uri_after_line(
     vec![]
 }
 
+/// Find `name` declared within `container`'s own body via exact
+/// range-containment, falling back to `find_name_in_uri_after_line` only
+/// when `container`'s own symbol entry can't be located.
+pub(crate) fn find_name_scoped_to_container(
+    idx: &Indexer,
+    name: &str,
+    container: &Location,
+) -> Option<Location> {
+    let file_data = ensure_file_data(idx, &container.uri)?;
+
+    if let Some(container_symbol) = file_data
+        .symbols
+        .iter()
+        .find(|symbol| symbol.selection_range == container.range)
+    {
+        return file_data
+            .symbols
+            .iter()
+            .find(|symbol| {
+                symbol.name == name
+                    && symbol.range != container_symbol.range
+                    && range_encloses(container_symbol.range, symbol.range)
+            })
+            .map(|found| Location {
+                uri: container.uri.clone(),
+                range: found.selection_range,
+            });
+    }
+
+    find_name_in_uri_after_line(
+        idx,
+        name,
+        container.uri.as_str(),
+        container.range.start.line,
+    )
+    .into_iter()
+    .next()
+}
+
 /// Like `find_declaration_range_in_lines` but only searches from `start_line`.
 pub(crate) fn find_declaration_range_after_line(
     lines: &[String],
@@ -144,3 +184,7 @@ impl crate::indexer::Indexer {
         find_name_in_uri(self, name, file_uri)
     }
 }
+
+#[cfg(test)]
+#[path = "find_tests.rs"]
+mod tests;

--- a/src/resolver/find_tests.rs
+++ b/src/resolver/find_tests.rs
@@ -1,0 +1,95 @@
+use super::*;
+use crate::indexer::Indexer;
+use tower_lsp::lsp_types::{Position, Range};
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file://{path}")).unwrap()
+}
+
+const SIBLING_FIELDS_SRC: &str = "\
+sealed interface Event {
+    data class RegularInput(val event: RegularEvent) : Event
+    data class OverdraftInput(val event: OverdraftEvent) : Event
+}
+sealed interface RegularEvent
+sealed interface OverdraftEvent
+";
+
+#[test]
+fn scoped_to_a_specific_variant_finds_that_variants_own_field_not_a_sibling() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Reducer.kt");
+    idx.index_content(&file_uri, SIBLING_FIELDS_SRC);
+
+    let overdraft_input = find_name_in_uri(&idx, "OverdraftInput", file_uri.as_str())
+        .into_iter()
+        .next()
+        .expect("OverdraftInput should be indexed");
+
+    let found = find_name_scoped_to_container(&idx, "event", &overdraft_input)
+        .expect("event field should be found within OverdraftInput");
+
+    assert_eq!(
+        found.range.start.line, 2,
+        "must resolve to OverdraftInput's own `event` field, not RegularInput's: {:?}",
+        found.range
+    );
+}
+
+#[test]
+fn scoped_to_the_other_variant_finds_its_own_field_instead() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Reducer.kt");
+    idx.index_content(&file_uri, SIBLING_FIELDS_SRC);
+
+    let regular_input = find_name_in_uri(&idx, "RegularInput", file_uri.as_str())
+        .into_iter()
+        .next()
+        .expect("RegularInput should be indexed");
+
+    let found = find_name_scoped_to_container(&idx, "event", &regular_input)
+        .expect("event field should be found within RegularInput");
+
+    assert_eq!(
+        found.range.start.line, 1,
+        "must resolve to RegularInput's own `event` field, not OverdraftInput's: {:?}",
+        found.range
+    );
+}
+
+#[test]
+fn falls_back_to_closest_after_line_when_container_symbol_is_not_found() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Reducer.kt");
+    idx.index_content(&file_uri, SIBLING_FIELDS_SRC);
+
+    let fake_container = Location {
+        uri: file_uri.clone(),
+        range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+    };
+
+    let found = find_name_scoped_to_container(&idx, "event", &fake_container);
+    let fallback = find_name_in_uri_after_line(&idx, "event", file_uri.as_str(), 0)
+        .into_iter()
+        .next();
+    assert_eq!(found, fallback);
+}
+
+/// Documents pick-first: scoping to the outer `Event` (which encloses both
+/// variants) has two matches, and the first-declared one wins.
+#[test]
+fn scoping_to_an_outer_container_with_multiple_matches_picks_the_first() {
+    let idx = Indexer::new();
+    let file_uri = uri("/Reducer.kt");
+    idx.index_content(&file_uri, SIBLING_FIELDS_SRC);
+
+    let event_interface = find_name_in_uri(&idx, "Event", file_uri.as_str())
+        .into_iter()
+        .next()
+        .expect("Event should be indexed");
+
+    let found = find_name_scoped_to_container(&idx, "event", &event_interface)
+        .expect("at least one event field is enclosed by Event");
+
+    assert_eq!(found.range.start.line, 1);
+}

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -32,7 +32,10 @@ use crate::types::{CallerContext, FileData};
 use crate::StrExt;
 
 use super::fd::{fd_find_and_parse, import_package_prefix};
-use super::find::{find_local_declaration, find_name_in_uri, find_name_in_uri_after_line};
+use super::find::{
+    find_local_declaration, find_name_in_uri, find_name_in_uri_after_line,
+    find_name_scoped_to_container,
+};
 use super::hierarchy::{walk_hierarchy, MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK};
 use super::infer::{infer_field_type, infer_variable_type};
 
@@ -147,25 +150,17 @@ pub(crate) fn resolve_symbol(
                 if start + 1 == segments.len() {
                     return outer_locs;
                 }
-                // Walk each remaining nested segment within the current file.
-                let mut current_file = outer_loc.uri.to_string();
-                let mut resolved: Option<Vec<Location>> = None;
+                // Walk each remaining nested segment, re-anchoring on its own
+                // location so a same-named sibling elsewhere in the file
+                // can't shadow it (see `find_name_scoped_to_container`).
+                let mut container = outer_loc.clone();
                 for seg in &segments[start + 1..] {
-                    let locs = find_name_in_uri(indexer, seg, &current_file);
-                    match locs.first() {
-                        Some(loc) => {
-                            current_file = loc.uri.to_string();
-                            resolved = Some(locs);
-                        }
-                        None => {
-                            resolved = None;
-                            break;
-                        }
+                    match find_name_scoped_to_container(indexer, seg, &container) {
+                        Some(loc) => container = loc,
+                        None => return vec![],
                     }
                 }
-                if let Some(locs) = resolved {
-                    return locs;
-                }
+                return vec![container];
             }
         }
     }

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -32,10 +32,7 @@ use crate::types::{CallerContext, FileData};
 use crate::StrExt;
 
 use super::fd::{fd_find_and_parse, import_package_prefix};
-use super::find::{
-    find_local_declaration, find_name_in_uri, find_name_in_uri_after_line,
-    find_name_scoped_to_container,
-};
+use super::find::{find_local_declaration, find_name_in_uri, find_name_scoped_to_container};
 use super::hierarchy::{walk_hierarchy, MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK};
 use super::infer::{infer_field_type, infer_variable_type};
 
@@ -963,27 +960,14 @@ fn resolve_qualified(
                 }
             }
 
-            // Walk any remaining nested-type segments (`Event.OverdraftInput`
-            // has one: `OverdraftInput`) to that specific nested class's own
-            // location before searching for `name` — anchoring on `root`'s
-            // own line instead would just find whichever same-named sibling
-            // member happens to be textually closest to `root`'s declaration,
-            // not a member of the actually-requested nested type (see
-            // `find_name_in_uri_after_line`'s own doc comment: "we want the
-            // parameter/field of THAT class, not a same-named field in a
-            // different class that happens to appear earlier"). A real bug
-            // this fixes: an MVI sealed interface with many `data class Foo(val
-            // event: FooEvent) : Event`-shaped variants side by side — hovering
-            // `event.event` inside an `is Event.OverdraftInput ->` branch
-            // resolved to a *different* variant's `event` field, whichever one
-            // happened to sit closest to `Event`'s own declaration line.
+            // Walk any remaining nested-type segments (`Event.OverdraftInput` has
+            // one: `OverdraftInput`) to that specific nested class's own scope
+            // before searching for `name`, so a same-named sibling member never
+            // shadows the actually-requested nested type's own member.
             let mut anchor = qual_loc.clone();
             let mut nested_segments_resolved = true;
             for &nested_segment in &segments[1..] {
-                match find_name_in_uri(indexer, nested_segment, anchor.uri.as_str())
-                    .into_iter()
-                    .next()
-                {
+                match find_name_scoped_to_container(indexer, nested_segment, &anchor) {
                     Some(location) => anchor = location,
                     None => {
                         nested_segments_resolved = false;
@@ -995,10 +979,8 @@ fn resolve_qualified(
                 continue;
             }
 
-            let after_line = anchor.range.start.line;
-            let locs = find_name_in_uri_after_line(indexer, name, anchor.uri.as_str(), after_line);
-            if !locs.is_empty() {
-                return locs;
+            if let Some(loc) = find_name_scoped_to_container(indexer, name, &anchor) {
+                return vec![loc];
             }
         }
         // Extension functions may live in a different file than the receiver class.

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -577,6 +577,38 @@ fn resolve_deep_qualifier_chain() {
 }
 
 #[test]
+fn resolve_qualified_chain_scopes_a_colliding_middle_segment_to_its_own_outer_type() {
+    // Two sibling top-level types each declare a nested `Sub` with its own
+    // `target`. Resolving `Other.Sub.target` must walk to Other's own Sub, not
+    // Event's Sub (declared first in the file) via an unscoped mid-chain lookup.
+    let host_uri = uri("/Events.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &host_uri,
+        concat!(
+            "package com.pkg\n",
+            "sealed interface Event {\n",
+            "  sealed interface Sub {\n",
+            "    val target: Int\n",
+            "  }\n",
+            "}\n",
+            "sealed interface Other {\n",
+            "  sealed interface Sub {\n",
+            "    val target: Int\n",
+            "  }\n",
+            "}\n",
+        ),
+    );
+
+    let locs = resolve_symbol(&idx, "target", Some("Other.Sub"), &host_uri);
+    assert!(!locs.is_empty(), "Other.Sub.target not resolved");
+    assert_eq!(
+        locs[0].range.start.line, 8,
+        "must resolve to Other's own Sub.target (line 8), not Event's (line 3)"
+    );
+}
+
+#[test]
 fn resolve_nested_type_via_variable_annotation() {
     // `val factory: DashboardProductsReducer.Factory` — goto-def of `factory.create(...)`
     // should navigate to the `create` fun inside the `Factory` interface.

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -628,6 +628,26 @@ fn resolve_dotted_name_traverses_deep_nesting() {
 }
 
 #[test]
+fn resolve_dotted_name_scopes_a_nested_member_to_its_own_outer_type() {
+    // Two sibling sealed types in one file each declare a `Loading` member.
+    // `Event` is declared first, so a whole-file first-match lookup for
+    // `UiEvent.Loading` would wrongly return `Event`'s `Loading`.
+    let file_uri = uri("/Events.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &file_uri,
+        "sealed interface Event {\n  object Loading : Event\n}\nsealed interface UiEvent {\n  object Loading : UiEvent\n}\n",
+    );
+
+    let locs = resolve_symbol(&idx, "UiEvent.Loading", None, &file_uri);
+    assert!(!locs.is_empty(), "UiEvent.Loading not resolved");
+    assert_eq!(
+        locs[0].range.start.line, 4,
+        "must resolve to UiEvent's own Loading (line 4), not Event's (line 1)"
+    );
+}
+
+#[test]
 fn resolve_dotted_name_skips_leading_package_segments() {
     // `demo.Foo` — the leading lowercase package segment must be skipped so the
     // type `Foo` resolves.


### PR DESCRIPTION
## Summary
- Adds `find_name_scoped_to_container`, an exact range-containment lookup for "find `name` declared within a known container," replacing three lower-fidelity approximations used across the string-domain resolver.
- Fixes `resolve_symbol`'s dotted-`name` branch (site #4): a qualified type reference like `UiEvent.Loading` no longer resolves to a same-named sibling's member declared earlier in the same file.
- Fixes `resolve_qualified`'s uppercase-qualifier branch (site #2): closes a residual gap the earlier hover fix (#271) left standing, where *middle* segments of a 3+-segment nested-type chain (e.g. the `Sub` in `Other.Sub.target`) were still walked with an unscoped first-match lookup.
- Fixes `find_name_scoped_to_container` itself against a real regression it introduced: JAR-derived stub symbols record only a declaration line (`range == selection_range`), so a located container symbol whose range doesn't actually enclose any member now falls back to the existing line-proximity heuristic instead of returning no match.
- **CST-domain counterpart** (sites #3/#3b): `InferDeps::find_field_type` computed the field's declaring `Url` internally but discarded it, so `chain.rs::forward_resolve_segments` and `expr_type.rs::infer_navigation_expr_type` anchored *every* hop of a multi-segment chain (`a.b.c`) on the outermost caller's own file, never on the class actually being walked into. Widens the trait method to return `(String, Url)` and threads a per-hop reachability anchor through both walkers, mirroring the string-domain fix. Method-return lookups aren't `Url`-aware yet, so the anchor doesn't advance past a method-typed hop — left as a coordination note for CST Slice 4.

This is Steps 1-3 and 5-7 of `docs/superpowers/specs/2026-08-24-qualified-resolution-unification-design.md`. Step 4 (site #1 reshaping) is skipped — the design doc's own evaluation criterion ("land only if step 3 shows real value in a single consistent lookup path") wasn't met, since sites #2 and #4's bail-out semantics differ enough (`return` vs `continue` in a surrounding loop) that extracting a shared `walk_qualified_segments` helper would be net-negative in clarity. Step 8 is a coordination note, not an executable step.

## Test plan
- [x] `cargo test --bin kmp-lsp` — 1775 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Every fix has a RED-then-GREEN regression test (sibling/package-collision decoy fixtures), each confirmed to fail against pre-fix code before the fix landed
- [x] The JAR-stub fallback regression was caught by the existing `member_call_on_jar_receiver_resolves_cst_resolved` test and fixed before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ