### PR TITLE
refactor: split section-comment-narrated functions into named helpers

### DIFF
--- a/contrib/kotlin-cli.py
+++ b/contrib/kotlin-cli.py
@@ -322,6 +322,59 @@ def _infer_base_package(pkg: str) -> str:
     return ".".join(parts)
 
 
+def _sentinel_package_and_feature_names(
+    content: str, base_package: str, feature_pascal: str, feature_camel: str, feature_snake: str
+) -> str:
+    """Replace the base package and feature-name variants with bare __WORD__ sentinels.
+
+    Package first (most specific — must run before the individual word-part
+    substitutions below could partially match inside it); Pascal case before
+    camel/snake to avoid partial matches between variants.
+    """
+    result = content
+    if base_package:
+        result = result.replace(base_package, "__PACKAGE_NAME__")
+    result = result.replace(feature_pascal, "__FEATURE_NAME__")
+    result = result.replace(feature_camel, "__featureName__")
+    result = result.replace(feature_snake, "__feature_name__")
+    return result
+
+
+def _escape_kotlin_and_velocity_dollars(content: str) -> str:
+    """Escape `${...}` and bare `$ident` so Velocity doesn't interpret them as its own syntax.
+
+    Must run after sentinel substitution: sentinels are bare `__WORD__` at this
+    point, never `${...}` or `$ident`, so every match here is a real Kotlin/
+    Velocity dollar sign that needs escaping, not one of our placeholders.
+    """
+    result = re.sub(r'\$\{(\w+)\}', r'\\${\1}', content)
+    result = re.sub(
+        r'\$([A-Za-z_]\w*)',
+        lambda m: m.group(0) if m.group(1).startswith("__") else f'\\${m.group(1)}',
+        result,
+    )
+    return result
+
+
+def _restore_sentinels_as_template_vars(content: str) -> str:
+    """Turn __WORD__ sentinels back into ${VAR} template placeholders."""
+    result = content.replace("__PACKAGE_NAME__", "${PACKAGE_NAME}")
+    result = result.replace("__FEATURE_NAME__", "${FEATURE_NAME}")
+    result = result.replace("__featureName__", "${featureName}")
+    result = result.replace("__feature_name__", "${feature_name}")
+    return result
+
+
+def _unescape_scaffold_vars(content: str) -> str:
+    """Undo dollar-escaping that _escape_kotlin_and_velocity_dollars applied to our
+    own restored template vars before it ran (a real ${FEATURE_NAME} etc. in the
+    source, as opposed to one we just introduced, would otherwise stay escaped)."""
+    result = content
+    for var in _SCAFFOLD_VARS:
+        result = result.replace(f"\\${{{var}}}", f"${{{var}}}")
+    return result
+
+
 def _parameterize(content: str, feature_pascal: str, base_package: str) -> str:
     """Replace feature-identifier variants with ${VAR} placeholders.
 
@@ -331,39 +384,12 @@ def _parameterize(content: str, feature_pascal: str, base_package: str) -> str:
     feature_camel = feature_pascal[0].lower() + feature_pascal[1:]
     feature_snake = _pascal_to_snake(feature_pascal)
 
-    result = content
-
-    # 1. Package path (most specific — replace before individual word parts)
-    if base_package:
-        result = result.replace(base_package, "__PACKAGE_NAME__")
-
-    # 2. Class-name variants → sentinels (Pascal first to avoid partial matches)
-    result = result.replace(feature_pascal, "__FEATURE_NAME__")
-    result = result.replace(feature_camel,  "__featureName__")
-    result = result.replace(feature_snake,  "__feature_name__")
-
-    # 3. Escape remaining ${...} (Kotlin string templates that Velocity would interpret)
-    #    At this point sentinels are bare __WORD__ — not inside ${}, so no sentinel
-    #    can match here; every match is a Kotlin ${ } that needs escaping.
-    result = re.sub(r'\$\{(\w+)\}', r'\\${\1}', result)
-
-    # 4. Escape bare $ident (Velocity reference syntax) — skip our sentinels
-    result = re.sub(
-        r'\$([A-Za-z_]\w*)',
-        lambda m: m.group(0) if m.group(1).startswith("__") else f'\\${m.group(1)}',
-        result,
+    result = _sentinel_package_and_feature_names(
+        content, base_package, feature_pascal, feature_camel, feature_snake
     )
-
-    # 5. Restore sentinels → ${VAR} placeholders
-    result = result.replace("__PACKAGE_NAME__", "${PACKAGE_NAME}")
-    result = result.replace("__FEATURE_NAME__", "${FEATURE_NAME}")
-    result = result.replace("__featureName__",  "${featureName}")
-    result = result.replace("__feature_name__", "${feature_name}")
-
-    # 6. Un-escape any of our vars that step 3 may have caught before sentinels were set
-    for var in _SCAFFOLD_VARS:
-        result = result.replace(f"\\${{{var}}}", f"${{{var}}}")
-
+    result = _escape_kotlin_and_velocity_dollars(result)
+    result = _restore_sentinels_as_template_vars(result)
+    result = _unescape_scaffold_vars(result)
     return result
 
 
@@ -564,35 +590,17 @@ def cmd_scaffold_feature(
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
-def cmd_generate_template(
-    client: LspClient,
-    source_class: str,
-    family_name: str,
-    workspace: str,
-    dry_run: bool,
-    as_json: bool,
-) -> None:
-    """Generate IDEA file templates from an existing class and its feature siblings.
+def _discover_feature_files(
+    client: LspClient, feature_id: str, source_file: pathlib.Path
+) -> list[tuple[str, str]]:
+    """Every workspace file whose top-level class name starts with `feature_id`,
+    paired with its package (read from the file's own `package` declaration).
 
-    Finds all workspace symbols that share the feature identifier prefix (e.g.
-    all GoldConversion* classes), parameterizes their source files by replacing
-    every case-variant of the feature identifier with ${FEATURE_NAME} /
-    ${featureName} / ${feature_name} / ${PACKAGE_NAME}, and writes the results
-    as a reusable IDEA file template family.
-
-    The generated templates are immediately usable with scaffold-feature:
-        scaffold-feature NewFeature --template 'My Family' --package com.example
+    Uses workspace/symbol rather than a directory walk since it's reliable
+    across subdirectories (contract/, screen/, viewmodel/, etc.). Falls back to
+    just the source file when nothing else matches. Returns them sorted with
+    the source class's own file first, then alphabetically by basename.
     """
-    # 1. Resolve the source class to a file
-    sym = _resolve_unique_symbol(client, source_class, kind_filter=_KOTLIN_CLASS_KINDS)
-    source_file = pathlib.Path(sym["location"]["uri"].removeprefix("file://"))
-
-    # 2. Derive feature identifier (strip known role suffix: GoldConversionInteractor → GoldConversion)
-    feature_id = _extract_feature_id(source_class)
-    print(f"Feature identifier: {feature_id!r}", file=sys.stderr)
-
-    # 3. Discover all files that belong to this feature via workspaceSymbol
-    #    (reliable across subdirectories — contract/, screen/, viewmodel/, etc.)
     resp = client.request("workspace/symbol", {"query": feature_id})
     all_syms = resp.get("result") or []
     feature_files: dict[str, str] = {}  # filepath → package
@@ -603,7 +611,6 @@ def cmd_generate_template(
             continue
         fpath = s["location"]["uri"].removeprefix("file://")
         if fpath not in feature_files:
-            # Read the package declaration from the file
             try:
                 for line in pathlib.Path(fpath).read_text(encoding="utf-8").splitlines()[:8]:
                     if line.startswith("package "):
@@ -615,25 +622,18 @@ def cmd_generate_template(
                 feature_files[fpath] = ""
 
     if not feature_files:
-        # Fallback: just the source file
         feature_files[str(source_file)] = ""
 
-    # Sort: source class file first, rest alphabetically by basename
-    sorted_files = sorted(
+    return sorted(
         feature_files.items(),
         key=lambda kv: (0 if kv[0] == str(source_file) else 1, pathlib.Path(kv[0]).name),
     )
 
-    # 4. Infer base package from source file (strips role sub-packages)
-    src_package = feature_files.get(str(source_file), "")
-    base_package = _infer_base_package(src_package) if src_package else ""
 
-    print(f"Base package:       {base_package!r}", file=sys.stderr)
-    print(f"Files ({len(sorted_files)}):", file=sys.stderr)
-    for fp, _ in sorted_files:
-        print(f"  {fp}", file=sys.stderr)
-
-    # 5. Parameterize each file and derive file_name_pattern
+def _build_template_entries(
+    sorted_files: list[tuple[str, str]], feature_id: str, base_package: str
+) -> list[dict]:
+    """Parameterize each feature file's content and derive its file_name_pattern."""
     entries = []
     for filepath, pkg in sorted_files:
         try:
@@ -666,42 +666,34 @@ def cmd_generate_template(
             "file_name_pattern": file_name_pattern,
             "content":           parameterized,
         })
+    return entries
 
-    if not entries:
-        print("No files to templatize.", file=sys.stderr)
-        sys.exit(1)
 
-    if as_json:
-        print(json.dumps(
-            [{"suffix": e["file_suffix"], "source": e["filepath"],
-              "file_name": e["file_name_pattern"]} for e in entries],
-            indent=2,
-        ))
-        return
-
-    if dry_run:
+def _print_dry_run_preview(entries: list[dict]) -> None:
+    """Print, per entry, up to 6 changed lines relative to the original file
+    (in-memory original — no disk re-read needed)."""
+    print()
+    for e in entries:
+        print(f"── {pathlib.Path(e['filepath']).name}  [{e['file_suffix']}]")
+        print(f"   file-name: {e['file_name_pattern'] or '(auto-derived by scaffold-feature)'}")
+        orig = e["orig_content"].splitlines()
+        new  = e["content"].splitlines()
+        shown = 0
+        for i, (o, n) in enumerate(zip(orig, new)):
+            if o != n:
+                print(f"   L{i+1:3d}  - {o.strip()[:80]}")
+                print(f"        + {n.strip()[:80]}")
+                shown += 1
+                if shown >= 6:
+                    remaining = sum(1 for a, b in zip(orig[i+1:], new[i+1:]) if a != b)
+                    if remaining:
+                        print(f"        … ({remaining} more changes)")
+                    break
         print()
-        for e in entries:
-            print(f"── {pathlib.Path(e['filepath']).name}  [{e['file_suffix']}]")
-            print(f"   file-name: {e['file_name_pattern'] or '(auto-derived by scaffold-feature)'}")
-            # Show changed lines (use in-memory original — no disk re-read needed)
-            orig = e["orig_content"].splitlines()
-            new  = e["content"].splitlines()
-            shown = 0
-            for i, (o, n) in enumerate(zip(orig, new)):
-                if o != n:
-                    print(f"   L{i+1:3d}  - {o.strip()[:80]}")
-                    print(f"        + {n.strip()[:80]}")
-                    shown += 1
-                    if shown >= 6:
-                        remaining = sum(1 for a, b in zip(orig[i+1:], new[i+1:]) if a != b)
-                        if remaining:
-                            print(f"        … ({remaining} more changes)")
-                        break
-            print()
-        return
 
-    # 6. Write template files
+
+def _write_template_files(workspace: str, family_name: str, entries: list[dict]) -> None:
+    """Write `entries` as an IDEA file template family and update its settings.xml."""
     templates_dir = _find_templates_dir(workspace)
     if templates_dir is None:
         templates_dir = pathlib.Path(workspace) / ".idea" / "fileTemplates"
@@ -727,6 +719,63 @@ def cmd_generate_template(
     print(f"\nGenerated {len(entries)} template(s) for family '{family_name}'")
     print(f"Use: scaffold-feature NewFeature --template '{family_name}' --package <base-pkg>")
 
+
+def cmd_generate_template(
+    client: LspClient,
+    source_class: str,
+    family_name: str,
+    workspace: str,
+    dry_run: bool,
+    as_json: bool,
+) -> None:
+    """Generate IDEA file templates from an existing class and its feature siblings.
+
+    Finds all workspace symbols that share the feature identifier prefix (e.g.
+    all GoldConversion* classes), parameterizes their source files by replacing
+    every case-variant of the feature identifier with ${FEATURE_NAME} /
+    ${featureName} / ${feature_name} / ${PACKAGE_NAME}, and writes the results
+    as a reusable IDEA file template family.
+
+    The generated templates are immediately usable with scaffold-feature:
+        scaffold-feature NewFeature --template 'My Family' --package com.example
+    """
+    sym = _resolve_unique_symbol(client, source_class, kind_filter=_KOTLIN_CLASS_KINDS)
+    source_file = pathlib.Path(sym["location"]["uri"].removeprefix("file://"))
+
+    # Strip known role suffix: GoldConversionInteractor → GoldConversion
+    feature_id = _extract_feature_id(source_class)
+    print(f"Feature identifier: {feature_id!r}", file=sys.stderr)
+
+    sorted_files = _discover_feature_files(client, feature_id, source_file)
+
+    # Base package strips role sub-packages from the source file's own package.
+    src_package = dict(sorted_files).get(str(source_file), "")
+    base_package = _infer_base_package(src_package) if src_package else ""
+
+    print(f"Base package:       {base_package!r}", file=sys.stderr)
+    print(f"Files ({len(sorted_files)}):", file=sys.stderr)
+    for fp, _ in sorted_files:
+        print(f"  {fp}", file=sys.stderr)
+
+    entries = _build_template_entries(sorted_files, feature_id, base_package)
+
+    if not entries:
+        print("No files to templatize.", file=sys.stderr)
+        sys.exit(1)
+
+    if as_json:
+        print(json.dumps(
+            [{"suffix": e["file_suffix"], "source": e["filepath"],
+              "file_name": e["file_name_pattern"]} for e in entries],
+            indent=2,
+        ))
+        return
+
+    if dry_run:
+        _print_dry_run_preview(entries)
+        return
+
+    _write_template_files(workspace, family_name, entries)
 
 
 def _loc(loc: dict) -> str:
@@ -969,38 +1018,25 @@ def cmd_find_implementors(client: LspClient, name: str, as_json: bool):
             print(_loc(r))
 
 
-def cmd_extract_interface(client: LspClient, class_name: str, as_json: bool):
-    """Generate a Kotlin interface skeleton from a class's public members.
-
-    Signatures come from DocumentSymbol.detail (the truncated declaration stored
-    in the index).  Abstract/interface method bodies are excluded automatically.
-    Output is printed to stdout — pipe to a .kt file or paste into your editor.
-    """
-    # 1. Locate the class file
-    sym = _resolve_unique_symbol(client, class_name, kind_filter=_KOTLIN_CLASS_KINDS)
-    file_uri = sym["location"]["uri"]
-    filepath = file_uri.removeprefix("file://")
-
-    # 2. Get all symbols in that file
-    all_syms = _document_symbols(client, filepath)
-
-    # 3. Find the class symbol by name to get its range
-    class_sym = next(
+def _find_class_symbol(all_syms: list[dict], class_name: str) -> dict | None:
+    """The DocumentSymbol for `class_name` among a file's symbol list, or None."""
+    return next(
         (s for s in all_syms
          if s["name"] == class_name
          and _KIND_NAMES.get(s.get("kind", 0)) in _KOTLIN_CLASS_KINDS),
         None,
     )
-    if class_sym is None:
-        print(f"Could not locate '{class_name}' in documentSymbol results.",
-              file=sys.stderr)
-        sys.exit(1)
 
+
+def _collect_interface_members(all_syms: list[dict], class_sym: dict) -> list[dict]:
+    """Public members of `class_sym` suitable for an interface skeleton.
+
+    First records every function/method and nested-class range inside the
+    class, then keeps a candidate member only if it doesn't sit inside a
+    nested class or inside a function body (a local var/property), and isn't
+    visibly private/internal/protected by its `detail` prefix.
+    """
     class_range = class_sym["range"]
-
-    # 4. Collect members: first record all function/method ranges, then
-    #    include properties only if they lie outside any function body.
-    #    Also skip visibly-private/internal symbols by detail prefix.
     function_ranges: list[dict] = []
     nested_class_ranges: list[dict] = []
     candidate_members: list[dict] = []
@@ -1025,34 +1061,22 @@ def cmd_extract_interface(client: LspClient, class_name: str, as_json: bool):
     for s in candidate_members:
         kind = _KIND_NAMES.get(s.get("kind", 0))
         sym_range = s["range"]
-        # Skip symbols inside a nested class
         if any(_range_contains(nr, sym_range) for nr in nested_class_ranges):
             continue
-        # Skip local variables/properties that live inside a function body
         if kind not in ("method", "function") and any(
             _range_contains(fr, sym_range) for fr in function_ranges
         ):
             continue
-        # Skip private/internal members (they don't belong in a public interface)
         detail: str = s.get("detail") or ""
         if detail.startswith(("private ", "internal ", "protected ")):
             continue
         members.append(s)
 
-    if not members:
-        print(f"No members found inside '{class_name}'.", file=sys.stderr)
-        sys.exit(1)
+    return members
 
-    if as_json:
-        print(json.dumps(
-            [{"name": m["name"],
-              "kind": _KIND_NAMES.get(m.get("kind", 0), "?"),
-              "detail": m.get("detail", "")}
-             for m in members],
-            indent=2,
-        ))
-        return
 
+def _render_interface_skeleton(class_name: str, members: list[dict]) -> str:
+    """Render `members`' declarations as a Kotlin interface named `I{class_name}`."""
     iface_name = f"I{class_name}"
     lines = [f"interface {iface_name} {{"]
     for m in members:
@@ -1067,7 +1091,42 @@ def cmd_extract_interface(client: LspClient, class_name: str, as_json: bool):
             kind = _KIND_NAMES.get(m.get("kind", 0), "?")
             lines.append(f"    // {kind} {m['name']}")
     lines.append("}")
-    print("\n".join(lines))
+    return "\n".join(lines)
+
+
+def cmd_extract_interface(client: LspClient, class_name: str, as_json: bool):
+    """Generate a Kotlin interface skeleton from a class's public members.
+
+    Signatures come from DocumentSymbol.detail (the truncated declaration stored
+    in the index).  Abstract/interface method bodies are excluded automatically.
+    Output is printed to stdout — pipe to a .kt file or paste into your editor.
+    """
+    sym = _resolve_unique_symbol(client, class_name, kind_filter=_KOTLIN_CLASS_KINDS)
+    filepath = sym["location"]["uri"].removeprefix("file://")
+    all_syms = _document_symbols(client, filepath)
+
+    class_sym = _find_class_symbol(all_syms, class_name)
+    if class_sym is None:
+        print(f"Could not locate '{class_name}' in documentSymbol results.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    members = _collect_interface_members(all_syms, class_sym)
+    if not members:
+        print(f"No members found inside '{class_name}'.", file=sys.stderr)
+        sys.exit(1)
+
+    if as_json:
+        print(json.dumps(
+            [{"name": m["name"],
+              "kind": _KIND_NAMES.get(m.get("kind", 0), "?"),
+              "detail": m.get("detail", "")}
+             for m in members],
+            indent=2,
+        ))
+        return
+
+    print(_render_interface_skeleton(class_name, members))
 
 
 def _apply_text_edits(path: str, edits: list[dict]) -> None:

--- a/contrib/kotlin-cli.py
+++ b/contrib/kotlin-cli.py
@@ -343,9 +343,11 @@ def _sentinel_package_and_feature_names(
 def _escape_kotlin_and_velocity_dollars(content: str) -> str:
     """Escape `${...}` and bare `$ident` so Velocity doesn't interpret them as its own syntax.
 
-    Must run after sentinel substitution: sentinels are bare `__WORD__` at this
-    point, never `${...}` or `$ident`, so every match here is a real Kotlin/
-    Velocity dollar sign that needs escaping, not one of our placeholders.
+    Must run after sentinel substitution. A sentinel can still end up as the
+    identifier part of a `$ident` match — e.g. a source `$FeatureName`
+    becomes `$__FEATURE_NAME__` once "FeatureName" is replaced — so the
+    `startswith("__")` check below skips escaping those: they're placeholders
+    we just introduced, not real Velocity references.
     """
     result = re.sub(r'\$\{(\w+)\}', r'\\${\1}', content)
     result = re.sub(

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -456,43 +456,65 @@ fn declaration_files_for(
     declared_pkg: Option<&str>,
     source_uri: &Url,
 ) -> Vec<String> {
-    // When `declared_pkg` is available (i.e., we resolved the declaring package
-    // from imports or declaration site), use it to filter: only keep definitions
-    // that live in that specific package.  This prevents same-named types in
-    // different packages (e.g. `com.a.IntroContract.Event` vs
-    // `com.b.IntroContract.Event`) from merging their declaration files into the
-    // candidate set and producing false positives.
-    //
-    // Crucially, we use `declared_pkg` (the *declaration* package), NOT the
-    // source file's package.  Using the source package would incorrectly drop the
-    // declaration file when `findReferences` is invoked from a call site in a
-    // *different* package — the common cross-package usage scenario.
-    //
-    // When `declared_pkg` is None (unscoped lowercase off-decl-site search), fall
-    // back to the source package so that same-named top-level symbols from
-    // unrelated packages are not merged into candidates.
-    // JAR/library-defined symbol: no workspace file lives in its package, so the
-    // same-package definition-file scan below would find nothing. Instead, discover
-    // the workspace files that *import* the JAR symbol and use those as candidates.
-    // This drives the import-scoped reference search (reusing the existing
-    // qualifier-precision machinery) and keeps unrelated same-named workspace
-    // symbols out of the result set.
     if let Some(jar_pkg) = declared_pkg {
-        let no_workspace_decl = index
-            .definition_locations(name)
-            .iter()
-            .all(|loc| index.is_library_uri(&loc.uri));
-        if no_workspace_decl && index.jar_declaration_scope(name).is_some() {
-            let fqn = format!("{jar_pkg}.{name}");
-            return index
-                .workspace_importers_of(&fqn)
-                .into_iter()
-                .filter_map(|url| url.to_file_path().ok())
-                .filter_map(|path| path.to_str().map(|s| s.to_owned()))
-                .collect();
+        if let Some(files) = jar_import_scoped_declaration_files(index, name, jar_pkg) {
+            return files;
         }
     }
+    same_package_declaration_files(index, name, parent_class, declared_pkg, source_uri)
+}
 
+/// A JAR/library-defined symbol has no workspace file in its own package, so
+/// [`same_package_declaration_files`] would find nothing. Discovers the
+/// workspace files that *import* the JAR symbol instead, driving the
+/// import-scoped reference search (reusing the existing qualifier-precision
+/// machinery) and keeping unrelated same-named workspace symbols out of the
+/// result set.
+///
+/// Returns `None` when `name` isn't actually JAR-only (a workspace
+/// declaration exists, or `name` isn't a recognized JAR declaration at all),
+/// telling the caller to fall through to the normal same-package scan.
+fn jar_import_scoped_declaration_files(
+    index: &(impl SymbolIndex + ScopeQuery),
+    name: &str,
+    jar_pkg: &str,
+) -> Option<Vec<String>> {
+    let no_workspace_decl = index
+        .definition_locations(name)
+        .iter()
+        .all(|loc| index.is_library_uri(&loc.uri));
+    if !no_workspace_decl || index.jar_declaration_scope(name).is_none() {
+        return None;
+    }
+    let fqn = format!("{jar_pkg}.{name}");
+    Some(
+        index
+            .workspace_importers_of(&fqn)
+            .into_iter()
+            .filter_map(|url| url.to_file_path().ok())
+            .filter_map(|path| path.to_str().map(|s| s.to_owned()))
+            .collect(),
+    )
+}
+
+/// Filters `definition_locations` by parent class and by package, using
+/// `declared_pkg` (the *declaration* package) rather than the source file's
+/// package — the common cross-package usage scenario would otherwise
+/// incorrectly drop the declaration file when `findReferences` is invoked
+/// from a call site in a different package. Same-named types in different
+/// packages (e.g. `com.a.IntroContract.Event` vs `com.b.IntroContract.Event`)
+/// stay separate rather than merging into one candidate set.
+///
+/// Falls back to the source package when `declared_pkg` is `None` (unscoped
+/// lowercase off-declaration-site search), so unrelated same-named top-level
+/// symbols from other packages still don't merge into the candidates.
+fn same_package_declaration_files(
+    index: &(impl SymbolIndex + ScopeQuery),
+    name: &str,
+    parent_class: Option<&str>,
+    declared_pkg: Option<&str>,
+    source_uri: &Url,
+) -> Vec<String> {
     let source_pkg = index.package_of(source_uri);
     let pkg_filter = declared_pkg.or(source_pkg.as_deref());
     index

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -409,106 +409,12 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 abandon_stale_jar_scan(&indexer, &in_progress, &jar_done_tx);
                 return;
             }
-            // ── Compiled-JAR first (sidecar path, populates jar_files / jar_definitions) ──
-            // The Gradle-cache pipeline only matters for a workspace with
-            // JVM sources — a Swift-only project cannot reference anything
-            // in it, and unconditionally running the pipeline there cost a
-            // 1.28M-name Tier-1 manifest over 755 JARs plus a 1.66M-symbol
-            // sources-JAR pass (observed live on an iOS repo). Gated on the
-            // INDEX, not on build-file markers — see
-            // `workspace_has_jvm_sources` for why. This task races the
-            // workspace scan that populates that index (every caller
-            // enqueues the scan first, so the queue is already non-idle
-            // here), so the gate WAITS: it opens the moment the scan
-            // indexes the first JVM source, and returns a negative verdict
-            // only once the queue drains. Explicitly configured `jarPaths`
-            // below stay unaffected.
-            let generation_ok = || {
-                indexer
-                    .workspace_root
-                    .generation_atomic()
-                    .load(Ordering::Acquire)
-                    == expected_gen
-            };
-            // Recover from a poisoned queue lock rather than panicking: a
-            // panic here would strand `jar_indexing_in_progress` as true and
-            // wedge the jar pipeline for the rest of the process. Reading
-            // `is_in_progress` off a poisoned queue is harmless.
-            let workspace_uses_gradle_cache = match crate::indexer::jar::wait_for_jvm_sources_gate(
-                &indexer,
-                || {
-                    scan_queue
-                        .lock()
-                        .unwrap_or_else(|poisoned| poisoned.into_inner())
-                        .is_in_progress()
-                },
-                generation_ok,
-                std::time::Duration::from_millis(100),
-            ) {
-                Some(verdict) => verdict,
-                None => {
-                    abandon_stale_jar_scan(&indexer, &in_progress, &jar_done_tx);
-                    return;
-                }
-            };
-            let gradle_paths = if workspace_uses_gradle_cache {
-                crate::indexer::jar::scan_gradle_jars(None)
-            } else {
-                log::info!(
-                    "jar: no Kotlin/Java sources in the workspace — skipping the \
-                     Gradle-cache JAR pipeline (configured jarPaths still honored)"
-                );
-                Vec::new()
-            };
-            let gradle_count = gradle_paths.len();
-            let mut paths = gradle_paths;
-
-            // Explicitly-configured jars (workspace.json `jarPaths` + init-options
-            // `jarPaths`), so non-Gradle projects (Make/Bazel/manual) get symbols too.
-            // Filesystem I/O (read workspace.json, walk dirs) runs here off-thread.
-            if let Some(root) = indexer.workspace_root.get() {
-                let mut configured = crate::workspace_json::load_configured_jar_paths(&root);
-                configured.extend(crate::workspace_json::resolve_jar_path_specs(
-                    &init_jar_specs,
-                    &root,
-                ));
-                for jar in configured {
-                    if !paths.contains(&jar) {
-                        paths.push(jar);
-                    }
-                }
-            }
-
-            // Check generation before doing any JAR indexing work.
-            let current_gen = indexer
-                .workspace_root
-                .generation_atomic()
-                .load(Ordering::Acquire);
-            if current_gen != expected_gen {
+            let Some(compiled) =
+                index_compiled_jars_phase(&indexer, &scan_queue, expected_gen, &init_jar_specs)
+            else {
                 abandon_stale_jar_scan(&indexer, &in_progress, &jar_done_tx);
                 return;
-            }
-
-            crate::indexer::jar::clear_jar_maps(&indexer);
-            let (compiled_total, sidecar_alive) = {
-                let mut sidecar = indexer
-                    .jar_sidecar
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner());
-                let compiled_total =
-                    crate::indexer::jar::build_jar_manifest(&indexer, &paths, &mut sidecar);
-                (compiled_total, sidecar.is_some())
-                // `sidecar` MutexGuard drops here, at the end of this block —
-                // released before index_sources_jars runs, so an on-demand
-                // materialization request only ever contends with the
-                // compiled-JAR phase, never the (much longer) sources-JAR
-                // phase that follows it.
             };
-            log::info!(
-                "jar: manifested {compiled_total} names from {} compiled JARs (Tier 1 only — \
-                 full materialization deferred to first real use)",
-                paths.len()
-            );
 
             // Check generation again before continuing to sources-JAR work.
             let current_gen = indexer
@@ -520,19 +426,18 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 return;
             }
 
-            // ── Sources-JAR second (auto-mount, populates main files / definitions) ──
-            // Runs LAST so that when both pipelines contribute the same FQN to
-            // `qualified` / `extension_by_receiver`, the sources-JAR entry (real
-            // line numbers from tree-sitter) wins over the compiled-JAR entry
-            // (synthetic line indices from the sidecar). Same Gradle gate as
-            // the compiled pipeline — sources JARs come from the same cache.
-            let sources_total = if workspace_uses_gradle_cache {
+            // Sources JARs run LAST so that when both pipelines contribute the same
+            // FQN to `qualified` / `extension_by_receiver`, the sources-JAR entry
+            // (real line numbers from tree-sitter) wins over the compiled-JAR entry
+            // (synthetic line indices from the sidecar). Same Gradle gate as the
+            // compiled pipeline — sources JARs come from the same cache.
+            let sources_total = if compiled.workspace_uses_gradle_cache {
                 crate::indexer::jar::index_sources_jars(&indexer, None, None)
             } else {
                 0
             };
 
-            if paths.is_empty() && sources_total == 0 {
+            if compiled.paths.is_empty() && sources_total == 0 {
                 if let Ok(mut phase) = indexer.jar_phase.lock() {
                     *phase = JarPhase::Ready { count: 0 };
                 } else {
@@ -547,9 +452,9 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
 
             log::info!(
                 "jar: indexing {} compiled JARs/AARs ({} from Gradle cache, {} configured)",
-                paths.len(),
-                gradle_count,
-                paths.len() - gradle_count
+                compiled.paths.len(),
+                compiled.gradle_count,
+                compiled.paths.len() - compiled.gradle_count
             );
 
             // Check generation once more before recording terminal phase.
@@ -562,9 +467,10 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 return;
             }
 
-            let total = sources_total + compiled_total;
-            let final_phase = if !sidecar_alive && compiled_total > 0 {
+            let total = sources_total + compiled.compiled_total;
+            let final_phase = if !compiled.sidecar_alive && compiled.compiled_total > 0 {
                 // Sidecar died mid-index; sources may still be available.
+                let compiled_total = compiled.compiled_total;
                 JarPhase::Failed(format!(
                     "sidecar died mid-index; {total} symbols partially loaded ({sources_total} from sources, {compiled_total} from compiled)"
                 ))
@@ -586,6 +492,121 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             let _ = jar_done_tx.send(());
         });
     }
+}
+
+struct CompiledJarsOutcome {
+    paths: Vec<PathBuf>,
+    gradle_count: usize,
+    compiled_total: usize,
+    sidecar_alive: bool,
+    workspace_uses_gradle_cache: bool,
+}
+
+/// Crawl the Gradle cache (sidecar path, populates `jar_files`/`jar_definitions`)
+/// and merge in explicitly-configured jar paths, then Tier-1-manifest all of them
+/// through the sidecar.
+///
+/// The Gradle-cache pipeline only matters for a workspace with JVM sources — a
+/// Swift-only project cannot reference anything in it, and unconditionally
+/// running the pipeline there cost a 1.28M-name Tier-1 manifest over 755 JARs
+/// plus a 1.66M-symbol sources-JAR pass (observed live on an iOS repo). Gated
+/// on the INDEX, not on build-file markers — see `workspace_has_jvm_sources`
+/// for why. This task races the workspace scan that populates that index
+/// (every caller enqueues the scan first, so the queue is already non-idle
+/// here), so the gate WAITS: it opens the moment the scan indexes the first
+/// JVM source, and returns a negative verdict only once the queue drains.
+/// Explicitly configured `jarPaths` stay unaffected by the gate.
+///
+/// Returns `None` if a newer scan superseded this one (generation changed, or
+/// the gate itself detected staleness) — the caller must abandon rather than
+/// use a stale result.
+fn index_compiled_jars_phase(
+    indexer: &Indexer,
+    scan_queue: &Mutex<ScanQueue>,
+    expected_gen: u64,
+    init_jar_specs: &[String],
+) -> Option<CompiledJarsOutcome> {
+    let generation_ok = || {
+        indexer
+            .workspace_root
+            .generation_atomic()
+            .load(Ordering::Acquire)
+            == expected_gen
+    };
+    // Recover from a poisoned queue lock rather than panicking: a panic here
+    // would strand `jar_indexing_in_progress` as true and wedge the jar
+    // pipeline for the rest of the process. Reading `is_in_progress` off a
+    // poisoned queue is harmless.
+    let workspace_uses_gradle_cache = crate::indexer::jar::wait_for_jvm_sources_gate(
+        indexer,
+        || {
+            scan_queue
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_in_progress()
+        },
+        generation_ok,
+        std::time::Duration::from_millis(100),
+    )?;
+
+    let gradle_paths = if workspace_uses_gradle_cache {
+        crate::indexer::jar::scan_gradle_jars(None)
+    } else {
+        log::info!(
+            "jar: no Kotlin/Java sources in the workspace — skipping the \
+             Gradle-cache JAR pipeline (configured jarPaths still honored)"
+        );
+        Vec::new()
+    };
+    let gradle_count = gradle_paths.len();
+    let mut paths = gradle_paths;
+
+    // Explicitly-configured jars (workspace.json `jarPaths` + init-options
+    // `jarPaths`), so non-Gradle projects (Make/Bazel/manual) get symbols too.
+    // Filesystem I/O (read workspace.json, walk dirs) runs here off-thread.
+    if let Some(root) = indexer.workspace_root.get() {
+        let mut configured = crate::workspace_json::load_configured_jar_paths(&root);
+        configured.extend(crate::workspace_json::resolve_jar_path_specs(
+            init_jar_specs,
+            &root,
+        ));
+        for jar in configured {
+            if !paths.contains(&jar) {
+                paths.push(jar);
+            }
+        }
+    }
+
+    if !generation_ok() {
+        return None;
+    }
+
+    crate::indexer::jar::clear_jar_maps(indexer);
+    let (compiled_total, sidecar_alive) = {
+        let mut sidecar = indexer
+            .jar_sidecar
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let compiled_total = crate::indexer::jar::build_jar_manifest(indexer, &paths, &mut sidecar);
+        (compiled_total, sidecar.is_some())
+        // `sidecar` MutexGuard drops here, at the end of this block —
+        // released before index_sources_jars runs, so an on-demand
+        // materialization request only ever contends with the compiled-JAR
+        // phase, never the (much longer) sources-JAR phase that follows it.
+    };
+    log::info!(
+        "jar: manifested {compiled_total} names from {} compiled JARs (Tier 1 only — \
+         full materialization deferred to first real use)",
+        paths.len()
+    );
+
+    Some(CompiledJarsOutcome {
+        paths,
+        gradle_count,
+        compiled_total,
+        sidecar_alive,
+        workspace_uses_gradle_cache,
+    })
 }
 
 /// Clean up after a background JAR scan abandons because the workspace generation


### PR DESCRIPTION
## Summary
- `ScanHandler::spawn_jar_indexing`: extracted the compiled-JAR crawl/manifest phase into `index_compiled_jars_phase`, removing the `// ── Compiled-JAR first ──` / `// ── Sources-JAR second ──` banner comments and shrinking the closure from 173 to ~70 lines.
- `references::declaration_files_for`: split into `jar_import_scoped_declaration_files` and `same_package_declaration_files`, replacing a comment that narrated both branches before the code implementing them.
- `contrib/kotlin-cli.py`: split `_parameterize`'s 6 numbered steps into dedicated sentinel/escape/restore functions, and split `cmd_generate_template`/`cmd_extract_interface`'s numbered steps into discovery/build/render helpers.

All three matched the "section comments inside a function body signal a split" rule in `docs/agent-reference.md` — found via a codebase-wide scout for large comment blocks. Pure extractions, no behavior change intended.

## Test plan
- [x] `cargo test` — full suite green (1775+ unit tests, integration/smoke tests, doc tests)
- [x] `cargo clippy --bin kmp-lsp -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `_parameterize` differentially tested against the pre-refactor implementation across several inputs — byte-identical output
- [x] `contrib/kotlin-cli.py` re-parses/compiles; new helper functions sanity-checked in isolation (interface-member filtering correctly excludes locals/private/nested-class members)

🤖 Generated with [Claude Code](https://claude.com/claude-code)