### PR TITLE
perf(resolution-accuracy): eliminate rg/fd subprocess spawns from the benchmark

### DIFF
--- a/src/features/unresolved_symbol_diagnostics.rs
+++ b/src/features/unresolved_symbol_diagnostics.rs
@@ -16,7 +16,8 @@ use tree_sitter::Node;
 
 use crate::indexer::live_tree::LiveDoc;
 use crate::indexer::{
-    classify_cursor, resolve_identity, Indexer, NavigationSource, SymbolAtCursor, SymbolRole,
+    classify_cursor, resolve_identity_with_io, Indexer, NavigationSource, SymbolAtCursor,
+    SymbolRole,
 };
 use crate::queries::{KIND_IMPORT_HEADER, KIND_PACKAGE_HEADER, KIND_SIMPLE_IDENT, KIND_TYPE_IDENT};
 
@@ -141,7 +142,7 @@ fn classify_reference(
     symbol: &SymbolAtCursor,
     receiver_type: Option<String>,
 ) -> ResolutionOutcome {
-    let success = match resolve_identity(symbol, indexer, uri) {
+    let success = match resolve_identity_with_io(symbol, indexer, uri, true) {
         NavigationSource::CstResolved(defs) if !defs.is_empty() => {
             Some((SuccessTier::CstResolved, defs.0))
         }
@@ -153,7 +154,7 @@ fn classify_reference(
     match success {
         Some((tier, locations)) => ResolutionOutcome::Success { tier, locations },
         None if receiver_type.is_some() => {
-            let probe = indexer.find_definition_qualified(&symbol.name, None, uri);
+            let probe = indexer.find_definition_qualified_index_only(&symbol.name, None, uri);
             if probe.is_empty() {
                 ResolutionOutcome::Gap
             } else {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -40,8 +40,8 @@ pub(crate) use self::infer::{
     cst_symbol::{
         classify_cursor, classify_symbol_at, enclosing_nav_expr_if_member, is_call_callee,
         is_declaration_site, local_scope_occurrences, navigation_member_ident,
-        navigation_receiver_node, resolve_identity, shape_filter_locations, NavigationSource,
-        SymbolAtCursor, SymbolRole,
+        navigation_receiver_node, resolve_identity, resolve_identity_with_io,
+        shape_filter_locations, NavigationSource, SymbolAtCursor, SymbolRole,
     },
     deps::{CallShape, CallableInfo, InferDeps, OuterScopedParams, ShapeFiltered},
     expr_type::infer_expr_type,

--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -345,9 +345,29 @@ pub(crate) fn resolve_identity(
     indexer: &Indexer,
     uri: &Url,
 ) -> NavigationSource<Definitions> {
+    resolve_identity_with_io(symbol, indexer, uri, false)
+}
+
+/// Like `resolve_identity` but, when `index_only` is set, never spawns
+/// `rg`/`fd` — see `resolve_symbol_index_only`'s own doc comment for why.
+/// Used by the resolution-accuracy benchmark, which calls this once per
+/// identifier in a whole corpus.
+pub(crate) fn resolve_identity_with_io(
+    symbol: &SymbolAtCursor,
+    indexer: &Indexer,
+    uri: &Url,
+    index_only: bool,
+) -> NavigationSource<Definitions> {
+    let find_definition_qualified = |name: &str, qualifier: Option<&str>, uri: &Url| {
+        if index_only {
+            indexer.find_definition_qualified_index_only(name, qualifier, uri)
+        } else {
+            indexer.find_definition_qualified(name, qualifier, uri)
+        }
+    };
     match &symbol.role {
         SymbolRole::Declaration { indexed } => {
-            let locations = Definitions(indexer.find_definition_qualified(&symbol.name, None, uri));
+            let locations = Definitions(find_definition_qualified(&symbol.name, None, uri));
             // Only declarations `KOTLIN_DEFINITIONS` actually indexes can be
             // trusted CST-resolved; an unindexed one (bare param, val/var-less
             // constructor param, type param) falls through to an unanchored
@@ -364,8 +384,7 @@ pub(crate) fn resolve_identity(
             shape,
             ..
         } => {
-            let locations =
-                indexer.find_definition_qualified(&symbol.name, Some(receiver_type), uri);
+            let locations = find_definition_qualified(&symbol.name, Some(receiver_type), uri);
             // A call's own shape rules out a same-named, wrong-arity member/
             // extension on the same receiver type — e.g. `triggers.collect {
             // trigger -> }` (1 arg via trailing lambda) must not resolve to a
@@ -391,7 +410,7 @@ pub(crate) fn resolve_identity(
             ..
         }
         | SymbolRole::ImportSegment => NavigationSource::NameScan(Definitions(
-            indexer.find_definition_qualified(&symbol.name, None, uri),
+            find_definition_qualified(&symbol.name, None, uri),
         )),
     }
 }

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -49,6 +49,17 @@ impl Indexer {
         self.resolve_symbol(name, qualifier, from_uri)
     }
 
+    /// Like `find_definition_qualified` but never spawns `rg`/`fd` — see
+    /// `resolve_symbol_index_only`'s own doc comment for why.
+    pub(crate) fn find_definition_qualified_index_only(
+        &self,
+        name: &str,
+        qualifier: Option<&str>,
+        from_uri: &Url,
+    ) -> Vec<Location> {
+        self.resolve_symbol_index_only(name, qualifier, from_uri)
+    }
+
     /// Resolve an unqualified call's callee name, filtering same-file
     /// candidates whose arity can't satisfy `shape` — see
     /// [`crate::resolver::resolve_callee_definition`]. Not part of

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -54,3 +54,5 @@ pub(crate) use infer_lines::{
 };
 #[cfg(test)]
 pub(crate) use resolve::resolve_symbol;
+#[cfg(test)]
+pub(crate) use resolve::resolve_symbol_index_only;

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -106,6 +106,31 @@ pub(crate) fn resolve_symbol(
     qualifier: Option<&str>,
     from_uri: &Url,
 ) -> Vec<Location> {
+    resolve_symbol_with_io(indexer, name, qualifier, from_uri, ResolveIo::Full)
+}
+
+/// Same dispatch as `resolve_symbol`, but every bare-name fallback step uses
+/// `ResolveIo::IndexOnly` instead of always spawning `rg`/`fd`. For a bulk
+/// scan that resolves every identifier in a whole corpus (the
+/// resolution-accuracy benchmark) and — by design — expects most bare/local
+/// references to miss, letting each of those exhaust the full rg/fd fallback
+/// chain turned a 13k-file scan into a roughly hour-long run.
+pub(crate) fn resolve_symbol_index_only(
+    indexer: &Indexer,
+    name: &str,
+    qualifier: Option<&str>,
+    from_uri: &Url,
+) -> Vec<Location> {
+    resolve_symbol_with_io(indexer, name, qualifier, from_uri, ResolveIo::IndexOnly)
+}
+
+fn resolve_symbol_with_io(
+    indexer: &Indexer,
+    name: &str,
+    qualifier: Option<&str>,
+    from_uri: &Url,
+    io: ResolveIo,
+) -> Vec<Location> {
     // 0. Qualified access: `AccountPickerMapper.Content` — cursor on `Content`.
     //    Resolve the qualifier to a file, then search that file for `name`.
     if let Some(qual) = qualifier {
@@ -140,7 +165,7 @@ pub(crate) fn resolve_symbol(
         let segments: Vec<&str> = name.split('.').collect();
         // Start at the first type (uppercase) segment, skipping package prefixes.
         if let Some(start) = segments.iter().position(|s| s.starts_with_uppercase()) {
-            let outer_locs = resolve_symbol_inner(indexer, segments[start], from_uri, true);
+            let outer_locs = resolve_chain(indexer, segments[start], from_uri, io, true, None);
             if let Some(outer_loc) = outer_locs.first() {
                 // A package-qualified plain type (`demo.Foo`) has no nested
                 // segments after the type — the resolved type itself is the target.
@@ -162,27 +187,7 @@ pub(crate) fn resolve_symbol(
         }
     }
 
-    resolve_symbol_inner(indexer, name, from_uri, true)
-}
-
-/// Internal resolver.  When `with_hierarchy` is false step 4.5 is skipped to
-/// avoid infinite recursion inside `resolve_from_class_hierarchy` (which calls
-/// this function to locate each superclass, and those files would in turn call
-/// the hierarchy walk again with a fresh visited-set, looping forever).
-pub(crate) fn resolve_symbol_inner(
-    indexer: &Indexer,
-    name: &str,
-    from_uri: &Url,
-    with_hierarchy: bool,
-) -> Vec<Location> {
-    resolve_chain(
-        indexer,
-        name,
-        from_uri,
-        ResolveIo::Full,
-        with_hierarchy,
-        None,
-    )
+    resolve_chain(indexer, name, from_uri, io, true, None)
 }
 
 /// Resolve a call's callee name, filtering same-file candidates by `shape`
@@ -201,9 +206,9 @@ pub(crate) fn resolve_callee_definition(
 
 /// The single prioritised resolution chain, parameterised by IO policy.
 ///
-/// `resolve_symbol_inner` (`Full`), `resolve_symbol_no_rg` (`NoRg`) and
-/// `resolve_type_index_only_simple` (`IndexOnly`) are all thin wrappers over this
-/// function. The `ResolveIo` policy selects which subprocess fallbacks (`fd`/`rg`),
+/// `resolve_symbol_with_io` (`Full`/`IndexOnly`), `resolve_symbol_no_rg` (`NoRg`)
+/// and `resolve_type_index_only_simple` (`IndexOnly`) are all thin wrappers over
+/// this function. The `ResolveIo` policy selects which subprocess fallbacks (`fd`/`rg`),
 /// the hierarchy walk, the cold-file on-demand index, and which global-defs tail
 /// fallback are permitted — see the `ResolveIo` doc-comment for the per-policy table.
 ///
@@ -395,7 +400,7 @@ fn find_in_star_imports(indexer: &Indexer, name: &str, star_pkgs: &[String]) -> 
 
 /// Index-only resolver for use in completion paths.
 ///
-/// Identical to `resolve_symbol_inner` but omits:
+/// Identical to `resolve_symbol`'s `Full` policy but omits:
 /// - Step 4's `rg_in_package_dir` fallback (inside `resolve_star_imports`)
 /// - Step 4.5 hierarchy walk
 /// - Step 5 `rg_find_definition`
@@ -1733,6 +1738,14 @@ impl crate::indexer::Indexer {
         from_uri: &Url,
     ) -> Vec<Location> {
         resolve_symbol(self, name, qualifier, from_uri)
+    }
+    pub(crate) fn resolve_symbol_index_only(
+        &self,
+        name: &str,
+        qualifier: Option<&str>,
+        from_uri: &Url,
+    ) -> Vec<Location> {
+        resolve_symbol_index_only(self, name, qualifier, from_uri)
     }
     pub(crate) fn resolve_symbol_no_rg(&self, name: &str, from_uri: &Url) -> Vec<Location> {
         resolve_symbol_no_rg(self, name, from_uri)

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -259,6 +259,46 @@ fun collect(scope: Int, block: Int) {\n\
     );
 }
 
+/// `resolve_symbol_index_only` must never reach `resolve_chain`'s rg/fd
+/// steps: a symbol reachable only via the project-wide rg tail fallback
+/// (not indexed, not imported, not same-package) resolves under the `Full`
+/// policy but must resolve to nothing under `IndexOnly`.
+#[test]
+fn resolve_symbol_index_only_never_spawns_rg_or_fd() {
+    if !rg_available() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let caller_src = "package com.example.caller\nfun use() { OnlyFindableByRg() }\n";
+    let caller_path = root.join("Caller.kt");
+    std::fs::write(&caller_path, caller_src).unwrap();
+    let caller_uri = Url::from_file_path(&caller_path).unwrap();
+
+    // Deliberately never indexed via `index_content` — only reachable via
+    // rg's project-wide filesystem search (resolve_chain's step 5).
+    let target_src = "package com.other\nclass OnlyFindableByRg\n";
+    std::fs::write(root.join("Target.kt"), target_src).unwrap();
+
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+    idx.index_content(&caller_uri, caller_src);
+
+    let full = resolve_symbol(&idx, "OnlyFindableByRg", None, &caller_uri);
+    assert!(
+        !full.is_empty(),
+        "sanity check: the Full policy's rg tail fallback must find it"
+    );
+
+    let index_only = resolve_symbol_index_only(&idx, "OnlyFindableByRg", None, &caller_uri);
+    assert!(
+        index_only.is_empty(),
+        "IndexOnly must never spawn rg, so it can't find a target only \
+         reachable via the filesystem tail fallback, got: {index_only:?}"
+    );
+}
+
 // ── resolve_implicit_receiver_callee ───────────────────────────────────────
 
 /// The reported bug: `collect(block)` inside `fun <T> Flow<T>.collect(scope,


### PR DESCRIPTION
## Summary
The `resolution-accuracy` CLI benchmark (and the `unresolved_symbol_diagnostics` module it shares with a future live diagnostic) resolves every identifier in a whole corpus. Its own doc comment already claimed it "only exercises `classify_cursor`+`resolve_identity`, not the full goto-definition pipeline (no rg-grep fallback)" — but that wasn't actually true: both `resolve_identity`'s bare-name path and the module's own Gap-vs-FilteredCandidate probe went through `resolve_symbol`'s `Full` IO policy, which spawns `rg`/`fd` subprocesses on every miss.

Since this benchmark deliberately has no local-scope/parameter/lambda-param resolution (by design — see its module doc), nearly every bare reference exhausted the full rg/fd fallback chain before giving up as a Gap. Measured on a 24-file sample: **673 subprocess spawns**, ~28 per file. On a real 13k-file workspace this made a full scan take roughly an hour, which made it impractical to actually run.

- Adds `resolve_symbol_index_only` (mirrors `resolve_symbol`'s exact dispatch, but pins `ResolveIo::IndexOnly` for every bare-name fallback step instead of `Full`) and `Indexer::find_definition_qualified_index_only`.
- Adds `resolve_identity_with_io`, a thin generalization of `resolve_identity` that switches between the two based on an `index_only` flag; `resolve_identity` itself is now a one-line wrapper that keeps calling it with `index_only: false`, so its two other production callers (`features/definition.rs`, `features/rename.rs`, real goto-definition/rename) are byte-for-byte unaffected.
- Switches the benchmark's own `classify_reference` (in `features/unresolved_symbol_diagnostics.rs`) onto the index-only variants.

Result on the same 24-file sample: spawns 673 → 12, per-file scan time drops ~6x, Success/Gap counts stay within noise of the pre-fix run (the benchmark now actually measures what its own doc already claimed it measured, rather than partially measuring "how good is rg fallback").

## Test plan
- [x] `cargo test --bin kmp-lsp` — 1776 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] New regression test `resolve_symbol_index_only_never_spawns_rg_or_fd`: builds a symbol only reachable via the project-wide rg tail fallback (not indexed, not imported, not same-package), confirms `resolve_symbol` (Full) finds it and `resolve_symbol_index_only` doesn't. Confirmed RED against a temporarily-reverted fix before landing.
- [x] Empirically verified against a real 13k-file workspace (`~/Work/Moneta/android`): full-corpus `resolution-accuracy` scan now completes in minutes instead of the ~1hr it took before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ