### PR TITLE
fix(stack-overflow): bound the field/variable-type inference recursion cycle

### DIFF
--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -621,11 +621,20 @@ fn names_object_declaration(indexer: &Indexer, label: &str, from_uri: &Url) -> b
         })
 }
 
+/// Shared recursion budget for `infer_variable_type`/`infer_variable_type_raw`
+/// and `find_field_type_in_class`: `infer_var_from_rhs_data`'s `field_match`
+/// branch re-enters `find_field_type_in_class`, whose own fallback re-enters
+/// variable-type inference — each side resetting to a fresh budget on
+/// re-entry, rather than decrementing one shared counter, let a real
+/// unannotated-field-chain-heavy file overflow the stack (594 real
+/// mutually-recursive frames, no synthetic pathological input needed).
+const MAX_RAW_TYPE_INFER_DEPTH: u8 = 4;
+
 /// Scan the current file's lines for a type annotation on `var_name` and return
 /// the declared type name if found.  Delegates to [`infer_type_in_lines`] and
 /// falls back to method return-type inference for `val x = receiver.method(...)`.
 pub(crate) fn infer_variable_type(indexer: &Indexer, var_name: &str, uri: &Url) -> Option<String> {
-    infer_variable_type_impl(indexer, var_name, uri, 4)
+    infer_variable_type_impl(indexer, var_name, uri, MAX_RAW_TYPE_INFER_DEPTH)
 }
 
 /// Like [`infer_variable_type`] but preserves generic parameters in the returned
@@ -637,7 +646,7 @@ pub(crate) fn infer_variable_type_raw(
     var_name: &str,
     uri: &Url,
 ) -> Option<String> {
-    infer_variable_type_raw_impl(indexer, var_name, uri, 4)
+    infer_variable_type_raw_impl(indexer, var_name, uri, MAX_RAW_TYPE_INFER_DEPTH)
 }
 
 fn infer_variable_type_impl(
@@ -800,7 +809,7 @@ fn infer_var_from_rhs_data(
                 .unwrap_or(recv_stripped)
                 .strip_nullable();
             if let Some((field_type, _declaring_uri)) =
-                find_field_type_in_class(indexer, recv_base, &field, uri)
+                find_field_type_in_class_impl(indexer, recv_base, &field, uri, depth - 1)
             {
                 return Some(field_type);
             }
@@ -1119,6 +1128,28 @@ pub(crate) fn find_field_type_in_class(
     field_name: &str,
     from_uri: &Url,
 ) -> Option<(String, Url)> {
+    find_field_type_in_class_impl(
+        indexer,
+        class_name,
+        field_name,
+        from_uri,
+        MAX_RAW_TYPE_INFER_DEPTH,
+    )
+}
+
+/// Depth-guarded implementation of [`find_field_type_in_class`] — shares its
+/// budget with `infer_var_from_rhs_data`'s `field_match` branch, the one
+/// caller that re-enters this function (see `MAX_RAW_TYPE_INFER_DEPTH`).
+fn find_field_type_in_class_impl(
+    indexer: &Indexer,
+    class_name: &str,
+    field_name: &str,
+    from_uri: &Url,
+    depth: u8,
+) -> Option<(String, Url)> {
+    if depth == 0 {
+        return None;
+    }
     let mut candidates = super::resolve::resolve_type_index_only(indexer, class_name, from_uri);
     if candidates.is_empty() {
         candidates = indexer.workspace_def_candidates(class_name);
@@ -1136,7 +1167,9 @@ pub(crate) fn find_field_type_in_class(
     // Fallback: full variable inference including CST-indexed field_access_rhs
     // and method_call_rhs data (handles unannotated `val x = recv.field`).
     for location in &candidates {
-        if let Some(field_type) = infer_variable_type_raw(indexer, field_name, &location.uri) {
+        if let Some(field_type) =
+            infer_variable_type_raw_impl(indexer, field_name, &location.uri, depth - 1)
+        {
             return Some((field_type, location.uri.clone()));
         }
     }

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -240,6 +240,39 @@ fn find_field_type_in_class_resolves_unannotated_field_access() {
     assert_eq!(field_type, "Flow<DashboardTrigger>");
 }
 
+/// Regression: found scanning a real 13k-file codebase, where a chain of
+/// unannotated field accesses across many files overflowed the stack —
+/// `find_field_type_in_class`'s fallback re-enters variable-type inference,
+/// which can itself call back into `find_field_type_in_class` for a
+/// receiver's own field type, each side resetting to a fresh depth budget on
+/// re-entry instead of sharing one. A genuine two-class mutual reference is
+/// the smallest reproduction of the same unbounded cycle.
+#[test]
+fn find_field_type_in_class_terminates_on_a_mutual_field_reference_cycle() {
+    use crate::indexer::Indexer;
+    use crate::resolver::infer::find_field_type_in_class;
+    use tower_lsp::lsp_types::Url;
+
+    fn uri(p: &str) -> Url {
+        Url::parse(&format!("file://{p}")).unwrap()
+    }
+
+    let idx = Indexer::new();
+    idx.index_content(
+        &uri("/A.kt"),
+        "package com.example\nclass A(val b: B) {\n    val value = b.value\n}\n",
+    );
+    idx.index_content(
+        &uri("/B.kt"),
+        "package com.example\nclass B(val a: A) {\n    val value = a.value\n}\n",
+    );
+
+    // Past the depth cap the walk bails at whatever partial (possibly
+    // approximate) answer it has — no specific value is asserted, only that
+    // this call returns at all instead of overflowing the stack.
+    let _ = find_field_type_in_class(&idx, "A", "value", &uri("/A.kt"));
+}
+
 #[test]
 fn supertype_subst_replaces_generic_params() {
     let raw = "Flow<ReducedResult<EffectType, StateType>>";


### PR DESCRIPTION
## Summary
Stacked on #274 — found while validating that PR's fix by finally being able to run a full-corpus `resolution-accuracy` scan (previously infeasible at ~1hr). The scan crashed with a genuine `fatal runtime error: stack overflow` 5430 files into a 13,225-file real workspace, on an ordinary 188-line Compose screen (`FamilyCardDetailScreen.kt`) — not a synthetic pathological input.

Root cause (via `gdb bt 3000` on a debug build, reproduced by scoping `--root` to just the crashing module): a genuinely unbounded mutual-recursion cycle between two long-standing resolution primitives, both of which already have their *own* depth guard, but reset it on crossing into each other:

- `find_field_type_in_class`'s fallback calls `infer_variable_type_raw` (fresh `depth = 4`) to resolve an unannotated `val x = recv.field`.
- `infer_variable_type_raw`'s own `infer_var_from_rhs_data` can, for `field_match`, call back into `find_field_type_in_class` (again with no depth passed through) to resolve the *receiver's* field type.

Neither side treats the other as "part of the same recursion," so each re-entry gets a fresh budget instead of decrementing a shared one. On a real file with a genuine chain of unannotated field accesses across files, this recursed 594 real frames before overflowing a 16 MiB stack. **This same cycle is reachable from the live LSP server** (hover, completion — `find_field_type_in_class` and `infer_variable_type_raw` are both core resolution primitives, not benchmark-only), so this isn't just a scan-tool bug.

## Fix
Threads one shared `depth: u8` budget (`MAX_RAW_TYPE_INFER_DEPTH`, matching the existing default of 4) across both sides via new `_impl` variants (`find_field_type_in_class_impl`, reusing the already-depth-aware `infer_variable_type_raw_impl`). The public `find_field_type_in_class`/`infer_variable_type_raw` entry points are unchanged for their other, naturally-bounded callers (e.g. `infer_field_chain_type`'s CST-segment walk, which is bounded by the chain's own finite segment count).

## Test plan
- [x] `cargo test --bin kmp-lsp` — 1777 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] New regression test `find_field_type_in_class_terminates_on_a_mutual_field_reference_cycle`: two classes with typed intermediate properties whose unannotated `val` fields mutually reference each other's same-named field — genuinely reproduces the stack overflow (confirmed via an isolated `--test-threads=1` run that the process SIGABRTs pre-fix) and terminates cleanly post-fix.
- [x] Re-ran the exact real-world repro (`kmp-lsp resolution-accuracy --root feature/cards` against `~/Work/Moneta/android`, 323 files including the originally-crashing one) — now completes cleanly in ~21s, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ