### PR TITLE
fix(stack-overflow): bound the field/variable-type inference recursion cycle

### DIFF
--- a/src/features/unresolved_symbol_diagnostics.rs
+++ b/src/features/unresolved_symbol_diagnostics.rs
@@ -16,7 +16,8 @@ use tree_sitter::Node;
 
 use crate::indexer::live_tree::LiveDoc;
 use crate::indexer::{
-    classify_cursor, resolve_identity, Indexer, NavigationSource, SymbolAtCursor, SymbolRole,
+    classify_cursor, resolve_identity_with_io, Indexer, NavigationSource, SymbolAtCursor,
+    SymbolRole,
 };
 use crate::queries::{KIND_IMPORT_HEADER, KIND_PACKAGE_HEADER, KIND_SIMPLE_IDENT, KIND_TYPE_IDENT};
 
@@ -141,7 +142,7 @@ fn classify_reference(
     symbol: &SymbolAtCursor,
     receiver_type: Option<String>,
 ) -> ResolutionOutcome {
-    let success = match resolve_identity(symbol, indexer, uri) {
+    let success = match resolve_identity_with_io(symbol, indexer, uri, true) {
         NavigationSource::CstResolved(defs) if !defs.is_empty() => {
             Some((SuccessTier::CstResolved, defs.0))
         }
@@ -153,7 +154,7 @@ fn classify_reference(
     match success {
         Some((tier, locations)) => ResolutionOutcome::Success { tier, locations },
         None if receiver_type.is_some() => {
-            let probe = indexer.find_definition_qualified(&symbol.name, None, uri);
+            let probe = indexer.find_definition_qualified_index_only(&symbol.name, None, uri);
             if probe.is_empty() {
                 ResolutionOutcome::Gap
             } else {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -40,8 +40,8 @@ pub(crate) use self::infer::{
     cst_symbol::{
         classify_cursor, classify_symbol_at, enclosing_nav_expr_if_member, is_call_callee,
         is_declaration_site, local_scope_occurrences, navigation_member_ident,
-        navigation_receiver_node, resolve_identity, shape_filter_locations, NavigationSource,
-        SymbolAtCursor, SymbolRole,
+        navigation_receiver_node, resolve_identity, resolve_identity_with_io,
+        shape_filter_locations, NavigationSource, SymbolAtCursor, SymbolRole,
     },
     deps::{CallShape, CallableInfo, InferDeps, OuterScopedParams, ShapeFiltered},
     expr_type::infer_expr_type,

--- a/src/indexer/infer/cst_symbol.rs
+++ b/src/indexer/infer/cst_symbol.rs
@@ -345,9 +345,29 @@ pub(crate) fn resolve_identity(
     indexer: &Indexer,
     uri: &Url,
 ) -> NavigationSource<Definitions> {
+    resolve_identity_with_io(symbol, indexer, uri, false)
+}
+
+/// Like `resolve_identity` but, when `index_only` is set, never spawns
+/// `rg`/`fd` — see `resolve_symbol_index_only`'s own doc comment for why.
+/// Used by the resolution-accuracy benchmark, which calls this once per
+/// identifier in a whole corpus.
+pub(crate) fn resolve_identity_with_io(
+    symbol: &SymbolAtCursor,
+    indexer: &Indexer,
+    uri: &Url,
+    index_only: bool,
+) -> NavigationSource<Definitions> {
+    let find_definition_qualified = |name: &str, qualifier: Option<&str>, uri: &Url| {
+        if index_only {
+            indexer.find_definition_qualified_index_only(name, qualifier, uri)
+        } else {
+            indexer.find_definition_qualified(name, qualifier, uri)
+        }
+    };
     match &symbol.role {
         SymbolRole::Declaration { indexed } => {
-            let locations = Definitions(indexer.find_definition_qualified(&symbol.name, None, uri));
+            let locations = Definitions(find_definition_qualified(&symbol.name, None, uri));
             // Only declarations `KOTLIN_DEFINITIONS` actually indexes can be
             // trusted CST-resolved; an unindexed one (bare param, val/var-less
             // constructor param, type param) falls through to an unanchored
@@ -364,8 +384,7 @@ pub(crate) fn resolve_identity(
             shape,
             ..
         } => {
-            let locations =
-                indexer.find_definition_qualified(&symbol.name, Some(receiver_type), uri);
+            let locations = find_definition_qualified(&symbol.name, Some(receiver_type), uri);
             // A call's own shape rules out a same-named, wrong-arity member/
             // extension on the same receiver type — e.g. `triggers.collect {
             // trigger -> }` (1 arg via trailing lambda) must not resolve to a
@@ -391,7 +410,7 @@ pub(crate) fn resolve_identity(
             ..
         }
         | SymbolRole::ImportSegment => NavigationSource::NameScan(Definitions(
-            indexer.find_definition_qualified(&symbol.name, None, uri),
+            find_definition_qualified(&symbol.name, None, uri),
         )),
     }
 }

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -49,6 +49,17 @@ impl Indexer {
         self.resolve_symbol(name, qualifier, from_uri)
     }
 
+    /// Like `find_definition_qualified` but never spawns `rg`/`fd` — see
+    /// `resolve_symbol_index_only`'s own doc comment for why.
+    pub(crate) fn find_definition_qualified_index_only(
+        &self,
+        name: &str,
+        qualifier: Option<&str>,
+        from_uri: &Url,
+    ) -> Vec<Location> {
+        self.resolve_symbol_index_only(name, qualifier, from_uri)
+    }
+
     /// Resolve an unqualified call's callee name, filtering same-file
     /// candidates whose arity can't satisfy `shape` — see
     /// [`crate::resolver::resolve_callee_definition`]. Not part of

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -621,11 +621,20 @@ fn names_object_declaration(indexer: &Indexer, label: &str, from_uri: &Url) -> b
         })
 }
 
+/// Shared recursion budget for `infer_variable_type`/`infer_variable_type_raw`
+/// and `find_field_type_in_class`: `infer_var_from_rhs_data`'s `field_match`
+/// branch re-enters `find_field_type_in_class`, whose own fallback re-enters
+/// variable-type inference — each side resetting to a fresh budget on
+/// re-entry, rather than decrementing one shared counter, let a real
+/// unannotated-field-chain-heavy file overflow the stack (594 real
+/// mutually-recursive frames, no synthetic pathological input needed).
+const MAX_RAW_TYPE_INFER_DEPTH: u8 = 4;
+
 /// Scan the current file's lines for a type annotation on `var_name` and return
 /// the declared type name if found.  Delegates to [`infer_type_in_lines`] and
 /// falls back to method return-type inference for `val x = receiver.method(...)`.
 pub(crate) fn infer_variable_type(indexer: &Indexer, var_name: &str, uri: &Url) -> Option<String> {
-    infer_variable_type_impl(indexer, var_name, uri, 4)
+    infer_variable_type_impl(indexer, var_name, uri, MAX_RAW_TYPE_INFER_DEPTH)
 }
 
 /// Like [`infer_variable_type`] but preserves generic parameters in the returned
@@ -637,7 +646,7 @@ pub(crate) fn infer_variable_type_raw(
     var_name: &str,
     uri: &Url,
 ) -> Option<String> {
-    infer_variable_type_raw_impl(indexer, var_name, uri, 4)
+    infer_variable_type_raw_impl(indexer, var_name, uri, MAX_RAW_TYPE_INFER_DEPTH)
 }
 
 fn infer_variable_type_impl(
@@ -800,7 +809,7 @@ fn infer_var_from_rhs_data(
                 .unwrap_or(recv_stripped)
                 .strip_nullable();
             if let Some((field_type, _declaring_uri)) =
-                find_field_type_in_class(indexer, recv_base, &field, uri)
+                find_field_type_in_class_impl(indexer, recv_base, &field, uri, depth - 1)
             {
                 return Some(field_type);
             }
@@ -1119,6 +1128,28 @@ pub(crate) fn find_field_type_in_class(
     field_name: &str,
     from_uri: &Url,
 ) -> Option<(String, Url)> {
+    find_field_type_in_class_impl(
+        indexer,
+        class_name,
+        field_name,
+        from_uri,
+        MAX_RAW_TYPE_INFER_DEPTH,
+    )
+}
+
+/// Depth-guarded implementation of [`find_field_type_in_class`] — shares its
+/// budget with `infer_var_from_rhs_data`'s `field_match` branch, the one
+/// caller that re-enters this function (see `MAX_RAW_TYPE_INFER_DEPTH`).
+fn find_field_type_in_class_impl(
+    indexer: &Indexer,
+    class_name: &str,
+    field_name: &str,
+    from_uri: &Url,
+    depth: u8,
+) -> Option<(String, Url)> {
+    if depth == 0 {
+        return None;
+    }
     let mut candidates = super::resolve::resolve_type_index_only(indexer, class_name, from_uri);
     if candidates.is_empty() {
         candidates = indexer.workspace_def_candidates(class_name);
@@ -1136,7 +1167,9 @@ pub(crate) fn find_field_type_in_class(
     // Fallback: full variable inference including CST-indexed field_access_rhs
     // and method_call_rhs data (handles unannotated `val x = recv.field`).
     for location in &candidates {
-        if let Some(field_type) = infer_variable_type_raw(indexer, field_name, &location.uri) {
+        if let Some(field_type) =
+            infer_variable_type_raw_impl(indexer, field_name, &location.uri, depth - 1)
+        {
             return Some((field_type, location.uri.clone()));
         }
     }

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -240,6 +240,39 @@ fn find_field_type_in_class_resolves_unannotated_field_access() {
     assert_eq!(field_type, "Flow<DashboardTrigger>");
 }
 
+/// Regression: found scanning a real 13k-file codebase, where a chain of
+/// unannotated field accesses across many files overflowed the stack —
+/// `find_field_type_in_class`'s fallback re-enters variable-type inference,
+/// which can itself call back into `find_field_type_in_class` for a
+/// receiver's own field type, each side resetting to a fresh depth budget on
+/// re-entry instead of sharing one. A genuine two-class mutual reference is
+/// the smallest reproduction of the same unbounded cycle.
+#[test]
+fn find_field_type_in_class_terminates_on_a_mutual_field_reference_cycle() {
+    use crate::indexer::Indexer;
+    use crate::resolver::infer::find_field_type_in_class;
+    use tower_lsp::lsp_types::Url;
+
+    fn uri(p: &str) -> Url {
+        Url::parse(&format!("file://{p}")).unwrap()
+    }
+
+    let idx = Indexer::new();
+    idx.index_content(
+        &uri("/A.kt"),
+        "package com.example\nclass A(val b: B) {\n    val value = b.value\n}\n",
+    );
+    idx.index_content(
+        &uri("/B.kt"),
+        "package com.example\nclass B(val a: A) {\n    val value = a.value\n}\n",
+    );
+
+    // Past the depth cap the walk bails at whatever partial (possibly
+    // approximate) answer it has — no specific value is asserted, only that
+    // this call returns at all instead of overflowing the stack.
+    let _ = find_field_type_in_class(&idx, "A", "value", &uri("/A.kt"));
+}
+
 #[test]
 fn supertype_subst_replaces_generic_params() {
     let raw = "Flow<ReducedResult<EffectType, StateType>>";

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -54,3 +54,5 @@ pub(crate) use infer_lines::{
 };
 #[cfg(test)]
 pub(crate) use resolve::resolve_symbol;
+#[cfg(test)]
+pub(crate) use resolve::resolve_symbol_index_only;

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -106,6 +106,31 @@ pub(crate) fn resolve_symbol(
     qualifier: Option<&str>,
     from_uri: &Url,
 ) -> Vec<Location> {
+    resolve_symbol_with_io(indexer, name, qualifier, from_uri, ResolveIo::Full)
+}
+
+/// Same dispatch as `resolve_symbol`, but every bare-name fallback step uses
+/// `ResolveIo::IndexOnly` instead of always spawning `rg`/`fd`. For a bulk
+/// scan that resolves every identifier in a whole corpus (the
+/// resolution-accuracy benchmark) and — by design — expects most bare/local
+/// references to miss, letting each of those exhaust the full rg/fd fallback
+/// chain turned a 13k-file scan into a roughly hour-long run.
+pub(crate) fn resolve_symbol_index_only(
+    indexer: &Indexer,
+    name: &str,
+    qualifier: Option<&str>,
+    from_uri: &Url,
+) -> Vec<Location> {
+    resolve_symbol_with_io(indexer, name, qualifier, from_uri, ResolveIo::IndexOnly)
+}
+
+fn resolve_symbol_with_io(
+    indexer: &Indexer,
+    name: &str,
+    qualifier: Option<&str>,
+    from_uri: &Url,
+    io: ResolveIo,
+) -> Vec<Location> {
     // 0. Qualified access: `AccountPickerMapper.Content` — cursor on `Content`.
     //    Resolve the qualifier to a file, then search that file for `name`.
     if let Some(qual) = qualifier {
@@ -140,7 +165,7 @@ pub(crate) fn resolve_symbol(
         let segments: Vec<&str> = name.split('.').collect();
         // Start at the first type (uppercase) segment, skipping package prefixes.
         if let Some(start) = segments.iter().position(|s| s.starts_with_uppercase()) {
-            let outer_locs = resolve_symbol_inner(indexer, segments[start], from_uri, true);
+            let outer_locs = resolve_chain(indexer, segments[start], from_uri, io, true, None);
             if let Some(outer_loc) = outer_locs.first() {
                 // A package-qualified plain type (`demo.Foo`) has no nested
                 // segments after the type — the resolved type itself is the target.
@@ -162,27 +187,7 @@ pub(crate) fn resolve_symbol(
         }
     }
 
-    resolve_symbol_inner(indexer, name, from_uri, true)
-}
-
-/// Internal resolver.  When `with_hierarchy` is false step 4.5 is skipped to
-/// avoid infinite recursion inside `resolve_from_class_hierarchy` (which calls
-/// this function to locate each superclass, and those files would in turn call
-/// the hierarchy walk again with a fresh visited-set, looping forever).
-pub(crate) fn resolve_symbol_inner(
-    indexer: &Indexer,
-    name: &str,
-    from_uri: &Url,
-    with_hierarchy: bool,
-) -> Vec<Location> {
-    resolve_chain(
-        indexer,
-        name,
-        from_uri,
-        ResolveIo::Full,
-        with_hierarchy,
-        None,
-    )
+    resolve_chain(indexer, name, from_uri, io, true, None)
 }
 
 /// Resolve a call's callee name, filtering same-file candidates by `shape`
@@ -201,9 +206,9 @@ pub(crate) fn resolve_callee_definition(
 
 /// The single prioritised resolution chain, parameterised by IO policy.
 ///
-/// `resolve_symbol_inner` (`Full`), `resolve_symbol_no_rg` (`NoRg`) and
-/// `resolve_type_index_only_simple` (`IndexOnly`) are all thin wrappers over this
-/// function. The `ResolveIo` policy selects which subprocess fallbacks (`fd`/`rg`),
+/// `resolve_symbol_with_io` (`Full`/`IndexOnly`), `resolve_symbol_no_rg` (`NoRg`)
+/// and `resolve_type_index_only_simple` (`IndexOnly`) are all thin wrappers over
+/// this function. The `ResolveIo` policy selects which subprocess fallbacks (`fd`/`rg`),
 /// the hierarchy walk, the cold-file on-demand index, and which global-defs tail
 /// fallback are permitted — see the `ResolveIo` doc-comment for the per-policy table.
 ///
@@ -395,7 +400,7 @@ fn find_in_star_imports(indexer: &Indexer, name: &str, star_pkgs: &[String]) -> 
 
 /// Index-only resolver for use in completion paths.
 ///
-/// Identical to `resolve_symbol_inner` but omits:
+/// Identical to `resolve_symbol`'s `Full` policy but omits:
 /// - Step 4's `rg_in_package_dir` fallback (inside `resolve_star_imports`)
 /// - Step 4.5 hierarchy walk
 /// - Step 5 `rg_find_definition`
@@ -1733,6 +1738,14 @@ impl crate::indexer::Indexer {
         from_uri: &Url,
     ) -> Vec<Location> {
         resolve_symbol(self, name, qualifier, from_uri)
+    }
+    pub(crate) fn resolve_symbol_index_only(
+        &self,
+        name: &str,
+        qualifier: Option<&str>,
+        from_uri: &Url,
+    ) -> Vec<Location> {
+        resolve_symbol_index_only(self, name, qualifier, from_uri)
     }
     pub(crate) fn resolve_symbol_no_rg(&self, name: &str, from_uri: &Url) -> Vec<Location> {
         resolve_symbol_no_rg(self, name, from_uri)

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -259,6 +259,46 @@ fun collect(scope: Int, block: Int) {\n\
     );
 }
 
+/// `resolve_symbol_index_only` must never reach `resolve_chain`'s rg/fd
+/// steps: a symbol reachable only via the project-wide rg tail fallback
+/// (not indexed, not imported, not same-package) resolves under the `Full`
+/// policy but must resolve to nothing under `IndexOnly`.
+#[test]
+fn resolve_symbol_index_only_never_spawns_rg_or_fd() {
+    if !rg_available() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let caller_src = "package com.example.caller\nfun use() { OnlyFindableByRg() }\n";
+    let caller_path = root.join("Caller.kt");
+    std::fs::write(&caller_path, caller_src).unwrap();
+    let caller_uri = Url::from_file_path(&caller_path).unwrap();
+
+    // Deliberately never indexed via `index_content` — only reachable via
+    // rg's project-wide filesystem search (resolve_chain's step 5).
+    let target_src = "package com.other\nclass OnlyFindableByRg\n";
+    std::fs::write(root.join("Target.kt"), target_src).unwrap();
+
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+    idx.index_content(&caller_uri, caller_src);
+
+    let full = resolve_symbol(&idx, "OnlyFindableByRg", None, &caller_uri);
+    assert!(
+        !full.is_empty(),
+        "sanity check: the Full policy's rg tail fallback must find it"
+    );
+
+    let index_only = resolve_symbol_index_only(&idx, "OnlyFindableByRg", None, &caller_uri);
+    assert!(
+        index_only.is_empty(),
+        "IndexOnly must never spawn rg, so it can't find a target only \
+         reachable via the filesystem tail fallback, got: {index_only:?}"
+    );
+}
+
 // ── resolve_implicit_receiver_callee ───────────────────────────────────────
 
 /// The reported bug: `collect(block)` inside `fun <T> Flow<T>.collect(scope,


### PR DESCRIPTION
(Re-opened as a fresh PR — #275 was auto-closed by GitHub when its stacked base branch, `perf/resolution-accuracy-index-only`, was deleted after merging #274. Same commits, retargeted to `main`.)

## Summary
Found while validating #274's fix by finally being able to run a full-corpus `resolution-accuracy` scan (previously infeasible at ~1hr). The scan crashed with a genuine `fatal runtime error: stack overflow` 5430 files into a 13,225-file real workspace, on an ordinary 188-line Compose screen (`FamilyCardDetailScreen.kt`) — not a synthetic pathological input.

Root cause (via `gdb bt 3000` on a debug build, reproduced by scoping `--root` to just the crashing module): a genuinely unbounded mutual-recursion cycle between two long-standing resolution primitives, both of which already have their *own* depth guard, but reset it on crossing into each other:

- `find_field_type_in_class`'s fallback calls `infer_variable_type_raw` (fresh `depth = 4`) to resolve an unannotated `val x = recv.field`.
- `infer_variable_type_raw`'s own `infer_var_from_rhs_data` can, for `field_match`, call back into `find_field_type_in_class` (again with no depth passed through) to resolve the *receiver's* field type.

Neither side treats the other as "part of the same recursion," so each re-entry gets a fresh budget instead of decrementing a shared one. On a real file with a genuine chain of unannotated field accesses across files, this recursed 594 real frames before overflowing a 16 MiB stack. **This same cycle is reachable from the live LSP server** (hover, completion — `find_field_type_in_class` and `infer_variable_type_raw` are both core resolution primitives, not benchmark-only), so this isn't just a scan-tool bug.

## Fix
Threads one shared `depth: u8` budget (`MAX_RAW_TYPE_INFER_DEPTH`, matching the existing default of 4) across both sides via new `_impl` variants (`find_field_type_in_class_impl`, reusing the already-depth-aware `infer_variable_type_raw_impl`). The public `find_field_type_in_class`/`infer_variable_type_raw` entry points are unchanged for their other, naturally-bounded callers (e.g. `infer_field_chain_type`'s CST-segment walk, which is bounded by the chain's own finite segment count).

## Test plan
- [x] `cargo test --bin kmp-lsp` — 1777 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] New regression test `find_field_type_in_class_terminates_on_a_mutual_field_reference_cycle`: two classes with typed intermediate properties whose unannotated `val` fields mutually reference each other's same-named field — genuinely reproduces the stack overflow (confirmed via an isolated `--test-threads=1` run that the process SIGABRTs pre-fix) and terminates cleanly post-fix.
- [x] Re-ran the exact real-world repro (`kmp-lsp resolution-accuracy --root feature/cards` against `~/Work/Moneta/android`, 323 files including the originally-crashing one) — now completes cleanly in ~21s, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ