### PR TITLE
fix(resolve): scope-function fallback also applies to the index-only path

### DIFF
--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -55,14 +55,7 @@ impl Indexer {
         qualifier: Option<&str>,
         from_uri: &Url,
     ) -> Vec<Location> {
-        let locations = self.resolve_symbol(name, qualifier, from_uri);
-        if !locations.is_empty() {
-            return locations;
-        }
-        if qualifier.is_some() && SCOPE_FUNCTIONS.contains(&name) {
-            return self.resolve_symbol(name, None, from_uri);
-        }
-        locations
+        self.find_definition_qualified_with_io(name, qualifier, from_uri, false)
     }
 
     /// Like `find_definition_qualified` but never spawns `rg`/`fd` — see
@@ -73,7 +66,32 @@ impl Indexer {
         qualifier: Option<&str>,
         from_uri: &Url,
     ) -> Vec<Location> {
-        self.resolve_symbol_index_only(name, qualifier, from_uri)
+        self.find_definition_qualified_with_io(name, qualifier, from_uri, true)
+    }
+
+    fn find_definition_qualified_with_io(
+        &self,
+        name: &str,
+        qualifier: Option<&str>,
+        from_uri: &Url,
+        index_only: bool,
+    ) -> Vec<Location> {
+        let locations = if index_only {
+            self.resolve_symbol_index_only(name, qualifier, from_uri)
+        } else {
+            self.resolve_symbol(name, qualifier, from_uri)
+        };
+        if !locations.is_empty() {
+            return locations;
+        }
+        if qualifier.is_some() && SCOPE_FUNCTIONS.contains(&name) {
+            return if index_only {
+                self.resolve_symbol_index_only(name, None, from_uri)
+            } else {
+                self.resolve_symbol(name, None, from_uri)
+            };
+        }
+        locations
     }
 
     /// Resolve an unqualified call's callee name, filtering same-file

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -138,7 +138,7 @@ fn resolve_symbol_with_io(
         // `super.method` must only look in the parent hierarchy, never via rg/index
         // of the current file (which would return the override).
         let is_keyword_qual = qual == "super" || qual == "this";
-        let locs = resolve_qualified(indexer, name, qual, from_uri);
+        let locs = resolve_qualified(indexer, name, qual, from_uri, io);
         if !locs.is_empty() {
             return locs;
         }
@@ -910,6 +910,7 @@ fn resolve_qualified(
     name: &str,
     qualifier: &str,
     from_uri: &Url,
+    io: ResolveIo,
 ) -> Vec<Location> {
     let segments: Vec<&str> = qualifier.split('.').collect();
     let root = segments[0];
@@ -938,8 +939,15 @@ fn resolve_qualified(
             return ext_locs;
         }
 
-        // Then check member functions (same-file).
-        let qual_locs = resolve_symbol(indexer, root, None, from_uri);
+        // Then check member functions (same-file). Honors the caller's IO
+        // policy — an IndexOnly caller (the resolution-accuracy benchmark's
+        // own index-only path) must not spawn rg/fd resolving the qualifier
+        // root any more than it may for a bare reference.
+        let qual_locs = if matches!(io, ResolveIo::IndexOnly) {
+            resolve_symbol_index_only(indexer, root, None, from_uri)
+        } else {
+            resolve_symbol(indexer, root, None, from_uri)
+        };
         for qual_loc in &qual_locs {
             // `Foo.member` with `Foo` a class name (not a variable) can only reach a
             // companion-object member in Kotlin — never an instance member of `Foo`,
@@ -964,10 +972,14 @@ fn resolve_qualified(
             // before searching for `name`, so a same-named sibling member never
             // shadows the actually-requested nested type's own member.
             let mut anchor = qual_loc.clone();
+            let mut anchor_class_name = root_base;
             let mut nested_segments_resolved = true;
             for &nested_segment in &segments[1..] {
                 match find_name_scoped_to_container(indexer, nested_segment, &anchor) {
-                    Some(location) => anchor = location,
+                    Some(location) => {
+                        anchor = location;
+                        anchor_class_name = nested_segment;
+                    }
                     None => {
                         nested_segments_resolved = false;
                         break;
@@ -981,14 +993,18 @@ fn resolve_qualified(
             if let Some(loc) = find_name_scoped_to_container(indexer, name, &anchor) {
                 return vec![loc];
             }
-        }
-        // No candidate's own body (or companion/nested scope) declared `name` —
-        // it may live on a superclass instead (e.g. `object Manager :
-        // AbstractManager<T>()` inheriting `requireComponent`), the same
-        // situation the `this`/`super` branches above already handle.
-        let hierarchy_locs = resolve_from_class_hierarchy(indexer, name, from_uri);
-        if !hierarchy_locs.is_empty() {
-            return hierarchy_locs;
+
+            // `anchor`'s own body doesn't declare `name` — it may live on a
+            // superclass instead (e.g. `object Manager : AbstractManager<T>()`
+            // inheriting `requireComponent`), the same situation the `this`/
+            // `super` branches above already handle. Scoped to `anchor`'s own
+            // class and declaring file, not `from_uri` — the qualifier and the
+            // call site are commonly different files.
+            let hierarchy_locs =
+                resolve_from_class_hierarchy_scoped(indexer, name, anchor_class_name, &anchor.uri);
+            if !hierarchy_locs.is_empty() {
+                return hierarchy_locs;
+            }
         }
         // Extension functions may live in a different file than the receiver class.
         // Atomic promote+read (zero budget): `resolve_qualified` is on both the
@@ -1565,13 +1581,28 @@ fn resolve_star_imports(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Locatio
 /// 3. Search the resolved file's symbol table for `name`.
 /// 4. Recurse into that file's own supertypes (depth-limited, cycle-safe).
 fn resolve_from_class_hierarchy(indexer: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
+    resolve_from_class_hierarchy_scoped(indexer, name, "", from_uri)
+}
+
+/// Like [`resolve_from_class_hierarchy`] but scoped to one specific class's
+/// own declared supertypes (`start_class`) instead of every class declared in
+/// `from_uri`'s file. Needed when the class and the caller can be different
+/// files — `Foo.member()` where `Foo` is a type/object name, not `this`/`super`
+/// (which are always resolved from inside the class they refer to, so the
+/// unscoped whole-file walk was never wrong for those callers).
+fn resolve_from_class_hierarchy_scoped(
+    indexer: &Indexer,
+    name: &str,
+    start_class: &str,
+    from_uri: &Url,
+) -> Vec<Location> {
     // Deep enough for real Android/Kotlin hierarchies: app base classes often stack
     // several levels (`…Fragment → BaseFragment → … → androidx Fragment`) before the
     // library super that declares an inherited member like `requireActivity`. The
     // visited-set bounds total work regardless of depth.
     let results = walk_hierarchy(
         indexer,
-        "",
+        start_class,
         from_uri.as_str(),
         CallerContext::default(),
         12,
@@ -1769,6 +1800,6 @@ impl crate::indexer::Indexer {
         qualifier: &str,
         from_uri: &Url,
     ) -> Vec<Location> {
-        resolve_qualified(self, name, qualifier, from_uri)
+        resolve_qualified(self, name, qualifier, from_uri, ResolveIo::Full)
     }
 }

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -398,15 +398,9 @@ fn find_in_star_imports(indexer: &Indexer, name: &str, star_pkgs: &[String]) -> 
     None
 }
 
-/// Index-only resolver for use in completion paths.
-///
-/// Identical to `resolve_symbol`'s `Full` policy but omits:
-/// - Step 4's `rg_in_package_dir` fallback (inside `resolve_star_imports`)
-/// - Step 4.5 hierarchy walk
-/// - Step 5 `rg_find_definition`
-///
-/// Completion is triggered on every keystroke; spawning external `rg`/`fd`
-/// processes on each request would block the LSP thread and spike CPU.
+/// Index-only resolver for use in completion paths (`ResolveIo::NoRg` — see
+/// its own doc comment for the exact IO policy, since restating it here is
+/// how this comment drifted out of sync with it the first time).
 pub(crate) fn resolve_symbol_no_rg(indexer: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
     resolve_chain(indexer, name, from_uri, ResolveIo::NoRg, false, None)
 }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -299,6 +299,47 @@ fn resolve_symbol_index_only_never_spawns_rg_or_fd() {
     );
 }
 
+/// Same guarantee as `resolve_symbol_index_only_never_spawns_rg_or_fd`, but
+/// for a qualified lookup (`resolve_qualified`'s uppercase branch) — Copilot
+/// review on PR #274: `resolve_qualified` resolved its qualifier root via the
+/// always-`Full` `resolve_symbol`, regardless of the caller's own IO policy.
+#[test]
+fn resolve_symbol_index_only_never_spawns_rg_or_fd_for_a_qualified_root() {
+    if !rg_available() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let caller_src = "package com.example.caller\nfun use() { OnlyFindableByRg().member() }\n";
+    let caller_path = root.join("Caller.kt");
+    std::fs::write(&caller_path, caller_src).unwrap();
+    let caller_uri = Url::from_file_path(&caller_path).unwrap();
+
+    // Deliberately never indexed via `index_content` — the qualifier root
+    // (`OnlyFindableByRg`) is only reachable via rg's project-wide filesystem
+    // search (resolve_chain's step 5).
+    let target_src = "package com.other\nclass OnlyFindableByRg { fun member() = Unit }\n";
+    std::fs::write(root.join("Target.kt"), target_src).unwrap();
+
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+    idx.index_content(&caller_uri, caller_src);
+
+    let full = resolve_symbol(&idx, "member", Some("OnlyFindableByRg"), &caller_uri);
+    assert!(
+        !full.is_empty(),
+        "sanity check: the Full policy's rg tail fallback must find the qualifier root"
+    );
+
+    let index_only =
+        resolve_symbol_index_only(&idx, "member", Some("OnlyFindableByRg"), &caller_uri);
+    assert!(
+        index_only.is_empty(),
+        "IndexOnly must never spawn rg resolving the qualifier root either, got: {index_only:?}"
+    );
+}
+
 // ── resolve_implicit_receiver_callee ───────────────────────────────────────
 
 /// The reported bug: `collect(block)` inside `fun <T> Flow<T>.collect(scope,
@@ -785,6 +826,43 @@ fn resolve_qualified_uppercase_root_hierarchy_fallback_reaches_jar_superclass() 
         "expected the JAR-derived AbstractManager.requireComponent, got {:?}",
         locs[0]
     );
+}
+
+#[test]
+fn resolve_qualified_uppercase_root_hierarchy_fallback_works_from_a_different_call_site_file() {
+    // Same fixture as `resolve_qualified_uppercase_root_falls_back_to_class_hierarchy`,
+    // but resolved `from` a third file that neither declares `Manager` nor
+    // `AbstractManager` — the realistic shape (`Manager.requireComponent()`
+    // called from many files, declared in exactly one). The hierarchy fallback
+    // must walk from `Manager`'s own declaring file, not the call site.
+    let abstract_manager_uri = uri("/AbstractManager.kt");
+    let manager_uri = uri("/Manager.kt");
+    let caller_uri = uri("/Caller.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &abstract_manager_uri,
+        concat!(
+            "package com.example\n",
+            "abstract class AbstractManager<T> {\n",
+            "  fun requireComponent(): T = TODO()\n",
+            "}\n",
+        ),
+    );
+    idx.index_content(
+        &manager_uri,
+        "package com.example\nobject Manager : AbstractManager<String>()\n",
+    );
+    idx.index_content(
+        &caller_uri,
+        "package com.example\nfun use() { Manager.requireComponent() }\n",
+    );
+
+    let locs = resolve_symbol(&idx, "requireComponent", Some("Manager"), &caller_uri);
+    assert!(
+        !locs.is_empty(),
+        "requireComponent not found via Manager's superclass hierarchy from a different call-site file"
+    );
+    assert_eq!(locs[0].uri, abstract_manager_uri);
 }
 
 #[test]

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -4688,6 +4688,56 @@ fn find_definition_qualified_falls_back_to_bare_lookup_for_scope_functions() {
     );
 }
 
+/// The resolution-accuracy benchmark's own `resolve_identity_with_io(..., true)`
+/// path calls `find_definition_qualified_index_only`, not `find_definition_qualified` —
+/// so the scope-function fallback must apply there too, or the benchmark this fix
+/// was built for never actually benefits from it (Copilot review on PR #277).
+#[test]
+fn find_definition_qualified_index_only_falls_back_to_bare_lookup_for_scope_functions() {
+    use crate::types::FileData;
+    use std::sync::Arc;
+
+    let idx = Indexer::new();
+    let jar_uri = "jar:file:///kotlin-stdlib.jar!/kotlin/StandardKt.class";
+    idx.jar_definitions
+        .entry("apply".to_string())
+        .or_default()
+        .push(tower_lsp::lsp_types::Location {
+            uri: Url::parse(jar_uri).unwrap(),
+            range: tower_lsp::lsp_types::Range::default(),
+        });
+    idx.jar_files.insert(
+        jar_uri.to_string(),
+        Arc::new(FileData {
+            package: Some("kotlin".to_string()),
+            ..Default::default()
+        }),
+    );
+
+    let use_uri = Url::parse("file:///app/Show.kt").unwrap();
+    idx.index_content(
+        &use_uri,
+        concat!(
+            "package app\n",
+            "import kotlin.apply\n",
+            "class SomeBuilderResult\n",
+            "class Builder { fun build(): SomeBuilderResult = SomeBuilderResult() }\n",
+            "fun show() {\n",
+            "    Builder().build().apply { show() }\n",
+            "}\n",
+        ),
+    );
+
+    let locs =
+        idx.find_definition_qualified_index_only("apply", Some("SomeBuilderResult"), &use_uri);
+    assert!(
+        locs.iter().any(|l| l.uri.as_str() == jar_uri),
+        "index-only receiver-typed `apply` must also fall back to the bare stdlib \
+         declaration; got {:?}",
+        locs.iter().map(|l| l.uri.as_str()).collect::<Vec<_>>()
+    );
+}
+
 /// Decoy: a receiver type that declares its OWN member named `apply` must still
 /// resolve to that member — the scope-function fallback may only fire after the
 /// ordinary receiver-scoped search has already failed, never unconditionally for


### PR DESCRIPTION
## Summary

Four Copilot review findings from the previously-merged stack, all fixed here:

**1. `find_definition_qualified_index_only` bypassed the scope-function fallback (PR #277 review)**
`find_definition_qualified_index_only` called `resolve_symbol_index_only` directly, bypassing the `SCOPE_FUNCTIONS` fallback #277 added to `find_definition_qualified`. The resolution-accuracy benchmark's own `resolve_identity_with_io(..., true)` path — the whole reason #277 exists — calls exactly this index-only variant, so the fix never actually reached the benchmark it was built for. Extracts the shared logic into `find_definition_qualified_with_io(index_only: bool)`, called by both public entry points, so the two variants can't diverge on this again.

**2. `resolve_symbol_no_rg`'s doc comment had drifted from `ResolveIo::NoRg`'s actual policy (PR #278 review)**
The doc comment claimed "identical to Full but omits" a specific list, but `ResolveIo::NoRg` actually differs more than that (still allows `fd` for imports; also disables cold-file indexing and local-decl line scanning). Points to the enum doc instead of re-describing the policy in a second place it can drift again.

**3. `resolve_qualified` resolved its qualifier root via the always-`Full` `resolve_symbol` regardless of the caller's own IO policy (PR #274 review)**
An `IndexOnly` caller (the resolution-accuracy benchmark) could still spawn `rg`/`fd` resolving e.g. `SomeType` in `SomeType.member` — the exact subprocess-spawn problem #274 was built to eliminate, still reachable through the qualified path. Threads `io: ResolveIo` through `resolve_qualified`; `resolve_member_only` (the one other caller) passes `Full` explicitly to preserve its existing behavior.

**4. PR #276's uppercase-qualifier hierarchy fallback used the wrong file/scope (PR #276 review)**
It walked supers of *every* class in `from_uri` (the call site file) rather than the qualifier's own declaring file and class — so `Manager.requireComponent()` only worked when the call site happened to be the same file `Manager` is declared in, not the realistic shape (one declaration, many call sites). Adds `resolve_from_class_hierarchy_scoped(class_name, ...)` and threads the qualifier's own resolved location through the per-candidate loop.

**Not fixed — pushed back on:** Copilot also flagged `idx` as an abbreviated variable name in new test code. `let idx = Indexer::new()` is the established convention throughout this codebase (378 occurrences, 146 in `resolver/tests.rs` alone) — renaming one new test's `idx` to `indexer` would be inconsistent with the surrounding file, not an improvement. Replied on the thread explaining this.

## Test plan
- [x] New RED-then-GREEN tests for all three functional fixes (scope-function index-only fallback, qualified-root IndexOnly leak, cross-file hierarchy fallback) — each confirmed to fail against pre-fix code
- [x] `cargo test --bin kmp-lsp` — 1785 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ