### PR TITLE
feat(resolver): add Resolver::field_type supertype walk (Primitive A)

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -428,7 +428,7 @@ impl InferDeps for Indexer {
             // own file is the closest thing to a reachability anchor.
             return Some((type_name, uri.clone()));
         }
-        crate::resolver::infer::find_field_type_in_class(self, class_name, field_name, uri)
+        crate::resolver::Resolver::field_type(self, class_name, field_name, uri)
     }
     fn find_fun_return_type(&self, fn_name: &str, uri: &Url) -> Option<String> {
         crate::resolver::infer::find_fun_return_type_by_name(self, fn_name, uri)

--- a/src/inlay_hints_tests.rs
+++ b/src/inlay_hints_tests.rs
@@ -252,6 +252,62 @@ fun make() {
     );
 }
 
+/// CST-domain regression for `Resolver::field_type`'s supertype walk
+/// (`src/resolver/infer.rs`): `uiState` is declared only on the generic
+/// superclass `MviViewModel<S, E>`, not on `ContactAddressViewModel` itself.
+/// This never touches `chain.rs`/`expr_type.rs` directly -- it proves the fix
+/// landed once in `resolver/` reaches inlay hints automatically through the
+/// `InferDeps` seam (`Indexer::find_field_type` -> `Resolver::field_type`),
+/// exactly the "fixed once, propagates automatically" point of routing
+/// through the trait instead of patching each CST consumer separately.
+///
+/// The base and derived classes live in separate files deliberately: in one
+/// file, `find_field_type_in_class`'s own-body check would accidentally
+/// "find" the base's `uiState` by whole-file line-proximity (see
+/// `infer_field_type_raw`'s `near_line` doc comment) and return the raw,
+/// unsubstituted `S` -- a separate, pre-existing quirk this test avoids
+/// conflating with the supertype-walk substitution under test here.
+#[test]
+fn untyped_val_navigation_through_inherited_generic_field_gets_hint() {
+    let base_uri = uri("/MviViewModel.kt");
+    let idx = Arc::new(Indexer::new());
+    idx.index_content(
+        &base_uri,
+        "package test\n\
+         abstract class MviViewModel<S, E> {\n\
+         \x20   val uiState: S = TODO()\n\
+         \x20   val effect: E = TODO()\n\
+         }\n",
+    );
+
+    let derived_uri = uri("/ContactAddressViewModel.kt");
+    let derived_src = "package test\n\
+         class ContactState\n\
+         class ContactEffect\n\
+         class ContactAddressViewModel : MviViewModel<ContactState, ContactEffect>()\n\
+         fun make(viewModel: ContactAddressViewModel) {\n\
+         \x20   val state = viewModel.uiState\n\
+         }\n";
+    idx.index_content(&derived_uri, derived_src);
+
+    let lines = derived_src.lines().count() as u32;
+    let hints = compute_inlay_hints(
+        &idx,
+        &derived_uri,
+        Range {
+            start: Position::new(0, 0),
+            end: Position::new(lines, 0),
+        },
+    );
+    assert!(
+        hints
+            .iter()
+            .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": ContactState")),
+        "expected ': ContactState' hint for a val initialized from a field \
+         declared only on the generic superclass, got: {hints:?}",
+    );
+}
+
 #[test]
 fn untyped_val_unindexed_di_factory_call_gets_hint() {
     // `val repo = get<UserRepository>()` where `get` is a Koin-style DI factory

--- a/src/resolver/api.rs
+++ b/src/resolver/api.rs
@@ -28,7 +28,8 @@ use tower_lsp::lsp_types::{Location, Url};
 use crate::indexer::Indexer;
 
 use super::infer::{
-    find_fun_return_type_by_name, find_fun_return_type_reachable, find_method_return_type,
+    find_field_type_in_class, find_field_type_via_supertypes, find_fun_return_type_by_name,
+    find_fun_return_type_reachable, find_method_return_type,
     find_method_return_type_via_supertypes, infer_field_chain_type, infer_receiver_type,
 };
 use super::ReceiverTypeAgreement;
@@ -165,6 +166,26 @@ pub(crate) trait Resolver {
         from_uri: Option<&Url>,
     ) -> Option<ReturnType>;
 
+    /// Resolve the declared type of `field_name` on a receiver whose type's
+    /// base name is `type_name`, together with the `Url` of the file where
+    /// that field is actually declared (the reachability anchor for the
+    /// *next* hop in a dotted chain — see `find_field_type_in_class`'s own
+    /// doc comment for why this differs from `method_return_type`, which
+    /// does not yet carry one).
+    ///
+    /// The single composite for field resolution: checks `type_name`'s own
+    /// body first, then walks its declared supertypes (with type-argument
+    /// substitution) — the field-typed sibling of `method_return_type`.
+    ///
+    /// Returns `None` when no field (own or inherited) with a declared type
+    /// is found.
+    fn field_type(
+        &self,
+        type_name: &str,
+        field_name: &str,
+        from_uri: &Url,
+    ) -> Option<(String, Url)>;
+
     /// Does `candidate_type`'s receiver relate to `target_type` — exact
     /// match, a proven supertype/subtype relationship (in either direction a
     /// caller separately checks), a proven exclusion, or "the index can't
@@ -234,5 +255,15 @@ impl Resolver for Indexer {
             target_type,
             sidecar_budget,
         )
+    }
+
+    fn field_type(
+        &self,
+        type_name: &str,
+        field_name: &str,
+        from_uri: &Url,
+    ) -> Option<(String, Url)> {
+        find_field_type_in_class(self, type_name, field_name, from_uri)
+            .or_else(|| find_field_type_via_supertypes(self, type_name, field_name, from_uri))
     }
 }

--- a/src/resolver/api.rs
+++ b/src/resolver/api.rs
@@ -158,7 +158,7 @@ pub(crate) trait Resolver {
     /// context.
     ///
     /// Returns `None` when no matching method (own, extension, or inherited) with
-    /// a declared return type is found.
+    /// a resolvable return type — declared or inferred — is found.
     fn method_return_type(
         &self,
         type_name: &str,
@@ -166,7 +166,8 @@ pub(crate) trait Resolver {
         from_uri: Option<&Url>,
     ) -> Option<ReturnType>;
 
-    /// Resolve the declared type of `field_name` on a receiver whose type's
+    /// Resolve `field_name`'s type (declared, or inferred from its
+    /// initializer for an unannotated `val`/`var`) on a receiver whose type's
     /// base name is `type_name`, together with the `Url` of the file where
     /// that field is actually declared (the reachability anchor for the
     /// *next* hop in a dotted chain — see `find_field_type_in_class`'s own
@@ -177,8 +178,8 @@ pub(crate) trait Resolver {
     /// body first, then walks its declared supertypes (with type-argument
     /// substitution) — the field-typed sibling of `method_return_type`.
     ///
-    /// Returns `None` when no field (own or inherited) with a declared type
-    /// is found.
+    /// Returns `None` when no field (own or inherited) with a resolvable
+    /// type is found.
     fn field_type(
         &self,
         type_name: &str,

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -1176,6 +1176,30 @@ fn find_field_type_in_class_impl(
     None
 }
 
+/// Candidates for a supertype walk's starting class: reachability-scoped
+/// first (`from_uri`'s own imports/package), falling back to an unscoped
+/// workspace search and finally `lookup_definitions` (the only one of the
+/// three that promotes a not-yet-materialized JAR) when nothing reachable is
+/// found. Shared by [`find_field_type_via_supertypes`] and
+/// [`find_method_return_type_via_supertypes`] so neither anchors its walk on
+/// an unrelated same-named class elsewhere in the workspace.
+fn reachable_class_candidates(
+    indexer: &Indexer,
+    class_base: &str,
+    from_uri: Option<&Url>,
+) -> Vec<Location> {
+    let mut candidates = from_uri
+        .map(|uri| super::resolve::resolve_type_index_only(indexer, class_base, uri))
+        .unwrap_or_default();
+    if candidates.is_empty() {
+        candidates = indexer.workspace_def_candidates(class_base);
+    }
+    if candidates.is_empty() {
+        candidates = indexer.lookup_definitions(class_base);
+    }
+    candidates
+}
+
 /// Resolve `field_name`'s declared type by walking `class_name`'s ancestors —
 /// the field-typed sibling of [`find_method_return_type_via_supertypes`].
 /// [`find_field_type_in_class`] only reads `class_name`'s own body, so a
@@ -1213,13 +1237,11 @@ fn find_field_type_via_supertypes_impl(
     if depth == 0 {
         return None;
     }
-    // Strip generics AND any qualifying package prefix, matching
-    // `find_method_return_type_via_supertypes`: `lookup_definitions` is keyed
-    // by the bare symbol name.
+    // Strip generics AND any qualifying package prefix — `class_base` is
+    // matched against bare symbol names below.
     let class_base = class_name.dotted_ident_prefix().last_segment().to_owned();
 
-    indexer
-        .lookup_definitions(&class_base)
+    reachable_class_candidates(indexer, &class_base, Some(from_uri))
         .into_iter()
         .take(crate::indexer::MAX_BY_NAME_DEFS)
         .find_map(|location| {
@@ -1863,17 +1885,11 @@ pub(crate) fn find_method_return_type_via_supertypes(
     method_name: &str,
     from_uri: Option<&Url>,
 ) -> Option<String> {
-    // Strip generics AND any qualifying package prefix: `lookup_definitions`
-    // is keyed by the bare symbol name, so a qualified `class_name` (e.g.
-    // `com.lib.MutableSharedFlow<Event>`) would otherwise silently miss it.
+    // Strip generics AND any qualifying package prefix — `class_base` is
+    // matched against bare symbol names below.
     let class_base = class_name.dotted_ident_prefix().last_segment().to_owned();
 
-    // `lookup_definitions` merges workspace + JAR locations (promoting a
-    // not-yet-materialized JAR as needed) into an owned `Vec<Location>` --
-    // the walk below promotes further JARs per-ancestor, and an owned Vec
-    // (unlike a DashMap `Ref`) can't deadlock against that.
-    indexer
-        .lookup_definitions(&class_base)
+    reachable_class_candidates(indexer, &class_base, from_uri)
         .into_iter()
         .take(crate::indexer::MAX_BY_NAME_DEFS)
         .find_map(|loc| {

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -218,7 +218,7 @@ pub(crate) fn infer_field_chain_type(
             .unwrap_or(&current)
             .strip_nullable();
         let (field_raw, declaring_uri) =
-            find_field_type_in_class(indexer, class_base, field, &reachability_uri)?;
+            super::Resolver::field_type(indexer, class_base, field, &reachability_uri)?;
         current = field_raw.clone();
         leaf_raw = field_raw;
         reachability_uri = declaring_uri;
@@ -1174,6 +1174,108 @@ fn find_field_type_in_class_impl(
         }
     }
     None
+}
+
+/// Resolve `field_name`'s declared type by walking `class_name`'s ancestors —
+/// the field-typed sibling of [`find_method_return_type_via_supertypes`].
+/// [`find_field_type_in_class`] only reads `class_name`'s own body, so a
+/// field declared only on a generic superclass (`viewModel.uiState` where
+/// `uiState` lives on `MviViewModel<State, Effect>`, not the specific
+/// subclass) never resolves through it alone.
+pub(crate) fn find_field_type_via_supertypes(
+    indexer: &Indexer,
+    class_name: &str,
+    field_name: &str,
+    from_uri: &Url,
+) -> Option<(String, Url)> {
+    find_field_type_via_supertypes_impl(
+        indexer,
+        class_name,
+        field_name,
+        from_uri,
+        MAX_RAW_TYPE_INFER_DEPTH,
+    )
+}
+
+/// Depth-guarded implementation of [`find_field_type_via_supertypes`] —
+/// shares [`find_field_type_in_class_impl`]'s recursion budget rather than
+/// starting a fresh one: an ancestor's own field lookup can fall back to
+/// variable-type inference, which can re-enter field-type lookup for yet
+/// another receiver (see `MAX_RAW_TYPE_INFER_DEPTH`), so this walk is a
+/// participant in that cycle, not a separately-bounded recursion of its own.
+fn find_field_type_via_supertypes_impl(
+    indexer: &Indexer,
+    class_name: &str,
+    field_name: &str,
+    from_uri: &Url,
+    depth: u8,
+) -> Option<(String, Url)> {
+    if depth == 0 {
+        return None;
+    }
+    // Strip generics AND any qualifying package prefix, matching
+    // `find_method_return_type_via_supertypes`: `lookup_definitions` is keyed
+    // by the bare symbol name.
+    let class_base = class_name.dotted_ident_prefix().last_segment().to_owned();
+
+    indexer
+        .lookup_definitions(&class_base)
+        .into_iter()
+        .take(crate::indexer::MAX_BY_NAME_DEFS)
+        .find_map(|location| {
+            find_field_type_via_class_hierarchy(
+                indexer,
+                &class_base,
+                location.uri.as_str(),
+                field_name,
+                from_uri,
+                depth,
+            )
+        })
+}
+
+/// Walk every ancestor of `class_base` (declared at `class_uri`) via
+/// [`walk_hierarchy`] looking for `field_name`'s declared type — mirrors
+/// [`find_method_return_type_via_class_hierarchy`]'s structure exactly.
+/// The direct supertype's own generic type arguments are substituted into a
+/// hit found there via `substitute_direct_supertype_args`; a hit on a deeper
+/// ancestor is returned as-is (same documented limitation the method version
+/// already accepts).
+fn find_field_type_via_class_hierarchy(
+    indexer: &Indexer,
+    class_base: &str,
+    class_uri: &str,
+    field_name: &str,
+    from_uri: &Url,
+    depth: u8,
+) -> Option<(String, Url)> {
+    use crate::types::CallerContext;
+
+    let caller = CallerContext {
+        uri: Some(from_uri.as_str()),
+        cursor_line: None,
+    };
+    let hits: Vec<(String, String, Url)> = walk_hierarchy(
+        indexer,
+        class_base,
+        class_uri,
+        caller,
+        8,
+        MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
+        |idx, super_name, super_uri, _caller| {
+            let Ok(super_url) = Url::parse(super_uri) else {
+                return Vec::new();
+            };
+            find_field_type_in_class_impl(idx, super_name, field_name, &super_url, depth - 1)
+                .map(|(raw, declaring_uri)| (super_name.to_owned(), raw, declaring_uri))
+                .into_iter()
+                .collect()
+        },
+    );
+    let (super_name, raw, declaring_uri) = hits.into_iter().next()?;
+    let substituted =
+        substitute_direct_supertype_args(indexer, class_uri, class_base, &super_name, &raw);
+    Some((substituted, declaring_uri))
 }
 
 // ─── Extension property type inference ───────────────────────────────────────

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -1606,6 +1606,59 @@ fn catalog_field_type_supertype_walk_ignores_unrelated_same_named_sibling_field(
     );
 }
 
+/// Two unrelated classes both named `Derived` exist in the workspace; only
+/// one is reachable from the caller's own import. The supertype walk's own
+/// starting-class lookup must stay reachability-scoped like
+/// `find_field_type_in_class`'s already is, not fall back to an unscoped
+/// by-name pick that could land on the wrong `Derived` and its wrong
+/// ancestor (Copilot review, PR #281).
+#[test]
+fn catalog_field_type_supertype_walk_stays_reachability_scoped_on_a_colliding_class_name() {
+    use crate::indexer::Indexer;
+    use crate::resolver::Resolver;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    // Indexed first, so an unscoped by-name lookup would find it first.
+    idx.index_content(
+        &Url::parse("file:///com/wrong/Derived.kt").unwrap(),
+        "package com.wrong\n\
+         abstract class WrongBase {\n\
+         \x20   val value: WrongType = TODO()\n\
+         }\n\
+         class WrongType\n\
+         class Derived : WrongBase()\n",
+    );
+    idx.index_content(
+        &Url::parse("file:///com/right/RightBase.kt").unwrap(),
+        "package com.right\n\
+         abstract class RightBase {\n\
+         \x20   val value: RightType = TODO()\n\
+         }\n\
+         class RightType\n",
+    );
+    let right_derived = Url::parse("file:///com/right/Derived.kt").unwrap();
+    idx.index_content(
+        &right_derived,
+        "package com.right\nclass Derived : RightBase()\n",
+    );
+    let caller = Url::parse("file:///com/caller/Caller.kt").unwrap();
+    idx.index_content(
+        &caller,
+        "package com.caller\nimport com.right.Derived\nfun use(d: Derived) { d.value }\n",
+    );
+
+    let (field_type, declaring_uri) = idx
+        .field_type("Derived", "value", &caller)
+        .expect("value must resolve via the reachable Derived's own supertype");
+    assert_eq!(
+        field_type, "RightType",
+        "must walk the reachable com.right.Derived's own supertype \
+         (RightBase), not the unrelated com.wrong.Derived indexed first"
+    );
+    assert_eq!(declaring_uri.as_str(), "file:///com/right/RightBase.kt");
+}
+
 /// Regression, exercised through the *supertype-walk* path specifically:
 /// mirrors `find_field_type_in_class_terminates_on_a_mutual_field_reference_cycle`,
 /// but the queried class doesn't declare the field itself -- it inherits it

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -1469,3 +1469,180 @@ fn receiver_based_resolution_also_substitutes_call_site_type_argument() {
          real receiver type is star-projected Flow<*>)"
     );
 }
+
+/// Confirms the gap `Resolver::field_type` exists to close:
+/// `find_field_type_in_class` only reads a class's own body, so a field
+/// declared only on a generic superclass (`viewModel.uiState` where
+/// `uiState` lives on `MviViewModel<S, E>`, not the specific subclass) is
+/// invisible to it — the scout report's `ContactAddressViewModel` evidence.
+///
+/// The base class and its subclass live in separate files (the realistic
+/// MVI shape, and how the GREEN/decoy siblings below are also built): were
+/// they in one file, `find_field_type_in_class`'s own-body check would
+/// accidentally "find" the base's `uiState` by whole-file line-proximity
+/// (see `infer_field_type_raw`'s `near_line` doc comment) despite it not
+/// being scoped to the queried class's container at all -- a separate,
+/// pre-existing quirk this test deliberately avoids conflating with the
+/// actual supertype-walk gap under test here.
+#[test]
+fn find_field_type_in_class_alone_misses_a_generic_superclass_field() {
+    use super::find_field_type_in_class;
+    use crate::indexer::Indexer;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    let base = Url::parse("file:///app/MviViewModel.kt").unwrap();
+    idx.index_content(
+        &base,
+        "package app\n\
+         abstract class MviViewModel<S, E> {\n\
+         \x20   val uiState: S = TODO()\n\
+         \x20   val effect: E = TODO()\n\
+         }\n",
+    );
+    let derived = Url::parse("file:///app/ContactAddressViewModel.kt").unwrap();
+    idx.index_content(
+        &derived,
+        "package app\n\
+         class ContactState\n\
+         class ContactEffect\n\
+         class ContactAddressViewModel : MviViewModel<ContactState, ContactEffect>()\n",
+    );
+
+    assert_eq!(
+        find_field_type_in_class(&idx, "ContactAddressViewModel", "uiState", &derived),
+        None,
+        "find_field_type_in_class must NOT find a field declared only on a \
+         superclass -- that is exactly the gap the supertype walk closes"
+    );
+}
+
+/// GREEN: `Resolver::field_type` folds the supertype walk in, so `uiState`
+/// (declared only on `MviViewModel<S, E>`) resolves for the derived class,
+/// substituting the direct supertype's own concrete type arguments
+/// (`ContactState`/`ContactEffect`) into the raw declared type `S`.
+#[test]
+fn catalog_field_type_folds_supertype_inheritance_with_generic_substitution() {
+    use crate::indexer::Indexer;
+    use crate::resolver::Resolver;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    let base = Url::parse("file:///app/MviViewModel.kt").unwrap();
+    idx.index_content(
+        &base,
+        "package app\n\
+         abstract class MviViewModel<S, E> {\n\
+         \x20   val uiState: S = TODO()\n\
+         \x20   val effect: E = TODO()\n\
+         }\n",
+    );
+    let derived = Url::parse("file:///app/ContactAddressViewModel.kt").unwrap();
+    idx.index_content(
+        &derived,
+        "package app\n\
+         class ContactState\n\
+         class ContactEffect\n\
+         class ContactAddressViewModel : MviViewModel<ContactState, ContactEffect>()\n",
+    );
+
+    let (field_type, _declaring_uri) = idx
+        .field_type("ContactAddressViewModel", "uiState", &derived)
+        .expect("uiState must resolve via the supertype walk");
+    assert_eq!(
+        field_type, "ContactState",
+        "the direct supertype's own generic argument (ContactState for S) \
+         must be substituted into the raw declared type"
+    );
+}
+
+/// Decoy: an unrelated sibling class reachable from the same file as the
+/// real ancestor also declares a field named `uiState`, with a different
+/// type, but is itself NOT anywhere in `ContactAddressViewModel`'s
+/// hierarchy. `find_field_type_via_supertypes` resolves each ancestor by
+/// walking real CST-recorded `supers` edges (`walk_hierarchy`) and looks up
+/// `uiState` scoped to that specific resolved ancestor class -- not an
+/// unscoped by-name scan across the file -- so the decoy's field must never
+/// surface, matching the discipline `find_name_scoped_to_container`'s
+/// existence elsewhere in this codebase already enforces for other lookups.
+#[test]
+fn catalog_field_type_supertype_walk_ignores_unrelated_same_named_sibling_field() {
+    use crate::indexer::Indexer;
+    use crate::resolver::Resolver;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    let base = Url::parse("file:///app/MviViewModel.kt").unwrap();
+    idx.index_content(
+        &base,
+        "package app\n\
+         // Unrelated: not a supertype of ContactAddressViewModel, but shares\n\
+         // the field name `uiState` with an incompatible type -- declared\n\
+         // well before the real ancestor so a proximity-based scan (rather\n\
+         // than genuine container scoping) could not accidentally pass.\n\
+         class UnrelatedSettingsHolder {\n\
+         \x20   val uiState: Boolean = TODO()\n\
+         }\n\
+         abstract class MviViewModel<S, E> {\n\
+         \x20   val uiState: S = TODO()\n\
+         }\n",
+    );
+    let derived = Url::parse("file:///app/ContactAddressViewModel.kt").unwrap();
+    idx.index_content(
+        &derived,
+        "package app\n\
+         class ContactState\n\
+         class ContactAddressViewModel : MviViewModel<ContactState, Unit>()\n",
+    );
+
+    let (field_type, _declaring_uri) = idx
+        .field_type("ContactAddressViewModel", "uiState", &derived)
+        .expect("uiState must resolve via the real supertype walk");
+    assert_eq!(
+        field_type, "ContactState",
+        "the real ancestor's uiState (substituted to ContactState) must win \
+         -- the unrelated sibling's same-named Boolean field must never be \
+         picked up by the supertype walk"
+    );
+}
+
+/// Regression, exercised through the *supertype-walk* path specifically:
+/// mirrors `find_field_type_in_class_terminates_on_a_mutual_field_reference_cycle`,
+/// but the queried class doesn't declare the field itself -- it inherits it
+/// from a superclass whose own inference re-enters the same
+/// field/variable-type mutual-recursion cycle PR #278 bounded
+/// (`find_field_type_in_class_impl` <-> `infer_variable_type_raw_impl`).
+/// `find_field_type_via_supertypes` must thread the *same* shared depth
+/// budget through, not add its own separate unguarded recursion, or this
+/// reopens the exact stack overflow that fix closed.
+#[test]
+fn find_field_type_via_supertypes_terminates_on_a_mutual_field_reference_cycle() {
+    use crate::indexer::Indexer;
+    use crate::resolver::Resolver;
+    use tower_lsp::lsp_types::Url;
+
+    fn uri(p: &str) -> Url {
+        Url::parse(&format!("file://{p}")).unwrap()
+    }
+
+    let idx = Indexer::new();
+    idx.index_content(
+        &uri("/A.kt"),
+        "package com.example\n\
+         open class A(val b: B) {\n\
+         \x20   val value = b.value\n\
+         }\n\
+         class DerivedA : A(TODO())\n",
+    );
+    idx.index_content(
+        &uri("/B.kt"),
+        "package com.example\nclass B(val a: A) {\n    val value = a.value\n}\n",
+    );
+
+    // Past the depth cap the walk bails at whatever partial (possibly
+    // approximate) answer it has -- no specific value is asserted, only that
+    // this call, reached via the supertype-walk fallback (DerivedA declares
+    // no `value` field itself), returns at all instead of overflowing the
+    // stack.
+    let _ = idx.field_type("DerivedA", "value", &uri("/A.kt"));
+}

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -828,6 +828,61 @@ fn resolve_qualified_uppercase_root_hierarchy_fallback_reaches_jar_superclass() 
     );
 }
 
+/// `Resolver::field_type`'s supertype walk (`find_field_type_via_supertypes`)
+/// is JAR-promotion-aware the same way `resolve_from_class_hierarchy` is
+/// above, so it can walk into a JAR-derived superclass whose stub symbols
+/// carry the same degenerate `.range == .selection_range` (no real body
+/// span). Unlike a member *function* (found via the container-scoped
+/// `find_in_workspace_defs` check), a JAR class's own member *property* has
+/// no indexed-detail resolution path yet (`infer_field_type_raw` never reads
+/// `jar_files`, only workspace `files`) — the point of this test is that the
+/// walk still terminates with a clean `None` instead of panicking on the
+/// JAR stub's degenerate range, not that the property resolves.
+#[test]
+fn catalog_field_type_supertype_walk_reaches_jar_superclass_without_panicking() {
+    use crate::sidecar::SidecarSymbol;
+
+    let sym = |name: &str, kind: &str, container: &str| SidecarSymbol {
+        name: name.to_owned(),
+        kind: kind.to_owned(),
+        container: container.to_owned(),
+        detail: format!("val {name}: String"),
+        doc: String::new(),
+        type_params: vec![],
+        extension_receiver_type: String::new(),
+        trailing_lambda: false,
+        deprecated: false,
+        pkg: "com.lib".to_owned(),
+        top_level: container.is_empty(),
+        supers: vec![],
+    };
+    let idx = Indexer::new();
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/abstract-viewmodel.jar"),
+        &[
+            sym("AbstractViewModel", "class", ""),
+            sym("uiState", "val", "AbstractViewModel"),
+        ],
+    );
+
+    let host_uri = uri("/ConcreteViewModel.kt");
+    idx.index_content(
+        &host_uri,
+        "package com.example\nclass ConcreteViewModel : AbstractViewModel()\n",
+    );
+
+    let result =
+        crate::resolver::Resolver::field_type(&idx, "ConcreteViewModel", "uiState", &host_uri);
+    assert!(
+        result.is_none(),
+        "a JAR class's own member property has no indexed-detail resolution \
+         path today (unlike an extension property); the walk must return \
+         None gracefully instead of panicking on the JAR stub's degenerate \
+         range, got {result:?}"
+    );
+}
+
 #[test]
 fn resolve_qualified_uppercase_root_hierarchy_fallback_works_from_a_different_call_site_file() {
     // Same fixture as `resolve_qualified_uppercase_root_falls_back_to_class_hierarchy`,


### PR DESCRIPTION
## Summary

Implements **Primitive A** of `docs/superpowers/specs/2026-08-24-unresolved-member-gap-remediation-design.md` — a `Resolver::field_type` trait method mirroring `method_return_type`'s existing composite ("checks the type's own body, then walks its declared supertypes"), closing a gap where a property/field declared only on a generic superclass (`viewModel.uiState` where `uiState` lives on `MviViewModel<State, Effect>`, not the specific subclass) never resolved.

- `Resolver::field_type` added to the trait; `Indexer`'s impl is `find_field_type_in_class(...).or_else(find_field_type_via_supertypes(...))`.
- `find_field_type_via_supertypes` mirrors `find_method_return_type_via_supertypes`'s structure (ancestor walk via `walk_hierarchy`, direct-supertype generic-argument substitution).
- Wired into both consumers: `Indexer::find_field_type` (the `InferDeps` seam — CST domain, `chain.rs`/`expr_type.rs` pick this up automatically) and `infer_field_chain_type` (the string-domain chain walker).
- **Critical correctness requirement, verified**: `find_field_type_via_supertypes` becomes a third participant in the mutual-recursion cycle a recent fix (stack-overflow bound between `find_field_type_in_class` and `infer_variable_type_raw`) closed — it threads the *same* shared `MAX_RAW_TYPE_INFER_DEPTH` budget rather than starting a fresh one, verified by a regression test that reproduces that exact cycle through the new supertype-walk path specifically.

**Two Copilot review findings, both fixed** (see thread replies for detail):
1. `field_type`'s doc said "declared type" but the implementation also infers unannotated fields from their initializer — fixed, and fixed `method_return_type`'s identical pre-existing wording at the same time.
2. `find_field_type_via_supertypes` anchored its ancestor walk on an unscoped by-name lookup (`lookup_definitions`), which could pick the wrong same-named class in a large workspace and walk the wrong hierarchy entirely. Found the same characteristic in the pre-existing `find_method_return_type_via_supertypes` (this PR's new function faithfully mirrored it) and fixed both together via a shared `reachable_class_candidates` helper — reachability-scoped first, `lookup_definitions` kept only as the final JAR-promoting fallback.

## Test plan
- [x] RED-then-GREEN for the core gap (`find_field_type_in_class_alone_misses_a_generic_superclass_field` → `catalog_field_type_folds_supertype_inheritance_with_generic_substitution`)
- [x] Decoy: unrelated same-named sibling field must not be picked up
- [x] CST-domain propagation proof: inlay-hints test through `InferDeps`/`chain.rs`/`expr_type.rs` with zero changes to those files
- [x] Mutual-recursion cycle regression, reached through the supertype-walk path specifically
- [x] JAR-superclass decoy: degenerate `.range == .selection_range` doesn't panic
- [x] New: reachability-vs-unscoped-collision regression — two unrelated same-named classes, confirmed fails against the pre-fix unscoped lookup, passes after
- [x] `cargo test --bin kmp-lsp` — 1792 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ