### PR TITLE
fix(resolve): resolve Compose-style member extension functions without import

### DIFF
--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
@@ -394,8 +394,13 @@ private class JavaClassVisitor(private val entries: MutableList<SymbolEntry>, pr
 
     override fun visit(version: Int, access: Int, name: String, signature: String?, superName: String?, interfaces: Array<out String>?) {
         className = name.substringAfterLast('/')
-        isPublicClass = (access and Opcodes.ACC_PUBLIC) != 0
-        if (isPublicClass && !className.contains('$')) {
+        // Excludes `$`-named (nested/inner) classes here, once, so every
+        // member-visiting callback below (`visitMethod`, `visitField`) that
+        // gates on `isPublicClass` automatically skips members of a class
+        // that was never itself emitted as a class definition — Kotlin
+        // callers reference `Outer.Inner`, never the JVM's `Outer$Inner`.
+        isPublicClass = (access and Opcodes.ACC_PUBLIC) != 0 && !className.contains('$')
+        if (isPublicClass) {
             // Direct super types (super class + interfaces) as simple names; `Object`
             // is implicit and dropped as noise.
             val supers = buildList {

--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
@@ -416,6 +416,21 @@ private class JavaClassVisitor(private val entries: MutableList<SymbolEntry>, pr
         entries += SymbolEntry(name, "fun", className, "fun $name(...)", pkg = pkg, topLevel = false)
         return null
     }
+
+    override fun visitField(access: Int, name: String, descriptor: String, signature: String?, value: Any?): FieldVisitor? {
+        if (!isPublicClass) return null
+        val isPublic = (access and Opcodes.ACC_PUBLIC) != 0
+        val isSynthetic = (access and Opcodes.ACC_SYNTHETIC) != 0
+        if (!isPublic || isSynthetic) return null
+        if (name.contains('$')) return null
+        // `val` for effectively-immutable (ACC_FINAL, the common case for
+        // constants like `Activity.RESULT_OK`), `var` otherwise — mirrors
+        // Kotlin's own val/var distinction closely enough for kind mapping.
+        val kind = if ((access and Opcodes.ACC_FINAL) != 0) "val" else "var"
+        val typeName = org.objectweb.asm.Type.getType(descriptor).className.substringAfterLast('.')
+        entries += SymbolEntry(name, kind, className, "$kind $name: $typeName", pkg = pkg, topLevel = false)
+        return null
+    }
 }
 
 // ── Public entry point ─────────────────────────────────────────────────────────

--- a/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
+++ b/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
@@ -120,6 +120,37 @@ class IndexerTest {
     }
 
     @Test
+    @DisplayName("indexClassBytes extracts a public static final field via the Java fallback path (no Kotlin metadata)")
+    fun testJavaPublicFieldExtraction() {
+        // Mirrors android.jar's own motivating example: Activity.RESULT_OK is a
+        // plain Java `public static final int` field with no Kotlin metadata.
+        val cw = org.objectweb.asm.ClassWriter(0)
+        cw.visit(
+            org.objectweb.asm.Opcodes.V1_8,
+            org.objectweb.asm.Opcodes.ACC_PUBLIC,
+            "com/example/TestActivity",
+            null,
+            "java/lang/Object",
+            null
+        )
+        cw.visitField(
+            org.objectweb.asm.Opcodes.ACC_PUBLIC or org.objectweb.asm.Opcodes.ACC_STATIC or org.objectweb.asm.Opcodes.ACC_FINAL,
+            "RESULT_OK",
+            "I",
+            null,
+            -1
+        ).visitEnd()
+        cw.visitEnd()
+
+        val result = indexClassBytes(cw.toByteArray())
+
+        assertTrue(
+            result.any { it.name == "RESULT_OK" && it.kind == "val" && it.container == "TestActivity" },
+            "should find the public static final field via the Java fallback path; got: ${result.map { "${it.name}:${it.kind}:${it.container}:${it.detail}" }}"
+        )
+    }
+
+    @Test
     @DisplayName("indexClassBytes captures package and top-level flag")
     fun testPackageAndTopLevel() {
         val result = indexClassBytes(minimalClassBytes("androidx/compose/runtime/Composables"))

--- a/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
+++ b/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
@@ -151,6 +151,40 @@ class IndexerTest {
     }
 
     @Test
+    @DisplayName("indexClassBytes does not orphan fields on a nested (\$-named) class")
+    fun testJavaFieldExtractionSkipsNestedClass() {
+        // The class-visiting entry point already skips emitting a class definition
+        // for `$`-named classes (see testInnerClass). Field extraction must apply
+        // the same exclusion — otherwise fields get indexed under a container
+        // qualifier ("Outer$Inner") that was never indexed as a class and that no
+        // Kotlin caller would ever reference (Kotlin spells it "Outer.Inner").
+        val cw = org.objectweb.asm.ClassWriter(0)
+        cw.visit(
+            org.objectweb.asm.Opcodes.V1_8,
+            org.objectweb.asm.Opcodes.ACC_PUBLIC,
+            "com/example/Outer\$Inner",
+            null,
+            "java/lang/Object",
+            null
+        )
+        cw.visitField(
+            org.objectweb.asm.Opcodes.ACC_PUBLIC or org.objectweb.asm.Opcodes.ACC_STATIC or org.objectweb.asm.Opcodes.ACC_FINAL,
+            "ORPHAN_FIELD",
+            "I",
+            null,
+            -1
+        ).visitEnd()
+        cw.visitEnd()
+
+        val result = indexClassBytes(cw.toByteArray())
+
+        assertTrue(
+            result.isEmpty(),
+            "fields on a \$-named class must be skipped, matching class-skipping behavior; got: ${result.map { "${it.name}:${it.kind}:${it.container}" }}"
+        )
+    }
+
+    @Test
     @DisplayName("indexClassBytes captures package and top-level flag")
     fun testPackageAndTopLevel() {
         val result = indexClassBytes(minimalClassBytes("androidx/compose/runtime/Composables"))

--- a/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
+++ b/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
@@ -81,6 +81,45 @@ class IndexerTest {
     }
 
     @Test
+    @DisplayName("indexClassBytes extracts a public method via the Java fallback path (no Kotlin metadata, no sources JAR)")
+    fun testJavaPublicMethodExtraction() {
+        // Mirrors android.jar's own shape: plain Java bytecode, no @kotlin.Metadata,
+        // no sibling -sources.jar — exercises JavaClassVisitor.visitMethod, which no
+        // existing fixture reached (minimalClassBytes only emits a skipped <init>).
+        val cw = org.objectweb.asm.ClassWriter(0)
+        cw.visit(
+            org.objectweb.asm.Opcodes.V1_8,
+            org.objectweb.asm.Opcodes.ACC_PUBLIC,
+            "com/example/TestActivity",
+            null,
+            "java/lang/Object",
+            null
+        )
+        val ctor = cw.visitMethod(org.objectweb.asm.Opcodes.ACC_PUBLIC, "<init>", "()V", null, null)
+        ctor.visitCode()
+        ctor.visitVarInsn(org.objectweb.asm.Opcodes.ALOAD, 0)
+        ctor.visitMethodInsn(org.objectweb.asm.Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+        ctor.visitInsn(org.objectweb.asm.Opcodes.RETURN)
+        ctor.visitMaxs(1, 1)
+        ctor.visitEnd()
+        val finish = cw.visitMethod(org.objectweb.asm.Opcodes.ACC_PUBLIC, "finish", "()V", null, null)
+        finish.visitCode()
+        finish.visitInsn(org.objectweb.asm.Opcodes.RETURN)
+        finish.visitMaxs(0, 0)
+        finish.visitEnd()
+        cw.visitEnd()
+
+        val result = indexClassBytes(cw.toByteArray())
+
+        assertTrue(result.any { it.name == "TestActivity" && it.kind == "class" },
+            "should find the class entry; got: ${result.map { it.name }}")
+        assertTrue(
+            result.any { it.name == "finish" && it.kind == "fun" && it.container == "TestActivity" },
+            "should find the public method via the Java fallback path; got: ${result.map { "${it.name}:${it.kind}:${it.container}" }}"
+        )
+    }
+
+    @Test
     @DisplayName("indexClassBytes captures package and top-level flag")
     fun testPackageAndTopLevel() {
         val result = indexClassBytes(minimalClassBytes("androidx/compose/runtime/Composables"))

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -465,13 +465,31 @@ async fn run_index(root: &Path, verbose: bool) {
     }
 }
 
+/// Extends a Gradle-cache JAR scan with the Android SDK's compiled
+/// `android.jar`, for CLI paths (`find`, `diagnose`) that call
+/// `scan_gradle_jars` directly and therefore bypass `ScanHandler`'s own
+/// wiring of `detect_android_sdk_jar_path`. Reuses
+/// `compiled_jar_paths_with_android_sdk` rather than duplicating the
+/// detection logic — passes `true` for its JVM-source gate unconditionally
+/// since the CLI's own Gradle-cache scan already runs unconditionally here
+/// (no JVM-source gate at these call sites to mirror).
+fn compiled_jar_paths_for_cli(root: &Path, gradle_paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    crate::workspace::scan_handler::compiled_jar_paths_with_android_sdk(
+        Some(root.to_path_buf()),
+        true,
+        gradle_paths,
+    )
+}
+
 async fn run_find(root: &Path, mode: Mode, json: bool, verbose: bool, name: &str) {
     let results = match effective_mode(mode, root, "find", verbose) {
         Mode::Fast => fast_find(name, root),
         _ => {
             let index = build_index(root, false).await;
-            // Scan Gradle JARs so stdlib/library symbols resolve in find queries.
-            let jars = crate::indexer::jar::scan_gradle_jars(None);
+            // Scan Gradle JARs (+ the Android SDK jar, if detected) so
+            // stdlib/library/Android symbols resolve in find queries.
+            let jars =
+                compiled_jar_paths_for_cli(root, crate::indexer::jar::scan_gradle_jars(None));
             if !jars.is_empty() {
                 if let Ok(mut sidecar_guard) = index.jar_sidecar.lock() {
                     crate::indexer::jar::clear_jar_maps(&index);
@@ -735,7 +753,7 @@ async fn run_diagnose(root: &Path, file: &Path, _verbose: bool, only: Option<&[S
         // `Unavailable`, which is terminal — which is why the gap only showed up
         // once a sidecar became present, e.g. in CI after the sidecar artifact
         // was wired into the test jobs.)
-        let jars = crate::indexer::jar::scan_gradle_jars(None);
+        let jars = compiled_jar_paths_for_cli(root, crate::indexer::jar::scan_gradle_jars(None));
         if let Ok(mut sidecar_guard) = index.jar_sidecar.lock() {
             let total = if jars.is_empty() {
                 0
@@ -841,3 +859,7 @@ fn effective_mode(requested: Mode, root: &Path, subcommand: &str, verbose: bool)
         }
     }
 }
+
+#[cfg(test)]
+#[path = "run_tests.rs"]
+mod tests;

--- a/src/cli/run_tests.rs
+++ b/src/cli/run_tests.rs
@@ -3,8 +3,37 @@
 //! `compiled_jar_paths_for_cli`).
 
 use super::compiled_jar_paths_for_cli;
+use crate::indexer::test_helpers::ENV_VAR_LOCK;
 use std::fs;
 use tempfile::TempDir;
+
+/// Run `f` with both `ANDROID_HOME` and `ANDROID_SDK_ROOT` unset — CI
+/// runners (GitHub-hosted `ubuntu-latest`/`macos-latest`/`windows-latest`)
+/// ship a real, pre-installed Android SDK with these set, which would
+/// otherwise leak into `resolve_android_sdk_root`'s env-var fallback and
+/// make `detect_android_sdk_jar_path` find a real SDK even for a fixture
+/// with no `local.properties`. Locks `ENV_VAR_LOCK` once (rather than
+/// nesting two `with_env_var_unset` calls against the same non-reentrant
+/// mutex, which would deadlock) and restores both vars on the way out.
+fn without_host_android_sdk<F: FnOnce()>(f: F) {
+    let _guard = ENV_VAR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev_home = std::env::var("ANDROID_HOME").ok();
+    let prev_sdk_root = std::env::var("ANDROID_SDK_ROOT").ok();
+    std::env::remove_var("ANDROID_HOME");
+    std::env::remove_var("ANDROID_SDK_ROOT");
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    match prev_home {
+        Some(v) => std::env::set_var("ANDROID_HOME", v),
+        None => std::env::remove_var("ANDROID_HOME"),
+    }
+    match prev_sdk_root {
+        Some(v) => std::env::set_var("ANDROID_SDK_ROOT", v),
+        None => std::env::remove_var("ANDROID_SDK_ROOT"),
+    }
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
+}
 
 /// Build a fake Android SDK install under `dir` with one platform containing
 /// `android.jar`, and a `local.properties` pointing the workspace at it —
@@ -26,40 +55,46 @@ fn write_fake_android_sdk(dir: &std::path::Path, api_level: &str) -> std::path::
 
 #[test]
 fn compiled_jar_paths_for_cli_includes_the_detected_android_sdk_jar() {
-    let tmp = TempDir::new().unwrap();
-    let expected_jar = write_fake_android_sdk(tmp.path(), "android-34");
+    without_host_android_sdk(|| {
+        let tmp = TempDir::new().unwrap();
+        let expected_jar = write_fake_android_sdk(tmp.path(), "android-34");
 
-    // Empty Gradle-cache scan result — proves the SDK jar is added on top
-    // of whatever `scan_gradle_jars` finds, not derived from it.
-    let jars = compiled_jar_paths_for_cli(tmp.path(), Vec::new());
+        // Empty Gradle-cache scan result — proves the SDK jar is added on top
+        // of whatever `scan_gradle_jars` finds, not derived from it.
+        let jars = compiled_jar_paths_for_cli(tmp.path(), Vec::new());
 
-    assert!(
-        jars.contains(&expected_jar),
-        "CLI find/diagnose jar list must include the detected android.jar, got: {jars:?}"
-    );
+        assert!(
+            jars.contains(&expected_jar),
+            "CLI find/diagnose jar list must include the detected android.jar, got: {jars:?}"
+        );
+    });
 }
 
 #[test]
 fn compiled_jar_paths_for_cli_does_not_duplicate_an_already_present_sdk_jar() {
-    let tmp = TempDir::new().unwrap();
-    let expected_jar = write_fake_android_sdk(tmp.path(), "android-34");
+    without_host_android_sdk(|| {
+        let tmp = TempDir::new().unwrap();
+        let expected_jar = write_fake_android_sdk(tmp.path(), "android-34");
 
-    let jars = compiled_jar_paths_for_cli(tmp.path(), vec![expected_jar.clone()]);
+        let jars = compiled_jar_paths_for_cli(tmp.path(), vec![expected_jar.clone()]);
 
-    assert_eq!(
-        jars.iter().filter(|p| **p == expected_jar).count(),
-        1,
-        "the SDK jar must not be duplicated when the Gradle-cache scan already found it"
-    );
+        assert_eq!(
+            jars.iter().filter(|p| **p == expected_jar).count(),
+            1,
+            "the SDK jar must not be duplicated when the Gradle-cache scan already found it"
+        );
+    });
 }
 
 #[test]
 fn compiled_jar_paths_for_cli_is_a_no_op_without_an_android_sdk() {
-    let tmp = TempDir::new().unwrap();
-    // No local.properties / SDK — nothing to detect.
-    let jars = compiled_jar_paths_for_cli(tmp.path(), Vec::new());
-    assert!(
-        jars.is_empty(),
-        "no SDK jar should be added when none is detected, got: {jars:?}"
-    );
+    without_host_android_sdk(|| {
+        let tmp = TempDir::new().unwrap();
+        // No local.properties / SDK — nothing to detect.
+        let jars = compiled_jar_paths_for_cli(tmp.path(), Vec::new());
+        assert!(
+            jars.is_empty(),
+            "no SDK jar should be added when none is detected, got: {jars:?}"
+        );
+    });
 }

--- a/src/cli/run_tests.rs
+++ b/src/cli/run_tests.rs
@@ -1,0 +1,65 @@
+//! Tests for CLI-path Android SDK jar wiring (`find`/`diagnose` bypassing
+//! `ScanHandler`'s own `detect_android_sdk_jar_path` wiring — see
+//! `compiled_jar_paths_for_cli`).
+
+use super::compiled_jar_paths_for_cli;
+use std::fs;
+use tempfile::TempDir;
+
+/// Build a fake Android SDK install under `dir` with one platform containing
+/// `android.jar`, and a `local.properties` pointing the workspace at it —
+/// mirrors the fixture `workspace_json_tests.rs` uses for
+/// `detect_android_sdk_jar_path` itself.
+fn write_fake_android_sdk(dir: &std::path::Path, api_level: &str) -> std::path::PathBuf {
+    let fake_sdk = dir.join("sdk");
+    let platform_dir = fake_sdk.join("platforms").join(api_level);
+    fs::create_dir_all(&platform_dir).unwrap();
+    let jar_path = platform_dir.join("android.jar");
+    fs::write(&jar_path, b"fake jar").unwrap();
+    fs::write(
+        dir.join("local.properties"),
+        format!("sdk.dir={}\n", fake_sdk.display()),
+    )
+    .unwrap();
+    jar_path
+}
+
+#[test]
+fn compiled_jar_paths_for_cli_includes_the_detected_android_sdk_jar() {
+    let tmp = TempDir::new().unwrap();
+    let expected_jar = write_fake_android_sdk(tmp.path(), "android-34");
+
+    // Empty Gradle-cache scan result — proves the SDK jar is added on top
+    // of whatever `scan_gradle_jars` finds, not derived from it.
+    let jars = compiled_jar_paths_for_cli(tmp.path(), Vec::new());
+
+    assert!(
+        jars.contains(&expected_jar),
+        "CLI find/diagnose jar list must include the detected android.jar, got: {jars:?}"
+    );
+}
+
+#[test]
+fn compiled_jar_paths_for_cli_does_not_duplicate_an_already_present_sdk_jar() {
+    let tmp = TempDir::new().unwrap();
+    let expected_jar = write_fake_android_sdk(tmp.path(), "android-34");
+
+    let jars = compiled_jar_paths_for_cli(tmp.path(), vec![expected_jar.clone()]);
+
+    assert_eq!(
+        jars.iter().filter(|p| **p == expected_jar).count(),
+        1,
+        "the SDK jar must not be duplicated when the Gradle-cache scan already found it"
+    );
+}
+
+#[test]
+fn compiled_jar_paths_for_cli_is_a_no_op_without_an_android_sdk() {
+    let tmp = TempDir::new().unwrap();
+    // No local.properties / SDK — nothing to detect.
+    let jars = compiled_jar_paths_for_cli(tmp.path(), Vec::new());
+    assert!(
+        jars.is_empty(),
+        "no SDK jar should be added when none is detected, got: {jars:?}"
+    );
+}

--- a/src/features/call_arg_diagnostics_tests.rs
+++ b/src/features/call_arg_diagnostics_tests.rs
@@ -857,6 +857,68 @@ fn extension_fn_wrong_arg_count_detected() {
     );
 }
 
+/// Primitive D risk-closure test (member-extension visibility fix's
+/// "shared-predicate blast radius" concern, design doc's own Risks section):
+/// a MEMBER extension function (declared inside an interface, like Compose's
+/// `ColumnScope.weight`) called with the WRONG argument count, from a file
+/// importing nothing from its declaring package.
+///
+/// Traced precisely: `check_call_args` resolves signatures via
+/// `resolve_call_signature` -> `resolve_qualified` (`indexer/infer/sig.rs`),
+/// whose own `collect_params_from_file`/`receiver_matches` closure is an
+/// ENTIRELY SEPARATE predicate from `extension_is_in_scope` (`resolver/infer.rs`)
+/// — it never calls it. `receiver_matches` only accepts a symbol whose
+/// `container` equals the receiver base (an ordinary member) or whose
+/// `container` is `None` and `extension_receiver` equals the receiver base
+/// (an ordinary top-level extension); a member extension's `container` is
+/// `Some(interface name)`, which satisfies neither arm, so `receiver_matches`
+/// rejects it unconditionally. Primitive D's `extension_is_in_scope` fix
+/// therefore cannot widen this diagnostic's arity check for a member
+/// extension in either direction — this path was already, and remains,
+/// blind to member extensions entirely (a separate, pre-existing gap, not
+/// touched by this primitive). The correct, unaffected behavior is: no
+/// diagnostic at all (no false positive from the new visibility rule, and no
+/// false negative introduced or removed by it either).
+#[test]
+fn member_extension_fn_wrong_arg_count_produces_no_call_arg_diagnostic() {
+    let (uri, idx, src) = setup(&[
+        (
+            "/scope.kt",
+            concat!(
+                "package some.pkg\n",
+                "class IMockProvider\n",
+                "interface SomeScope {\n",
+                "    fun IMockProvider.loadJSONFromAssets(path: String, force: Boolean): Any\n",
+                "}\n",
+            ),
+        ),
+        (
+            "/usage.kt",
+            concat!(
+                "package app\n",
+                "class Foo(private val context: IMockProvider) {\n",
+                // Wrong arg count: 0 provided, 2 required by the member extension above.
+                "  val result = context.loadJSONFromAssets()\n",
+                "}\n",
+            ),
+        ),
+    ]);
+    let doc = parse_live(
+        &src,
+        crate::indexer::live_tree::lang_for_path(uri.path()).unwrap(),
+    )
+    .unwrap();
+    let diagnostics = call_arg_diagnostics(&idx, &uri, &doc);
+    assert!(
+        diagnostics.is_empty(),
+        "a member-extension call is invisible to collect_params_from_file's \\
+         receiver_matches (a predicate wholly separate from \\
+         extension_is_in_scope) both before and after Primitive D, so no \\
+         diagnostic should fire regardless of the wrong arg count; got: \\
+         {diagnostics:?}"
+    );
+}
+
 #[test]
 fn extension_fn_cross_file_resolved() {
     // Extension function defined in a DIFFERENT file than the type.

--- a/src/features/nullable_call_diagnostics.rs
+++ b/src/features/nullable_call_diagnostics.rs
@@ -251,30 +251,33 @@ fn pure_field_chain_at(
 }
 
 /// Whether `entry` (a workspace-global extension) is actually visible from the
-/// file at `uri`: declared in the *same file*, or in scope per
-/// `extension_is_in_scope` (same package — including two default-package
-/// files — or covered by an import).
+/// file at `uri`: declared in the *same file*, or — for an ORDINARY top-level
+/// extension only — in scope per `extension_is_in_scope` (same package,
+/// including two default-package files, or covered by an import).
 fn extension_in_scope_here(
     entry: &crate::types::ExtensionEntry,
     uri: &Url,
     caller_file_data: Option<&crate::types::FileData>,
 ) -> bool {
-    // Deliberately does not pass `entry.container` through: this diagnostic
-    // has no evidence a member extension's dispatch receiver (e.g.
-    // `ColumnScope`) is actually active at the call site, so treating every
-    // matching member extension as in scope — as `extension_is_in_scope`
-    // does for goto-def-shaped callers — would let an unrelated `m.weight()`
-    // wrongly emit or suppress a `?.` warning. Falling back to the ordinary
-    // package/import rule (which a Kotlin member extension can only ever
-    // satisfy via same-package, never an import) restores this diagnostic's
-    // pre-existing, more conservative behavior.
+    // A member extension (`entry.container.is_some()`) is excluded from the
+    // package/import check entirely, not just passed `None` for its own
+    // `container` field: this diagnostic has no evidence a member
+    // extension's dispatch receiver (e.g. `ColumnScope`) is actually active
+    // at the call site, so letting the ordinary package-match rule below
+    // independently succeed whenever the caller happens to share the member
+    // extension's package — as it would for a plain `Some(&caller_file_data)`
+    // in the same package — would let an unrelated `m.weight()` wrongly emit
+    // or suppress a `?.` warning just as surely as the member-extension
+    // short-circuit itself would. Only the *declaring file* remains a valid
+    // positive match for a member extension here.
     entry.file_uri == uri.as_str()
-        || crate::resolver::infer::extension_is_in_scope(
-            entry.package.as_ref(),
-            &entry.name,
-            None,
-            caller_file_data,
-        )
+        || (entry.container.is_none()
+            && crate::resolver::infer::extension_is_in_scope(
+                entry.package.as_ref(),
+                &entry.name,
+                None,
+                caller_file_data,
+            ))
 }
 
 /// Whether the symbol declared at `location` is nested inside a container

--- a/src/features/nullable_call_diagnostics.rs
+++ b/src/features/nullable_call_diagnostics.rs
@@ -259,11 +259,20 @@ fn extension_in_scope_here(
     uri: &Url,
     caller_file_data: Option<&crate::types::FileData>,
 ) -> bool {
+    // Deliberately does not pass `entry.container` through: this diagnostic
+    // has no evidence a member extension's dispatch receiver (e.g.
+    // `ColumnScope`) is actually active at the call site, so treating every
+    // matching member extension as in scope — as `extension_is_in_scope`
+    // does for goto-def-shaped callers — would let an unrelated `m.weight()`
+    // wrongly emit or suppress a `?.` warning. Falling back to the ordinary
+    // package/import rule (which a Kotlin member extension can only ever
+    // satisfy via same-package, never an import) restores this diagnostic's
+    // pre-existing, more conservative behavior.
     entry.file_uri == uri.as_str()
         || crate::resolver::infer::extension_is_in_scope(
             entry.package.as_ref(),
             &entry.name,
-            entry.container.as_ref(),
+            None,
             caller_file_data,
         )
 }

--- a/src/features/nullable_call_diagnostics.rs
+++ b/src/features/nullable_call_diagnostics.rs
@@ -276,6 +276,8 @@ fn extension_in_scope_here(
                 entry.package.as_ref(),
                 &entry.name,
                 None,
+                crate::types::Visibility::Public,
+                false,
                 caller_file_data,
             ))
 }

--- a/src/features/nullable_call_diagnostics.rs
+++ b/src/features/nullable_call_diagnostics.rs
@@ -263,6 +263,7 @@ fn extension_in_scope_here(
         || crate::resolver::infer::extension_is_in_scope(
             entry.package.as_ref(),
             &entry.name,
+            entry.container.as_ref(),
             caller_file_data,
         )
 }

--- a/src/features/nullable_call_diagnostics_tests.rs
+++ b/src/features/nullable_call_diagnostics_tests.rs
@@ -171,6 +171,44 @@ fn extension_on_nullable_receiver_is_clean() {
 }
 
 #[test]
+fn member_extension_out_of_scope_does_not_drive_nullable_diagnostic() {
+    // Regression guard for the Compose member-extension short-circuit added to
+    // `extension_is_in_scope`: `weight` is a MEMBER extension of `ColumnScope`
+    // in an unrelated, unimported package, and this caller has no active
+    // `ColumnScope` receiver at all — `m.weight(1f)` is just an unrelated call
+    // on some other type that happens to share the name. Treating the member
+    // extension as unconditionally "in scope" here would wrongly emit a `?.`
+    // warning for a call this diagnostic cannot actually verify.
+    let (uri, idx, src) = setup(&[
+        (
+            "/scope.kt",
+            concat!(
+                "package androidx.compose.foundation.layout\n",
+                "class Modifier\n",
+                "interface ColumnScope {\n",
+                "    fun Modifier.weight(weight: Float): Modifier\n",
+                "}\n",
+            ),
+        ),
+        (
+            "/caller.kt",
+            concat!(
+                "package com.example.app\n",
+                "class Modifier\n",
+                "fun caller(m: Modifier?) {\n",
+                "    m.weight(1f)\n",
+                "}\n",
+            ),
+        ),
+    ]);
+    let diags = run_diagnostics(&idx, &uri, &src);
+    assert!(
+        diags.is_empty(),
+        "an out-of-scope member extension must not drive this diagnostic: {diags:?}"
+    );
+}
+
+#[test]
 fn unresolved_member_on_nullable_receiver_is_skipped() {
     // Neither a member nor a known extension — avoid guessing.
     let (uri, idx, src) = setup(&[(

--- a/src/features/nullable_call_diagnostics_tests.rs
+++ b/src/features/nullable_call_diagnostics_tests.rs
@@ -209,6 +209,43 @@ fn member_extension_out_of_scope_does_not_drive_nullable_diagnostic() {
 }
 
 #[test]
+fn member_extension_in_same_package_does_not_drive_nullable_diagnostic() {
+    // Regression guard for the narrower gap in the fix above: `extension_in_scope_here`
+    // passes `None` instead of `entry.container` to `extension_is_in_scope`, which
+    // blocks the member-extension short-circuit -- but the ordinary package-match
+    // branch underneath can still independently succeed when the caller happens to
+    // share `ColumnScope`'s package, with zero evidence `ColumnScope` is an active
+    // dispatch receiver at this call site. A same-package member extension must be
+    // just as unresolved here as the unimported one above.
+    let (uri, idx, src) = setup(&[
+        (
+            "/scope.kt",
+            concat!(
+                "package androidx.compose.foundation.layout\n",
+                "class Modifier\n",
+                "interface ColumnScope {\n",
+                "    fun Modifier.weight(weight: Float): Modifier\n",
+                "}\n",
+            ),
+        ),
+        (
+            "/caller.kt",
+            concat!(
+                "package androidx.compose.foundation.layout\n",
+                "fun caller(m: Modifier?) {\n",
+                "    m.weight(1f)\n",
+                "}\n",
+            ),
+        ),
+    ]);
+    let diags = run_diagnostics(&idx, &uri, &src);
+    assert!(
+        diags.is_empty(),
+        "a same-package member extension must not drive this diagnostic either: {diags:?}"
+    );
+}
+
+#[test]
 fn unresolved_member_on_nullable_receiver_is_skipped() {
     // Neither a member nor a known extension — avoid guessing.
     let (uri, idx, src) = setup(&[(

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1079,9 +1079,14 @@ impl Indexer {
         let Some(jar_file_data) = self.jar_files.get(loc.uri.as_str()) else {
             return false;
         };
+        // Receiver-less by-name fallback over ALL JAR definitions sharing
+        // `name`, not an `ExtensionEntry`-scoped lookup, so there is no
+        // per-symbol container available here. `None` preserves the existing
+        // package/import check unchanged for this path.
         crate::resolver::infer::extension_is_in_scope(
             jar_file_data.package.as_ref(),
             name,
+            None,
             caller_file_data,
         )
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -428,7 +428,7 @@ impl InferDeps for Indexer {
             // own file is the closest thing to a reachability anchor.
             return Some((type_name, uri.clone()));
         }
-        crate::resolver::infer::find_field_type_in_class(self, class_name, field_name, uri)
+        crate::resolver::Resolver::field_type(self, class_name, field_name, uri)
     }
     fn find_fun_return_type(&self, fn_name: &str, uri: &Url) -> Option<String> {
         crate::resolver::infer::find_fun_return_type_by_name(self, fn_name, uri)

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1082,11 +1082,15 @@ impl Indexer {
         // Receiver-less by-name fallback over ALL JAR definitions sharing
         // `name`, not an `ExtensionEntry`-scoped lookup, so there is no
         // per-symbol container available here. `None` preserves the existing
-        // package/import check unchanged for this path.
+        // package/import check unchanged for this path; the visibility/
+        // same-file arguments are inert whenever `entry_container` is `None`,
+        // since the member-extension branch that reads them never runs.
         crate::resolver::infer::extension_is_in_scope(
             jar_file_data.package.as_ref(),
             name,
             None,
+            crate::types::Visibility::Public,
+            false,
             caller_file_data,
         )
     }

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -221,6 +221,7 @@ pub(crate) fn contributions_from_data(
                 package: file_data.package.clone(),
                 trailing_lambda: sym.trailing_lambda,
                 deprecated: sym.deprecated,
+                container: sym.container.clone(),
             });
     }
 
@@ -440,6 +441,7 @@ impl LibraryBatch {
                     package: file_data.package.clone(),
                     trailing_lambda: sym.trailing_lambda,
                     deprecated: sym.deprecated,
+                    container: sym.container.clone(),
                 });
         }
 

--- a/src/indexer/apply_tests.rs
+++ b/src/indexer/apply_tests.rs
@@ -673,6 +673,7 @@ fn reset_index_state_mixed_extension_receiver_no_deadlock() {
         package: None,
         trailing_lambda: false,
         deprecated: false,
+        container: None,
     };
     // Mixed receiver: reset keeps the library entry and drops the workspace one,
     // forcing the `entries.len() != before` insert branch — the deadlock trigger.

--- a/src/indexer/infer/sig_tests.rs
+++ b/src/indexer/infer/sig_tests.rs
@@ -505,6 +505,7 @@ fn resolve_qualified_jar_extension_overloads_with_source_member() {
             package: Some("com.example".into()),
             trailing_lambda: false,
             deprecated: false,
+            container: None,
         });
 
     let call = CallSite {
@@ -624,6 +625,7 @@ fn resolve_qualified_bails_on_ubiquitous_name_even_with_receiver_extension() {
             package: Some("com.example".into()),
             trailing_lambda: false,
             deprecated: false,
+            container: None,
         });
 
     let call = CallSite {

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -39,6 +39,79 @@ fn gradle_cache_root(gradle_home: Option<&Path>) -> PathBuf {
         .join("files-2.1")
 }
 
+/// Maven `groupId`s that host build-tooling, compiler, or IDE-platform
+/// artifacts exclusively. Gradle's shared module cache holds every artifact
+/// resolved anywhere in the build graph (buildscript classpath, plugin
+/// classpath, lint/KSP tooling classpath), not just application runtime
+/// dependencies, so these end up walked alongside real ones even though
+/// application Kotlin/Java source never legitimately imports from them.
+/// Verified against a real multi-module Android corpus: zero imports from
+/// any package these groups ship.
+const KNOWN_BUILD_TOOLING_GROUP_IDS: &[&str] = &[
+    // Old `org.jetbrains.annotations`-shaded jar pulled in transitively by
+    // IntelliJ-platform tooling; the real `org.jetbrains:annotations`
+    // dependency covers any legitimate `@NotNull`/`@Nullable` usage.
+    "com.intellij",
+    // Android Gradle Plugin's embedded IntelliJ platform and Kotlin compiler,
+    // used internally by AGP's lint/desugaring passes. `intellij-core` here
+    // is a confirmed decoy source for both `Activity` and `CoroutineScope`.
+    "com.android.tools.external.com-intellij",
+    "com.android.tools.external.org-jetbrains",
+    // AGP/Lint's own layout-rendering, static-analysis, device-bridge,
+    // test-platform, telemetry, and Jetifier implementation packages.
+    "com.android.tools.layoutlib",
+    "com.android.tools.lint",
+    "com.android.tools.ddms",
+    "com.android.tools.utp",
+    "com.android.tools.analytics-library",
+    "com.android.tools.build.jetifier",
+    // Deprecated pre-AndroidX Data Binding compiler internals; app runtime
+    // uses `androidx.databinding` instead.
+    "com.android.databinding",
+    // IntelliJ platform's own collections library (`gnu.trove`).
+    "org.jetbrains.intellij.deps",
+];
+
+/// Specific `groupId`/`artifactId` pairs to exclude from groups that also
+/// host genuine runtime or build-logic dependencies, so the whole group
+/// cannot be dropped. `kotlin-compiler-embeddable` and
+/// `symbol-processing-aa-embeddable` are confirmed decoy sources for
+/// `Activity` (both ship a shaded `com.intellij.diagnostic.Activity`); the
+/// rest are confirmed-unused siblings from the same compiler/AGP-internals
+/// families.
+const KNOWN_BUILD_TOOLING_ARTIFACTS: &[(&str, &str)] = &[
+    ("org.jetbrains.kotlin", "kotlin-compiler-embeddable"),
+    ("org.jetbrains.kotlin", "kotlin-daemon-embeddable"),
+    (
+        "org.jetbrains.kotlin",
+        "kotlin-scripting-compiler-embeddable",
+    ),
+    (
+        "org.jetbrains.kotlin",
+        "kotlin-scripting-compiler-impl-embeddable",
+    ),
+    ("com.google.devtools.ksp", "symbol-processing-aa-embeddable"),
+    ("com.android.tools.build", "bundletool"),
+    ("com.android.tools.build", "aapt2-proto"),
+    ("com.android.tools.build", "aaptcompiler"),
+    ("com.android.tools.build", "apksig"),
+    ("com.android.tools.build", "apkzlib"),
+    ("com.android.tools.build", "builder"),
+    ("com.android.tools.build", "builder-model"),
+    ("com.android.tools.build", "builder-test-api"),
+    ("com.android.tools.build", "manifest-merger"),
+];
+
+/// True when a Gradle-cache JAR belongs to a known build-tooling/compiler/
+/// IDE-platform artifact rather than an application dependency — see
+/// [`KNOWN_BUILD_TOOLING_GROUP_IDS`] and [`KNOWN_BUILD_TOOLING_ARTIFACTS`].
+fn is_known_build_tooling_jar(meta: &crate::cli::extract_sources::GradleMeta) -> bool {
+    KNOWN_BUILD_TOOLING_GROUP_IDS.contains(&meta.group.as_str())
+        || KNOWN_BUILD_TOOLING_ARTIFACTS
+            .iter()
+            .any(|(group, artifact)| *group == meta.group && *artifact == meta.artifact)
+}
+
 /// Walk the Gradle module cache and collect all JAR/AAR paths, separated by
 /// kind.  Deduplication: for each `(group, artifact)` pair keep only the
 /// highest-version directory.
@@ -71,6 +144,9 @@ pub(crate) fn scan_gradle_jars_split(
         let Some(meta) = parse_jar_meta(&jar) else {
             continue;
         };
+        if is_known_build_tooling_jar(&meta) {
+            continue;
+        }
         let vk = version_key(&meta.version);
         let key = (meta.group, meta.artifact);
         let is_sources = jar

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -59,8 +59,12 @@ const KNOWN_BUILD_TOOLING_GROUP_IDS: &[&str] = &[
     "com.android.tools.external.org-jetbrains",
     // AGP/Lint's own layout-rendering, static-analysis, device-bridge,
     // test-platform, telemetry, and Jetifier implementation packages.
+    // NOTE: `com.android.tools.lint` is deliberately NOT listed here — see
+    // `KNOWN_BUILD_TOOLING_ARTIFACTS` below, which excludes only that
+    // group's genuinely tooling-only artifacts. `lint-api` and `lint-tests`
+    // are real compile-time (respectively test-compile-time) dependencies
+    // for any project that writes custom Android Lint rules.
     "com.android.tools.layoutlib",
-    "com.android.tools.lint",
     "com.android.tools.ddms",
     "com.android.tools.utp",
     "com.android.tools.analytics-library",
@@ -100,6 +104,18 @@ const KNOWN_BUILD_TOOLING_ARTIFACTS: &[(&str, &str)] = &[
     ("com.android.tools.build", "builder-model"),
     ("com.android.tools.build", "builder-test-api"),
     ("com.android.tools.build", "manifest-merger"),
+    // `com.android.tools.lint` group: only the genuinely tooling-only
+    // artifacts, verified against a real Gradle cache. `lint` is the
+    // standalone CLI (bundles UAST + the Gradle-plugin integration);
+    // `lint-checks` is AOSP's own bundled built-in check implementations;
+    // `lint-model`/`lint-typedef-remover` are internal AGP/Lint data models.
+    // `lint-api` (the custom-Detector API) and `lint-tests` (the
+    // `testImplementation` harness for custom-check unit tests) are left
+    // out — both are real, documented compile-time dependencies.
+    ("com.android.tools.lint", "lint"),
+    ("com.android.tools.lint", "lint-checks"),
+    ("com.android.tools.lint", "lint-model"),
+    ("com.android.tools.lint", "lint-typedef-remover"),
 ];
 
 /// True when a Gradle-cache JAR belongs to a known build-tooling/compiler/

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -775,7 +775,17 @@ pub(crate) fn populate_from_symbols(
     if sidecar_symbols.is_empty() {
         return 0;
     }
-    let fake_uri = match Url::parse(&format!("jar:file://{}", path.display())) {
+    // Build via `Url::from_file_path` (not `path.display()` interpolation) so
+    // spaces and other reserved characters are percent-escaped — the same
+    // pattern `jar_extract.rs` uses. A raw space (e.g. Windows' default
+    // `C:\Program Files\Android\Sdk\...`) makes the resulting `Location.uri`
+    // invalid per RFC 3986 and breaks go-to-definition/hover for every
+    // symbol from that JAR.
+    let Ok(file_url) = Url::from_file_path(path) else {
+        log::warn!("jar: cannot build file:// URL for {}", path.display());
+        return 0;
+    };
+    let fake_uri = match Url::parse(&format!("jar:{file_url}")) {
         Ok(u) => u,
         Err(e) => {
             log::warn!("jar: cannot build URI for {}: {e}", path.display());

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -796,12 +796,17 @@ pub(crate) fn populate_from_symbols(
     // pattern `jar_extract.rs` uses. A raw space (e.g. Windows' default
     // `C:\Program Files\Android\Sdk\...`) makes the resulting `Location.uri`
     // invalid per RFC 3986 and breaks go-to-definition/hover for every
-    // symbol from that JAR.
-    let Ok(file_url) = Url::from_file_path(path) else {
-        log::warn!("jar: cannot build file:// URL for {}", path.display());
-        return 0;
+    // symbol from that JAR. `Url::from_file_path` requires `path` to be
+    // absolute per the CURRENT OS's own convention, which real production
+    // paths (always sourced from this OS's own filesystem) satisfy; fall
+    // back to the previous naive construction for the rare case where it
+    // doesn't (e.g. a caller-supplied path with a foreign-OS shape) rather
+    // than dropping the JAR's symbols entirely.
+    let fake_uri_string = match Url::from_file_path(path) {
+        Ok(file_url) => format!("jar:{file_url}"),
+        Err(()) => format!("jar:file://{}", path.display()),
     };
-    let fake_uri = match Url::parse(&format!("jar:{file_url}")) {
+    let fake_uri = match Url::parse(&fake_uri_string) {
         Ok(u) => u,
         Err(e) => {
             log::warn!("jar: cannot build URI for {}: {e}", path.display());

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -916,7 +916,16 @@ fn build_jar_file_data(
             range: synthetic_range,
             selection_range: synthetic_range,
             detail: sym.detail.clone(),
-            container: if sym.container.is_empty() {
+            // `sym.container` is the enclosing JVM class, not the enclosing
+            // Kotlin declaration — a top-level Kotlin function still compiles
+            // into a synthetic `FileNameKt` class, so `sym.container` is
+            // non-empty for it too. `sym.top_level` is what actually
+            // distinguishes "real member" from "top-level with an
+            // implementation-detail wrapper class" (same condition the `fqn`
+            // computation below already uses for the identical question);
+            // without it every compiled-JAR top-level extension would be
+            // mistaken for a member extension of its own synthetic file class.
+            container: if sym.top_level || sym.container.is_empty() {
                 None
             } else {
                 Some(sym.container.clone())

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -1104,6 +1104,7 @@ fn build_jar_file_data(
                 package: symbol_package,
                 trailing_lambda: sym.trailing_lambda,
                 deprecated: sym.deprecated,
+                container: sym.container.clone(),
             });
     }
 

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -36,7 +36,11 @@ use crate::sidecar::SidecarSymbol;
 ///            inside a multi-line annotation no longer hide the declaration (`@Composable`).
 /// v12 → v13: sidecar now emits each class's direct super types (`supers`), populating
 ///            jar `FileData.supers` so inheritance can be walked through library types.
-const JAR_CACHE_VERSION: u32 = 13;
+/// v13 → v14: sidecar's `JavaClassVisitor` now emits public field symbols (`val`/`var`)
+///            in addition to classes/methods — a cache built before this shipped has no
+///            field entries at all, and the JAR's own (mtime, size) fingerprint never
+///            changes to reveal that, so the version must be bumped to force a rescan.
+const JAR_CACHE_VERSION: u32 = 14;
 
 #[derive(Serialize, Deserialize)]
 struct JarCache {
@@ -349,6 +353,28 @@ pub(crate) fn forget_cache_file_fingerprint_for_test() {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .retain(|(known, _)| known != &path);
+}
+
+/// Test-only: write a JAR-symbol cache file stamped with an arbitrary
+/// `version`, at the path that version's `cache_path()` would resolve to —
+/// simulating a cache an older kmp-lsp build left on disk before a schema
+/// change bumped `JAR_CACHE_VERSION`. Lets tests prove such a file is
+/// ignored (not just that a *current-version* file with a wrong `version`
+/// field would be, which the filename-embedded scheme makes unreachable in
+/// practice, but is still worth pinning as the mechanism's second line of
+/// defense).
+#[cfg(test)]
+pub(crate) fn write_versioned_cache_for_test(
+    version: u32,
+    entries: &HashMap<String, JarCacheEntry>,
+) {
+    let path = super::cache::xdg_cache_base()
+        .join("kmp-lsp")
+        .join(format!("jar-symbols-v{version}.bin"));
+    std::fs::create_dir_all(path.parent().expect("cache path has a parent")).unwrap();
+    let cache = JarCacheRef { version, entries };
+    let bytes = bincode::serialize(&cache).expect("serialize stale cache for test");
+    std::fs::write(&path, bytes).expect("write stale cache for test");
 }
 
 /// Check whether the cache entry for `jar` is still valid.

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -371,10 +371,16 @@ pub(crate) fn write_versioned_cache_for_test(
     let path = super::cache::xdg_cache_base()
         .join("kmp-lsp")
         .join(format!("jar-symbols-v{version}.bin"));
-    std::fs::create_dir_all(path.parent().expect("cache path has a parent")).unwrap();
+    let parent = path
+        .parent()
+        .unwrap_or_else(|| panic!("cache path {} has a parent", path.display()));
+    std::fs::create_dir_all(parent)
+        .unwrap_or_else(|e| panic!("create stale cache dir {}: {e}", parent.display()));
     let cache = JarCacheRef { version, entries };
-    let bytes = bincode::serialize(&cache).expect("serialize stale cache for test");
-    std::fs::write(&path, bytes).expect("write stale cache for test");
+    let bytes = bincode::serialize(&cache)
+        .unwrap_or_else(|e| panic!("serialize stale cache for test: {e}"));
+    std::fs::write(&path, bytes)
+        .unwrap_or_else(|e| panic!("write stale cache for test to {}: {e}", path.display()));
 }
 
 /// Check whether the cache entry for `jar` is still valid.

--- a/src/indexer/jar_manifest_cache.rs
+++ b/src/indexer/jar_manifest_cache.rs
@@ -24,8 +24,13 @@ use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
-/// Bump when `JarManifestEntry`/`JarManifestName` schema changes.
-const JAR_MANIFEST_CACHE_VERSION: u32 = 2;
+/// Bump when `JarManifestEntry`/`JarManifestName` schema changes, or when
+/// the sidecar's extraction logic changes what the manifest SHOULD contain
+/// for an unchanged JAR (the JAR's own (mtime, size) fingerprint can't
+/// detect that on its own).
+/// v2 → v3: sidecar's `JavaClassVisitor` now emits public field symbols
+///          (`val`/`var`) in addition to classes/methods.
+const JAR_MANIFEST_CACHE_VERSION: u32 = 3;
 
 #[derive(Serialize, Deserialize)]
 struct JarManifestCache {
@@ -81,6 +86,26 @@ fn cache_path() -> std::path::PathBuf {
 #[cfg(test)]
 pub(crate) fn manifest_cache_path_for_test() -> std::path::PathBuf {
     cache_path()
+}
+
+/// Test-only: write a JAR manifest cache file stamped with an arbitrary
+/// `version`, at the path that version's `cache_path()` would resolve to —
+/// simulating a manifest cache an older kmp-lsp build left on disk before a
+/// schema change bumped `JAR_MANIFEST_CACHE_VERSION`.
+#[cfg(test)]
+pub(crate) fn write_versioned_manifest_cache_for_test(
+    version: u32,
+    entries: &HashMap<String, JarManifestEntry>,
+) {
+    let path = super::cache::xdg_cache_base()
+        .join("kmp-lsp")
+        .join(format!("jar-manifest-v{version}.bin"));
+    std::fs::create_dir_all(path.parent().expect("cache path has a parent")).unwrap();
+    let cache = JarManifestCacheRef { version, entries };
+    let bytes = bincode::serialize(&cache).expect("serialize stale manifest cache for test");
+    let compressed =
+        zstd::encode_all(bytes.as_slice(), 3).expect("zstd-encode stale cache for test");
+    std::fs::write(&path, compressed).expect("write stale manifest cache for test");
 }
 
 /// Load the global JAR manifest cache. Returns an empty map on any error

--- a/src/indexer/jar_manifest_cache.rs
+++ b/src/indexer/jar_manifest_cache.rs
@@ -100,12 +100,22 @@ pub(crate) fn write_versioned_manifest_cache_for_test(
     let path = super::cache::xdg_cache_base()
         .join("kmp-lsp")
         .join(format!("jar-manifest-v{version}.bin"));
-    std::fs::create_dir_all(path.parent().expect("cache path has a parent")).unwrap();
+    let parent = path
+        .parent()
+        .unwrap_or_else(|| panic!("cache path {} has a parent", path.display()));
+    std::fs::create_dir_all(parent)
+        .unwrap_or_else(|e| panic!("create stale manifest cache dir {}: {e}", parent.display()));
     let cache = JarManifestCacheRef { version, entries };
-    let bytes = bincode::serialize(&cache).expect("serialize stale manifest cache for test");
-    let compressed =
-        zstd::encode_all(bytes.as_slice(), 3).expect("zstd-encode stale cache for test");
-    std::fs::write(&path, compressed).expect("write stale manifest cache for test");
+    let bytes = bincode::serialize(&cache)
+        .unwrap_or_else(|e| panic!("serialize stale manifest cache for test: {e}"));
+    let compressed = zstd::encode_all(bytes.as_slice(), 3)
+        .unwrap_or_else(|e| panic!("zstd-encode stale manifest cache for test: {e}"));
+    std::fs::write(&path, compressed).unwrap_or_else(|e| {
+        panic!(
+            "write stale manifest cache for test to {}: {e}",
+            path.display()
+        )
+    });
 }
 
 /// Load the global JAR manifest cache. Returns an empty map on any error

--- a/src/indexer/jar_manifest_cache_tests.rs
+++ b/src/indexer/jar_manifest_cache_tests.rs
@@ -71,6 +71,48 @@ fn jar_manifest_cache_missing_file_returns_empty_map() {
 }
 
 #[test]
+fn jar_manifest_cache_ignores_a_stale_pre_field_extraction_version() {
+    // Pins the fix for the cache-invalidation gap in the Android-SDK-jar PR:
+    // adding field-symbol extraction changed what a fully-materialized JAR's
+    // data SHOULD contain, but neither the JAR's own (mtime, size)
+    // fingerprint nor a bumped version constant would otherwise notice — a
+    // user upgrading kmp-lsp would silently keep serving pre-upgrade,
+    // field-less cached data forever. `2` is deliberately hardcoded (not
+    // `JAR_MANIFEST_CACHE_VERSION - 1`): it is the exact version number this
+    // manifest cache shipped with immediately before the fix, i.e. what a
+    // real user's on-disk cache is actually stamped with today. If the
+    // version constant were still 2, this stale file would sit at the exact
+    // path the loader reads and would be served as valid.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    with_xdg_cache(tmp.path(), || {
+        let mut stale_entries: HashMap<String, JarManifestEntry> = HashMap::new();
+        stale_entries.insert(
+            "/gradle/caches/android.jar".to_owned(),
+            JarManifestEntry {
+                mtime_secs: 1_700_000_000,
+                mtime_nanos: 0,
+                file_size: 999,
+                names: vec![JarManifestName {
+                    name: "View".to_owned(),
+                    kind: "class".to_owned(),
+                    container: None,
+                    package: Some("android.view".to_owned()),
+                    extension_receiver: None,
+                }],
+            },
+        );
+        super::jar_manifest_cache::write_versioned_manifest_cache_for_test(2, &stale_entries);
+
+        let loaded = load_jar_manifest_cache();
+        assert!(
+            loaded.is_empty(),
+            "a manifest cache written by the pre-field-extraction version must be ignored, \
+             not served stale — the version constant must have been bumped past 2"
+        );
+    });
+}
+
+#[test]
 fn jar_manifest_cache_corrupt_file_returns_empty_map() {
     let tmp = tempfile::tempdir().expect("tempdir");
     with_xdg_cache(tmp.path(), || {

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -100,6 +100,57 @@ fn jar_symbol_resolves_via_lookup() {
     assert_eq!(job_locs.len(), 1, "Job should be found");
 }
 
+/// A JAR path containing a space (e.g. Windows' default
+/// `C:\Program Files\Android\Sdk\...`) must produce a well-formed URI: the
+/// fake `jar:file://` URI has to percent-escape the space via
+/// `Url::from_file_path` (the pattern the rest of this codebase already
+/// uses — see `jar_extract.rs`), not interpolate `path.display()` raw. A raw
+/// space makes the resulting `Location.uri` invalid per RFC 3986, breaking
+/// go-to-definition/hover for every symbol from a JAR under a spaced path —
+/// the overwhelming majority of real Windows Android SDK installs (default
+/// `C:\Program Files\Android\Sdk`).
+#[test]
+fn jar_path_with_space_still_materializes() {
+    let indexer = idx();
+    let tmp = tempfile::tempdir().unwrap();
+    let jar_dir = tmp.path().join("Program Files").join("Android").join("Sdk");
+    std::fs::create_dir_all(&jar_dir).unwrap();
+    let jar_path = jar_dir.join("android.jar");
+
+    let symbols = vec![make_sidecar_symbol(
+        "View",
+        "class",
+        "class android.view.View",
+        "",
+    )];
+
+    let count = populate_from_symbols(&indexer, &jar_path, &symbols);
+    assert_eq!(
+        count, 1,
+        "space in the JAR path must not silently drop all symbols"
+    );
+
+    let view_locs = indexer.lookup_definitions("View");
+    assert_eq!(
+        view_locs.len(),
+        1,
+        "View should be found despite the space in its JAR path"
+    );
+    let uri_str = view_locs[0].uri.as_str();
+    assert!(
+        uri_str.starts_with("jar:file://"),
+        "View location should be a JAR URI, got {uri_str}"
+    );
+    assert!(
+        !uri_str.contains(' '),
+        "the space in the JAR path must be percent-escaped, not embedded raw: {uri_str}"
+    );
+    assert!(
+        uri_str.contains("%20"),
+        "expected the space to round-trip as %20 like Url::from_file_path produces: {uri_str}"
+    );
+}
+
 /// The crawl guarantees "sources-JAR data wins over compiled-JAR synthetic
 /// data in `qualified`" by ORDER (compiled first, sources last — see the
 /// crawl comment in scan_handler.rs). On-demand materialization runs

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -2780,3 +2780,33 @@ fn lookup_definitions_promotes_a_tier1_only_cache_backed_name() {
         );
     });
 }
+
+/// Regression guard: `Url::from_file_path` requires a path that is
+/// "absolute" per the CURRENT OS's own convention (e.g. a Unix-style
+/// `/home/...` string is not absolute on Windows — it has no drive letter).
+/// Many existing fixtures in this file use such OS-agnostic-looking strings
+/// purely as opaque map keys (the JAR never actually needs to exist on
+/// disk), which broke on Windows CI once `populate_from_symbols` started
+/// requiring `Url::from_file_path` to succeed for the (real) space-escaping
+/// fix. `populate_from_symbols` must fall back to the previous naive URI
+/// construction rather than dropping the JAR's symbols entirely — real
+/// production paths always come from this OS's own filesystem and never
+/// hit the fallback branch.
+#[test]
+fn populate_from_symbols_falls_back_for_a_non_absolute_path() {
+    let indexer = idx();
+    // Not absolute on ANY OS — deterministically exercises the fallback
+    // branch everywhere, unlike a Unix-style string (only non-absolute on
+    // Windows) or Windows-style string (only non-absolute on Unix).
+    let jar_path = "relative/path/to/some.jar";
+    let symbols = vec![make_sidecar_symbol("Probe", "class", "class Probe", "")];
+
+    let count = populate_from_symbols(&indexer, jar_path.as_ref(), &symbols);
+
+    assert_eq!(
+        count, 1,
+        "a non-absolute path must fall back to indexing the JAR's symbols, not drop them"
+    );
+    let probe_locs = indexer.lookup_definitions("Probe");
+    assert_eq!(probe_locs.len(), 1, "Probe should still be found");
+}

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -2185,6 +2185,45 @@ fn save_jar_cache_skips_the_reload_when_the_file_is_unchanged() {
     });
 }
 
+#[test]
+fn jar_cache_ignores_a_stale_pre_field_extraction_version() {
+    // Sibling of `jar_manifest_cache_ignores_a_stale_pre_field_extraction_version`:
+    // pins the same fix for the FULL JAR-symbol cache. `13` is deliberately
+    // hardcoded (not `JAR_CACHE_VERSION - 1`) — it is the exact version this
+    // cache shipped with immediately before field-symbol extraction was
+    // added, i.e. what a real user's on-disk `jar-symbols-v13.bin` is
+    // actually stamped with today. If the constant were still 13, this
+    // stale, field-less cache entry would sit at the loader's own path and
+    // be served as fresh — the JAR's own (mtime, size) fingerprint alone
+    // never changes when the sidecar's extraction logic changes.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    crate::indexer::test_helpers::with_xdg_cache(tmp.path(), || {
+        let mut stale_entries = std::collections::HashMap::new();
+        stale_entries.insert(
+            "/gradle/caches/android.jar".to_owned(),
+            crate::indexer::jar_cache::JarCacheEntry {
+                mtime_secs: 1_700_000_000,
+                mtime_nanos: 0,
+                file_size: 999,
+                symbols: vec![make_sidecar_symbol(
+                    "Activity",
+                    "class",
+                    "class android.app.Activity",
+                    "",
+                )],
+            },
+        );
+        crate::indexer::jar_cache::write_versioned_cache_for_test(13, &stale_entries);
+
+        let loaded = crate::indexer::jar_cache::load_jar_cache();
+        assert!(
+            loaded.is_empty(),
+            "a JAR-symbol cache written by the pre-field-extraction version must be ignored, \
+             not served stale — the version constant must have been bumped past 13"
+        );
+    });
+}
+
 /// Build a one-entry cache map backed by a real file under `dir`, for the
 /// save-throttle tests below.
 fn one_entry_cache_map(

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -151,6 +151,50 @@ fn jar_path_with_space_still_materializes() {
     );
 }
 
+/// A top-level Kotlin extension function still compiles to a synthetic
+/// `PaddingKt`-style JVM wrapper class, so the sidecar reports a non-empty
+/// `container` for it even though it is not a real Kotlin member.
+/// `SymbolEntry.container` must stay `None` for it (matching
+/// `SidecarSymbol::top_level`), or every compiled-JAR top-level extension
+/// gets mistaken for a member extension of its own wrapper class.
+#[test]
+fn populate_from_symbols_treats_top_level_synthetic_container_as_no_container() {
+    let indexer = idx();
+    let padding = crate::sidecar::SidecarSymbol {
+        name: "padding".to_owned(),
+        kind: "fun".to_owned(),
+        container: "PaddingKt".to_owned(),
+        detail: "fun Modifier.padding(all: Dp): Modifier".to_owned(),
+        doc: String::new(),
+        type_params: Vec::new(),
+        extension_receiver_type: "Modifier".to_owned(),
+        trailing_lambda: false,
+        deprecated: false,
+        pkg: "lib".to_owned(),
+        top_level: true,
+        supers: vec![],
+    };
+    populate_from_symbols(
+        &indexer,
+        "/home/test/.gradle/caches/compose-foundation-1.0.jar".as_ref(),
+        &[padding],
+    );
+
+    let entries = indexer
+        .extension_by_receiver
+        .get("Modifier")
+        .expect("padding must be indexed as an extension of Modifier");
+    let entry = entries
+        .iter()
+        .find(|e| e.name == "padding")
+        .expect("padding entry must exist");
+    assert_eq!(
+        entry.container, None,
+        "a top-level extension's synthetic JVM wrapper class must not be \
+         mistaken for a real Kotlin member container"
+    );
+}
+
 /// The crawl guarantees "sources-JAR data wins over compiled-JAR synthetic
 /// data in `qualified`" by ORDER (compiled first, sources last — see the
 /// crawl comment in scan_handler.rs). On-demand materialization runs

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -815,6 +815,68 @@ fn scan_gradle_jars_split_excludes_known_build_tooling_jars() {
 }
 
 #[test]
+fn scan_gradle_jars_split_keeps_lint_api_but_excludes_lint_tooling() {
+    // `com.android.tools.lint` was excluded as a whole group, but `lint-api`
+    // (com.android.tools.lint.detector.api.Detector/Issue/...) is a genuine
+    // compile-time dependency for any project that writes custom Android
+    // Lint rules, and `lint-tests` (`checks.infrastructure.TestLintTask`)
+    // is the standard `testImplementation` harness for testing them —
+    // unlike `lint-checks` (AOSP's own bundled built-in check
+    // implementations), which really is tooling-only. Mirrors the
+    // artifact-scoped precedent `kotlin-compiler-embeddable` already sets:
+    // narrow the exclusion within the group instead of dropping it whole.
+    // All three artifact names are real, verified against a live Gradle
+    // cache (`com.android.tools.lint:{lint-api,lint-tests,lint-checks}`).
+    let tmpdir = tempfile::tempdir().unwrap();
+    write_compiled_jar(
+        tmpdir.path(),
+        "com.android.tools.lint",
+        "lint-api",
+        "31.0.0",
+        &[("com/android/tools/lint/detector/api/Detector.class", "stub")],
+    );
+    write_compiled_jar(
+        tmpdir.path(),
+        "com.android.tools.lint",
+        "lint-tests",
+        "31.0.0",
+        &[(
+            "com/android/tools/lint/checks/infrastructure/TestLintTask.class",
+            "stub",
+        )],
+    );
+    write_compiled_jar(
+        tmpdir.path(),
+        "com.android.tools.lint",
+        "lint-checks",
+        "31.0.0",
+        &[("com/android/tools/lint/checks/ApiDetector.class", "stub")],
+    );
+
+    let (compiled, _) = crate::indexer::jar::scan_gradle_jars_split(Some(tmpdir.path()));
+
+    let survivors: Vec<String> = compiled
+        .iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        survivors.iter().any(|path| path.contains("lint-api")),
+        "lint-api is a real compile-time dependency for custom Lint rule authors \
+         and must survive the scan, got: {survivors:?}"
+    );
+    assert!(
+        survivors.iter().any(|path| path.contains("lint-tests")),
+        "lint-tests is the real testImplementation harness for custom Lint rule tests \
+         and must survive the scan, got: {survivors:?}"
+    );
+    assert!(
+        !survivors.iter().any(|path| path.contains("lint-checks")),
+        "lint-checks (AOSP's own bundled built-in check implementations) is \
+         tooling-only and must still be excluded, got: {survivors:?}"
+    );
+}
+
+#[test]
 fn index_sources_jars_end_to_end_with_real_jar() {
     // End-to-end smoke: walk the real Gradle cache + extract + parse + insert.
     // One small JAR, one .kt file.  Exercises the slow I/O path that

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -654,6 +654,115 @@ fn scan_gradle_jars_split_dedups_to_latest_version() {
     );
 }
 
+/// Create a compiled (non-sources) JAR on disk in the standard Gradle cache
+/// layout, mirroring [`write_sources_jar`] but without the `-sources` suffix
+/// so it lands in `scan_gradle_jars_split`'s compiled-JAR result instead of
+/// its sources-JAR result.
+fn write_compiled_jar(
+    gradle_home: &std::path::Path,
+    group: &str,
+    artifact: &str,
+    version: &str,
+    entries: &[(&str, &str)],
+) -> std::path::PathBuf {
+    let jar_dir = gradle_home
+        .join("caches")
+        .join("modules-2")
+        .join("files-2.1")
+        .join(group)
+        .join(artifact)
+        .join(version)
+        .join("abc123");
+    std::fs::create_dir_all(&jar_dir).unwrap();
+
+    let jar_path = jar_dir.join(format!("{artifact}-{version}.jar"));
+    let file = std::fs::File::create(&jar_path).unwrap();
+    let mut writer = zip::ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+    for (path, content) in entries {
+        writer.start_file_from_path(*path, options).unwrap();
+        writer.write_all(content.as_bytes()).unwrap();
+    }
+    writer.finish().unwrap();
+    jar_path
+}
+
+#[test]
+fn scan_gradle_jars_split_excludes_known_build_tooling_jars() {
+    // A synthetic Gradle-cache-shaped tempdir holding: a real runtime jar, a
+    // build-tooling jar excluded by groupId (`com.intellij`), a build-tooling
+    // jar excluded by a specific groupId/artifactId pair
+    // (`org.jetbrains.kotlin:kotlin-compiler-embeddable`), and a REAL runtime
+    // jar from that same groupId (`kotlin-stdlib`) to prove the filter is
+    // artifact-scoped rather than dropping the whole group.
+    let tmpdir = tempfile::tempdir().unwrap();
+    write_compiled_jar(
+        tmpdir.path(),
+        "androidx.core",
+        "core-ktx",
+        "1.13.0",
+        &[("androidx/core/content/ContextCompat.class", "stub")],
+    );
+    write_compiled_jar(
+        tmpdir.path(),
+        "com.intellij",
+        "annotations",
+        "12.0",
+        &[("org/jetbrains/annotations/NotNull.class", "stub")],
+    );
+    write_compiled_jar(
+        tmpdir.path(),
+        "org.jetbrains.kotlin",
+        "kotlin-compiler-embeddable",
+        "2.2.21",
+        &[(
+            "org/jetbrains/kotlin/com/intellij/diagnostic/Activity.class",
+            "stub",
+        )],
+    );
+    write_compiled_jar(
+        tmpdir.path(),
+        "org.jetbrains.kotlin",
+        "kotlin-stdlib",
+        "2.2.21",
+        &[("kotlin/collections/CollectionsKt.class", "stub")],
+    );
+
+    let (compiled, _) = crate::indexer::jar::scan_gradle_jars_split(Some(tmpdir.path()));
+
+    let survivors: Vec<String> = compiled
+        .iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        survivors.iter().any(|path| path.contains("core-ktx")),
+        "real runtime jar core-ktx must survive the scan, got: {survivors:?}"
+    );
+    assert!(
+        survivors.iter().any(|path| path.contains("kotlin-stdlib")),
+        "real runtime jar kotlin-stdlib must survive the scan even though its \
+         groupId also hosts an excluded artifact, got: {survivors:?}"
+    );
+    assert!(
+        !survivors
+            .iter()
+            .any(|path| path.contains("com.intellij") || path.contains("annotations-12.0")),
+        "com.intellij:annotations is a known build-tooling groupId and must be excluded, got: {survivors:?}"
+    );
+    assert!(
+        !survivors
+            .iter()
+            .any(|path| path.contains("kotlin-compiler-embeddable")),
+        "kotlin-compiler-embeddable is a known build-tooling artifact and must be excluded, got: {survivors:?}"
+    );
+    assert_eq!(
+        survivors.len(),
+        2,
+        "expected exactly the two real runtime jars to survive, got: {survivors:?}"
+    );
+}
+
 #[test]
 fn index_sources_jars_end_to_end_with_real_jar() {
     // End-to-end smoke: walk the real Gradle cache + extract + parse + insert.

--- a/src/inlay_hints_tests.rs
+++ b/src/inlay_hints_tests.rs
@@ -252,6 +252,62 @@ fun make() {
     );
 }
 
+/// CST-domain regression for `Resolver::field_type`'s supertype walk
+/// (`src/resolver/infer.rs`): `uiState` is declared only on the generic
+/// superclass `MviViewModel<S, E>`, not on `ContactAddressViewModel` itself.
+/// This never touches `chain.rs`/`expr_type.rs` directly -- it proves the fix
+/// landed once in `resolver/` reaches inlay hints automatically through the
+/// `InferDeps` seam (`Indexer::find_field_type` -> `Resolver::field_type`),
+/// exactly the "fixed once, propagates automatically" point of routing
+/// through the trait instead of patching each CST consumer separately.
+///
+/// The base and derived classes live in separate files deliberately: in one
+/// file, `find_field_type_in_class`'s own-body check would accidentally
+/// "find" the base's `uiState` by whole-file line-proximity (see
+/// `infer_field_type_raw`'s `near_line` doc comment) and return the raw,
+/// unsubstituted `S` -- a separate, pre-existing quirk this test avoids
+/// conflating with the supertype-walk substitution under test here.
+#[test]
+fn untyped_val_navigation_through_inherited_generic_field_gets_hint() {
+    let base_uri = uri("/MviViewModel.kt");
+    let idx = Arc::new(Indexer::new());
+    idx.index_content(
+        &base_uri,
+        "package test\n\
+         abstract class MviViewModel<S, E> {\n\
+         \x20   val uiState: S = TODO()\n\
+         \x20   val effect: E = TODO()\n\
+         }\n",
+    );
+
+    let derived_uri = uri("/ContactAddressViewModel.kt");
+    let derived_src = "package test\n\
+         class ContactState\n\
+         class ContactEffect\n\
+         class ContactAddressViewModel : MviViewModel<ContactState, ContactEffect>()\n\
+         fun make(viewModel: ContactAddressViewModel) {\n\
+         \x20   val state = viewModel.uiState\n\
+         }\n";
+    idx.index_content(&derived_uri, derived_src);
+
+    let lines = derived_src.lines().count() as u32;
+    let hints = compute_inlay_hints(
+        &idx,
+        &derived_uri,
+        Range {
+            start: Position::new(0, 0),
+            end: Position::new(lines, 0),
+        },
+    );
+    assert!(
+        hints
+            .iter()
+            .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": ContactState")),
+        "expected ': ContactState' hint for a val initialized from a field \
+         declared only on the generic superclass, got: {hints:?}",
+    );
+}
+
 #[test]
 fn untyped_val_unindexed_di_factory_call_gets_hint() {
     // `val repo = get<UserRepository>()` where `get` is a Koin-style DI factory

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -372,9 +372,19 @@ fn push_def_symbols(
         if kind != SymbolKind::NULL {
             let visibility = vis_fn(lines, sel.start.line as usize);
             let detail = extract_detail(lines, range.start.line, range.end.line);
+            // `SymbolKind::METHOD` covers a member function (nested inside a
+            // class/interface/object body), including a MEMBER EXTENSION
+            // function such as `interface ColumnScope { fun Modifier.weight(...) }`
+            // — its `function_declaration` CST node carries a `receiver_type`
+            // child exactly like a top-level extension `fun`'s does, so it must
+            // not be excluded here just because nesting demoted its `kind` from
+            // `FUNCTION` to `METHOD` (see `queries.rs`'s pattern 9 vs 10).
             let (extension_receiver, extension_receiver_type) = if matches!(
                 kind,
-                SymbolKind::FUNCTION | SymbolKind::PROPERTY | SymbolKind::VARIABLE
+                SymbolKind::FUNCTION
+                    | SymbolKind::METHOD
+                    | SymbolKind::PROPERTY
+                    | SymbolKind::VARIABLE
             ) {
                 extract_extension_receiver_from_cst(root, bytes, &range)
             } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -402,7 +402,11 @@ fn push_def_symbols(
             } else {
                 (String::new(), (0, 0))
             };
-            let trailing_lambda = matches!(kind, SymbolKind::FUNCTION)
+            // `METHOD` covers a member extension (see the comment above on
+            // `extension_receiver`'s own kind match) — without it here, a
+            // `ColumnScope`-style member extension's trailing-lambda call
+            // form would never be offered in completion.
+            let trailing_lambda = matches!(kind, SymbolKind::FUNCTION | SymbolKind::METHOD)
                 && last_value_param_is_function_type(root, bytes, &range);
             let deprecated = deprecated_at_line(lines, sel.start.line as usize);
             symbols.push(SymbolEntry {

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -1451,6 +1451,28 @@ fn extension_receiver_indexed_in_symbol_entry() {
 }
 
 #[test]
+fn member_extension_with_trailing_lambda_param_sets_trailing_lambda_flag() {
+    // Regression guard: a member extension (nested inside an interface, so
+    // its `kind` is `METHOD` rather than top-level `FUNCTION`) must still be
+    // recognized as trailing-lambda-callable when its last parameter is a
+    // function type — otherwise completion never offers the `weight { }`
+    // trailing-lambda call form for a Compose `ColumnScope`-shaped member
+    // extension.
+    let src = "interface ColumnScope {\n    fun Modifier.weight(fill: () -> Unit)\n}";
+    let data = super::parse_kotlin(src);
+    let sym = data
+        .symbols
+        .iter()
+        .find(|s| s.name == "weight")
+        .expect("weight should be indexed");
+    assert_eq!(sym.kind, SymbolKind::METHOD);
+    assert!(
+        sym.trailing_lambda,
+        "member extension with a trailing function-type parameter must set trailing_lambda"
+    );
+}
+
+#[test]
 fn non_extension_fun_has_empty_receiver() {
     let src = "fun greet(name: String): String = \"Hello $name\"";
     let data = super::parse_kotlin(src);

--- a/src/resolver/api.rs
+++ b/src/resolver/api.rs
@@ -28,7 +28,8 @@ use tower_lsp::lsp_types::{Location, Url};
 use crate::indexer::Indexer;
 
 use super::infer::{
-    find_fun_return_type_by_name, find_fun_return_type_reachable, find_method_return_type,
+    find_field_type_in_class, find_field_type_via_supertypes, find_fun_return_type_by_name,
+    find_fun_return_type_reachable, find_method_return_type,
     find_method_return_type_via_supertypes, infer_field_chain_type, infer_receiver_type,
 };
 use super::ReceiverTypeAgreement;
@@ -165,6 +166,26 @@ pub(crate) trait Resolver {
         from_uri: Option<&Url>,
     ) -> Option<ReturnType>;
 
+    /// Resolve the declared type of `field_name` on a receiver whose type's
+    /// base name is `type_name`, together with the `Url` of the file where
+    /// that field is actually declared (the reachability anchor for the
+    /// *next* hop in a dotted chain — see `find_field_type_in_class`'s own
+    /// doc comment for why this differs from `method_return_type`, which
+    /// does not yet carry one).
+    ///
+    /// The single composite for field resolution: checks `type_name`'s own
+    /// body first, then walks its declared supertypes (with type-argument
+    /// substitution) — the field-typed sibling of `method_return_type`.
+    ///
+    /// Returns `None` when no field (own or inherited) with a declared type
+    /// is found.
+    fn field_type(
+        &self,
+        type_name: &str,
+        field_name: &str,
+        from_uri: &Url,
+    ) -> Option<(String, Url)>;
+
     /// Does `candidate_type`'s receiver relate to `target_type` — exact
     /// match, a proven supertype/subtype relationship (in either direction a
     /// caller separately checks), a proven exclusion, or "the index can't
@@ -234,5 +255,15 @@ impl Resolver for Indexer {
             target_type,
             sidecar_budget,
         )
+    }
+
+    fn field_type(
+        &self,
+        type_name: &str,
+        field_name: &str,
+        from_uri: &Url,
+    ) -> Option<(String, Url)> {
+        find_field_type_in_class(self, type_name, field_name, from_uri)
+            .or_else(|| find_field_type_via_supertypes(self, type_name, field_name, from_uri))
     }
 }

--- a/src/resolver/api.rs
+++ b/src/resolver/api.rs
@@ -158,7 +158,7 @@ pub(crate) trait Resolver {
     /// context.
     ///
     /// Returns `None` when no matching method (own, extension, or inherited) with
-    /// a declared return type is found.
+    /// a resolvable return type — declared or inferred — is found.
     fn method_return_type(
         &self,
         type_name: &str,
@@ -166,7 +166,8 @@ pub(crate) trait Resolver {
         from_uri: Option<&Url>,
     ) -> Option<ReturnType>;
 
-    /// Resolve the declared type of `field_name` on a receiver whose type's
+    /// Resolve `field_name`'s type (declared, or inferred from its
+    /// initializer for an unannotated `val`/`var`) on a receiver whose type's
     /// base name is `type_name`, together with the `Url` of the file where
     /// that field is actually declared (the reachability anchor for the
     /// *next* hop in a dotted chain — see `find_field_type_in_class`'s own
@@ -177,8 +178,8 @@ pub(crate) trait Resolver {
     /// body first, then walks its declared supertypes (with type-argument
     /// substitution) — the field-typed sibling of `method_return_type`.
     ///
-    /// Returns `None` when no field (own or inherited) with a declared type
-    /// is found.
+    /// Returns `None` when no field (own or inherited) with a resolvable
+    /// type is found.
     fn field_type(
         &self,
         type_name: &str,

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -395,6 +395,15 @@ impl<'a> ExtensionCompletionBuilder<'a> {
     }
 
     fn add_entry(&mut self, entry: &crate::types::ExtensionEntry, is_library: bool) {
+        // A member extension (`container: Some(_)`) has no import syntax in
+        // Kotlin at all, and this builder has no evidence its declaring
+        // container is actually an active receiver at the completion site —
+        // offering it here would be a completion outside its real scope,
+        // paired with an auto-import `build_item_from_entry` would compute
+        // for a package.name Kotlin cannot use for an interface member.
+        if entry.container.is_some() {
+            return;
+        }
         let is_same_file = entry.file_uri == self.context.from_uri;
         // Inaccessible from this file: private/protected from another file always;
         // `internal` when the symbol comes from a library (an external module's
@@ -2026,6 +2035,14 @@ impl<'a> BareCompletionWalk<'a> {
             };
             for entry in entries.iter() {
                 if crate::Language::from_path(&entry.file_uri) != crate::Language::Kotlin {
+                    continue;
+                }
+                // Same exclusion as `ExtensionCompletionBuilder::add_entry`:
+                // a member extension's declaring container being one of this
+                // call's ancestors doesn't prove the container is the actual
+                // implicit receiver here, and `build_item_from_entry` would
+                // still compute an auto-import Kotlin has no syntax for.
+                if entry.container.is_some() {
                     continue;
                 }
                 let is_same_file = entry.file_uri == ext_context.from_uri;

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -1176,6 +1176,30 @@ fn find_field_type_in_class_impl(
     None
 }
 
+/// Candidates for a supertype walk's starting class: reachability-scoped
+/// first (`from_uri`'s own imports/package), falling back to an unscoped
+/// workspace search and finally `lookup_definitions` (the only one of the
+/// three that promotes a not-yet-materialized JAR) when nothing reachable is
+/// found. Shared by [`find_field_type_via_supertypes`] and
+/// [`find_method_return_type_via_supertypes`] so neither anchors its walk on
+/// an unrelated same-named class elsewhere in the workspace.
+fn reachable_class_candidates(
+    indexer: &Indexer,
+    class_base: &str,
+    from_uri: Option<&Url>,
+) -> Vec<Location> {
+    let mut candidates = from_uri
+        .map(|uri| super::resolve::resolve_type_index_only(indexer, class_base, uri))
+        .unwrap_or_default();
+    if candidates.is_empty() {
+        candidates = indexer.workspace_def_candidates(class_base);
+    }
+    if candidates.is_empty() {
+        candidates = indexer.lookup_definitions(class_base);
+    }
+    candidates
+}
+
 /// Resolve `field_name`'s declared type by walking `class_name`'s ancestors —
 /// the field-typed sibling of [`find_method_return_type_via_supertypes`].
 /// [`find_field_type_in_class`] only reads `class_name`'s own body, so a
@@ -1213,13 +1237,11 @@ fn find_field_type_via_supertypes_impl(
     if depth == 0 {
         return None;
     }
-    // Strip generics AND any qualifying package prefix, matching
-    // `find_method_return_type_via_supertypes`: `lookup_definitions` is keyed
-    // by the bare symbol name.
+    // Strip generics AND any qualifying package prefix — `class_base` is
+    // matched against bare symbol names below.
     let class_base = class_name.dotted_ident_prefix().last_segment().to_owned();
 
-    indexer
-        .lookup_definitions(&class_base)
+    reachable_class_candidates(indexer, &class_base, Some(from_uri))
         .into_iter()
         .take(crate::indexer::MAX_BY_NAME_DEFS)
         .find_map(|location| {
@@ -1863,17 +1885,11 @@ pub(crate) fn find_method_return_type_via_supertypes(
     method_name: &str,
     from_uri: Option<&Url>,
 ) -> Option<String> {
-    // Strip generics AND any qualifying package prefix: `lookup_definitions`
-    // is keyed by the bare symbol name, so a qualified `class_name` (e.g.
-    // `com.lib.MutableSharedFlow<Event>`) would otherwise silently miss it.
+    // Strip generics AND any qualifying package prefix — `class_base` is
+    // matched against bare symbol names below.
     let class_base = class_name.dotted_ident_prefix().last_segment().to_owned();
 
-    // `lookup_definitions` merges workspace + JAR locations (promoting a
-    // not-yet-materialized JAR as needed) into an owned `Vec<Location>` --
-    // the walk below promotes further JARs per-ancestor, and an owned Vec
-    // (unlike a DashMap `Ref`) can't deadlock against that.
-    indexer
-        .lookup_definitions(&class_base)
+    reachable_class_candidates(indexer, &class_base, from_uri)
         .into_iter()
         .take(crate::indexer::MAX_BY_NAME_DEFS)
         .find_map(|loc| {

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -1563,9 +1563,15 @@ fn candidate_declaration_is_reachable(
     let Some(candidate_file_data) = indexer.files.get(loc.uri.as_str()) else {
         return false;
     };
+    // This is a receiver-less by-name fallback over ALL workspace definitions
+    // sharing `fn_name`, not an `ExtensionEntry`-scoped lookup, so there is no
+    // per-symbol container available here to distinguish a member extension
+    // from an ordinary member/top-level function. Passing `None` preserves
+    // the existing package/import check unchanged for this path.
     extension_is_in_scope(
         candidate_file_data.package.as_ref(),
         fn_name,
+        None,
         caller_file_data,
     )
 }
@@ -1719,12 +1725,28 @@ pub(crate) fn find_method_return_type(
 
 /// Returns true when an extension function declared in `entry_package` is
 /// accessible from the calling file, either via same-package visibility or
-/// an explicit import in `caller_file_data`.
+/// an explicit import in `caller_file_data`. `entry_container` distinguishes
+/// a MEMBER extension function (`Some("ColumnScope")`, declared inside a
+/// class/interface body) from an ordinary top-level one (`None`).
 pub(crate) fn extension_is_in_scope(
     entry_package: Option<&String>,
     entry_name: &str,
+    entry_container: Option<&String>,
     caller_file_data: Option<&FileData>,
 ) -> bool {
+    // A member extension function has no import syntax in Kotlin at all — its
+    // visibility is governed by whether its declaring container is an
+    // implicit or explicit receiver in scope, never by package/import
+    // coverage. This codebase does not track live implicit-receiver scope in
+    // the string domain (that lives in the CST domain's `ThisLambdaCtx`,
+    // deliberately not consulted here), so a member extension is treated as
+    // in scope whenever a receiver-type-matching candidate exists at all:
+    // the existing `entry.name == name` / `receiver_base` match upstream in
+    // `resolve_extension_in_scope` already filters for that; this rule only
+    // removes the wrong import-based rejection layered on top of it.
+    if entry_container.is_some() {
+        return true;
+    }
     // Kotlin's default package (no `package` header) is a real package like
     // any other, so two default-package files are same-package to each
     // other -- but only once the caller's `FileData` is actually known.
@@ -1815,7 +1837,12 @@ fn find_extension_fn_return_type_scoped(
         if !matches!(entry.kind, SymbolKind::FUNCTION) {
             continue;
         }
-        if !extension_is_in_scope(entry.package.as_ref(), &entry.name, caller_file_data_ref) {
+        if !extension_is_in_scope(
+            entry.package.as_ref(),
+            &entry.name,
+            entry.container.as_ref(),
+            caller_file_data_ref,
+        ) {
             continue;
         }
         // Try detail first; fall back to source lines when detail is truncated.

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -1773,20 +1773,20 @@ pub(crate) fn extension_is_in_scope(
     })
 }
 
-/// Whether `SymbolEntry` `s` is the actual declaration a matched extension
+/// Whether `SymbolEntry` `symbol` is the actual declaration a matched extension
 /// candidate (`name` on `receiver_base`, with `entry_container` from its
 /// `ExtensionEntry`) refers to. Its own `container` must equal
 /// `entry_container` exactly, so a member extension's declaration lookup is
 /// not rejected by a check written only for top-level extensions.
 pub(crate) fn extension_declaration_matches(
-    s: &crate::types::SymbolEntry,
+    symbol: &crate::types::SymbolEntry,
     name: &str,
     receiver_base: &str,
     entry_container: Option<&String>,
 ) -> bool {
-    s.name == name
-        && s.extension_receiver() == receiver_base
-        && s.container.as_deref() == entry_container.map(String::as_str)
+    symbol.name == name
+        && symbol.extension_receiver() == receiver_base
+        && symbol.container.as_deref() == entry_container.map(String::as_str)
 }
 
 /// Find the return type of an extension function `method_name` declared with receiver

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -218,7 +218,7 @@ pub(crate) fn infer_field_chain_type(
             .unwrap_or(&current)
             .strip_nullable();
         let (field_raw, declaring_uri) =
-            find_field_type_in_class(indexer, class_base, field, &reachability_uri)?;
+            super::Resolver::field_type(indexer, class_base, field, &reachability_uri)?;
         current = field_raw.clone();
         leaf_raw = field_raw;
         reachability_uri = declaring_uri;
@@ -1174,6 +1174,108 @@ fn find_field_type_in_class_impl(
         }
     }
     None
+}
+
+/// Resolve `field_name`'s declared type by walking `class_name`'s ancestors —
+/// the field-typed sibling of [`find_method_return_type_via_supertypes`].
+/// [`find_field_type_in_class`] only reads `class_name`'s own body, so a
+/// field declared only on a generic superclass (`viewModel.uiState` where
+/// `uiState` lives on `MviViewModel<State, Effect>`, not the specific
+/// subclass) never resolves through it alone.
+pub(crate) fn find_field_type_via_supertypes(
+    indexer: &Indexer,
+    class_name: &str,
+    field_name: &str,
+    from_uri: &Url,
+) -> Option<(String, Url)> {
+    find_field_type_via_supertypes_impl(
+        indexer,
+        class_name,
+        field_name,
+        from_uri,
+        MAX_RAW_TYPE_INFER_DEPTH,
+    )
+}
+
+/// Depth-guarded implementation of [`find_field_type_via_supertypes`] —
+/// shares [`find_field_type_in_class_impl`]'s recursion budget rather than
+/// starting a fresh one: an ancestor's own field lookup can fall back to
+/// variable-type inference, which can re-enter field-type lookup for yet
+/// another receiver (see `MAX_RAW_TYPE_INFER_DEPTH`), so this walk is a
+/// participant in that cycle, not a separately-bounded recursion of its own.
+fn find_field_type_via_supertypes_impl(
+    indexer: &Indexer,
+    class_name: &str,
+    field_name: &str,
+    from_uri: &Url,
+    depth: u8,
+) -> Option<(String, Url)> {
+    if depth == 0 {
+        return None;
+    }
+    // Strip generics AND any qualifying package prefix, matching
+    // `find_method_return_type_via_supertypes`: `lookup_definitions` is keyed
+    // by the bare symbol name.
+    let class_base = class_name.dotted_ident_prefix().last_segment().to_owned();
+
+    indexer
+        .lookup_definitions(&class_base)
+        .into_iter()
+        .take(crate::indexer::MAX_BY_NAME_DEFS)
+        .find_map(|location| {
+            find_field_type_via_class_hierarchy(
+                indexer,
+                &class_base,
+                location.uri.as_str(),
+                field_name,
+                from_uri,
+                depth,
+            )
+        })
+}
+
+/// Walk every ancestor of `class_base` (declared at `class_uri`) via
+/// [`walk_hierarchy`] looking for `field_name`'s declared type — mirrors
+/// [`find_method_return_type_via_class_hierarchy`]'s structure exactly.
+/// The direct supertype's own generic type arguments are substituted into a
+/// hit found there via `substitute_direct_supertype_args`; a hit on a deeper
+/// ancestor is returned as-is (same documented limitation the method version
+/// already accepts).
+fn find_field_type_via_class_hierarchy(
+    indexer: &Indexer,
+    class_base: &str,
+    class_uri: &str,
+    field_name: &str,
+    from_uri: &Url,
+    depth: u8,
+) -> Option<(String, Url)> {
+    use crate::types::CallerContext;
+
+    let caller = CallerContext {
+        uri: Some(from_uri.as_str()),
+        cursor_line: None,
+    };
+    let hits: Vec<(String, String, Url)> = walk_hierarchy(
+        indexer,
+        class_base,
+        class_uri,
+        caller,
+        8,
+        MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
+        |idx, super_name, super_uri, _caller| {
+            let Ok(super_url) = Url::parse(super_uri) else {
+                return Vec::new();
+            };
+            find_field_type_in_class_impl(idx, super_name, field_name, &super_url, depth - 1)
+                .map(|(raw, declaring_uri)| (super_name.to_owned(), raw, declaring_uri))
+                .into_iter()
+                .collect()
+        },
+    );
+    let (super_name, raw, declaring_uri) = hits.into_iter().next()?;
+    let substituted =
+        substitute_direct_supertype_args(indexer, class_uri, class_base, &super_name, &raw);
+    Some((substituted, declaring_uri))
 }
 
 // ─── Extension property type inference ───────────────────────────────────────

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -1773,6 +1773,22 @@ pub(crate) fn extension_is_in_scope(
     })
 }
 
+/// Whether `SymbolEntry` `s` is the actual declaration a matched extension
+/// candidate (`name` on `receiver_base`, with `entry_container` from its
+/// `ExtensionEntry`) refers to. Its own `container` must equal
+/// `entry_container` exactly, so a member extension's declaration lookup is
+/// not rejected by a check written only for top-level extensions.
+pub(crate) fn extension_declaration_matches(
+    s: &crate::types::SymbolEntry,
+    name: &str,
+    receiver_base: &str,
+    entry_container: Option<&String>,
+) -> bool {
+    s.name == name
+        && s.extension_receiver() == receiver_base
+        && s.container.as_deref() == entry_container.map(String::as_str)
+}
+
 /// Find the return type of an extension function `method_name` declared with receiver
 /// `ReceiverType` where `ReceiverType`'s base name == `receiver_base`.
 ///
@@ -1834,7 +1850,11 @@ fn find_extension_fn_return_type_scoped(
         if entry.name != method_name {
             continue;
         }
-        if !matches!(entry.kind, SymbolKind::FUNCTION) {
+        // `METHOD` covers a member extension (see `push_def_symbols`'s own
+        // comment in `parser.rs`) — a plain `FUNCTION`-only filter silently
+        // skips every Compose-style `interface ColumnScope { fun
+        // Modifier.weight(...) }` return-type lookup.
+        if !matches!(entry.kind, SymbolKind::FUNCTION | SymbolKind::METHOD) {
             continue;
         }
         if !extension_is_in_scope(
@@ -1862,9 +1882,12 @@ fn find_extension_fn_return_type_scoped(
             .symbols
             .iter()
             .find(|s| {
-                s.name == method_name
-                    && s.extension_receiver() == receiver_base
-                    && s.container.is_none()
+                extension_declaration_matches(
+                    s,
+                    method_name,
+                    receiver_base,
+                    entry.container.as_ref(),
+                )
             })?
             .selection_start() as usize;
         let full_sig = file_data.lines.collect_signature(start_line);
@@ -1887,7 +1910,8 @@ fn find_extension_fn_return_type_global(
             if symbol.name != method_name {
                 continue;
             }
-            if !matches!(symbol.kind, SymbolKind::FUNCTION) {
+            // `METHOD` covers a member extension, same as the scoped lookup above.
+            if !matches!(symbol.kind, SymbolKind::FUNCTION | SymbolKind::METHOD) {
                 continue;
             }
             if symbol.extension_receiver() != receiver_base {

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -1567,11 +1567,15 @@ fn candidate_declaration_is_reachable(
     // sharing `fn_name`, not an `ExtensionEntry`-scoped lookup, so there is no
     // per-symbol container available here to distinguish a member extension
     // from an ordinary member/top-level function. Passing `None` preserves
-    // the existing package/import check unchanged for this path.
+    // the existing package/import check unchanged for this path; the
+    // visibility/same-file arguments are inert whenever `entry_container` is
+    // `None`, since the member-extension branch that reads them never runs.
     extension_is_in_scope(
         candidate_file_data.package.as_ref(),
         fn_name,
         None,
+        crate::types::Visibility::Public,
+        false,
         caller_file_data,
     )
 }
@@ -1727,11 +1731,16 @@ pub(crate) fn find_method_return_type(
 /// accessible from the calling file, either via same-package visibility or
 /// an explicit import in `caller_file_data`. `entry_container` distinguishes
 /// a MEMBER extension function (`Some("ColumnScope")`, declared inside a
-/// class/interface body) from an ordinary top-level one (`None`).
+/// class/interface body) from an ordinary top-level one (`None`); when it is
+/// `Some`, `entry_visibility` and `is_same_file` gate `private`/`protected`
+/// member extensions, which — unlike the package/import checks below — are
+/// otherwise skipped entirely for a member extension (see the branch itself).
 pub(crate) fn extension_is_in_scope(
     entry_package: Option<&String>,
     entry_name: &str,
     entry_container: Option<&String>,
+    entry_visibility: crate::types::Visibility,
+    is_same_file: bool,
     caller_file_data: Option<&FileData>,
 ) -> bool {
     // A member extension function has no import syntax in Kotlin at all — its
@@ -1744,7 +1753,21 @@ pub(crate) fn extension_is_in_scope(
     // the existing `entry.name == name` / `receiver_base` match upstream in
     // `resolve_extension_in_scope` already filters for that; this rule only
     // removes the wrong import-based rejection layered on top of it.
+    //
+    // That trade-off is about *dispatch-receiver* proof, not access control —
+    // `private`/`protected` are a separate axis this short-circuit must still
+    // respect. Mirrors the same-file exception `ExtensionCompletionBuilder::add_entry`
+    // (`resolver/complete.rs`) already uses for ordinary top-level extensions,
+    // since neither call site tracks the declaring type's own body scope.
     if entry_container.is_some() {
+        if !is_same_file
+            && matches!(
+                entry_visibility,
+                crate::types::Visibility::Private | crate::types::Visibility::Protected
+            )
+        {
+            return false;
+        }
         return true;
     }
     // Kotlin's default package (no `package` header) is a real package like
@@ -1861,6 +1884,8 @@ fn find_extension_fn_return_type_scoped(
             entry.package.as_ref(),
             &entry.name,
             entry.container.as_ref(),
+            entry.visibility,
+            entry.file_uri == from_uri.as_str(),
             caller_file_data_ref,
         ) {
             continue;

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -1606,6 +1606,59 @@ fn catalog_field_type_supertype_walk_ignores_unrelated_same_named_sibling_field(
     );
 }
 
+/// Two unrelated classes both named `Derived` exist in the workspace; only
+/// one is reachable from the caller's own import. The supertype walk's own
+/// starting-class lookup must stay reachability-scoped like
+/// `find_field_type_in_class`'s already is, not fall back to an unscoped
+/// by-name pick that could land on the wrong `Derived` and its wrong
+/// ancestor (Copilot review, PR #281).
+#[test]
+fn catalog_field_type_supertype_walk_stays_reachability_scoped_on_a_colliding_class_name() {
+    use crate::indexer::Indexer;
+    use crate::resolver::Resolver;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    // Indexed first, so an unscoped by-name lookup would find it first.
+    idx.index_content(
+        &Url::parse("file:///com/wrong/Derived.kt").unwrap(),
+        "package com.wrong\n\
+         abstract class WrongBase {\n\
+         \x20   val value: WrongType = TODO()\n\
+         }\n\
+         class WrongType\n\
+         class Derived : WrongBase()\n",
+    );
+    idx.index_content(
+        &Url::parse("file:///com/right/RightBase.kt").unwrap(),
+        "package com.right\n\
+         abstract class RightBase {\n\
+         \x20   val value: RightType = TODO()\n\
+         }\n\
+         class RightType\n",
+    );
+    let right_derived = Url::parse("file:///com/right/Derived.kt").unwrap();
+    idx.index_content(
+        &right_derived,
+        "package com.right\nclass Derived : RightBase()\n",
+    );
+    let caller = Url::parse("file:///com/caller/Caller.kt").unwrap();
+    idx.index_content(
+        &caller,
+        "package com.caller\nimport com.right.Derived\nfun use(d: Derived) { d.value }\n",
+    );
+
+    let (field_type, declaring_uri) = idx
+        .field_type("Derived", "value", &caller)
+        .expect("value must resolve via the reachable Derived's own supertype");
+    assert_eq!(
+        field_type, "RightType",
+        "must walk the reachable com.right.Derived's own supertype \
+         (RightBase), not the unrelated com.wrong.Derived indexed first"
+    );
+    assert_eq!(declaring_uri.as_str(), "file:///com/right/RightBase.kt");
+}
+
 /// Regression, exercised through the *supertype-walk* path specifically:
 /// mirrors `find_field_type_in_class_terminates_on_a_mutual_field_reference_cycle`,
 /// but the queried class doesn't declare the field itself -- it inherits it

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -875,7 +875,14 @@ fn extension_is_in_scope_treats_default_package_as_same_package() {
     };
 
     assert!(
-        extension_is_in_scope(None, "helper", None, Some(&caller_file_data)),
+        extension_is_in_scope(
+            None,
+            "helper",
+            None,
+            crate::types::Visibility::Public,
+            false,
+            Some(&caller_file_data),
+        ),
         "two default-package files (no `package` header on either side) must \
          be considered same-package, not unreachable"
     );
@@ -890,7 +897,14 @@ fn extension_is_in_scope_does_not_treat_unknown_caller_as_default_package() {
     use super::extension_is_in_scope;
 
     assert!(
-        !extension_is_in_scope(None, "helper", None, None),
+        !extension_is_in_scope(
+            None,
+            "helper",
+            None,
+            crate::types::Visibility::Public,
+            false,
+            None,
+        ),
         "an unloaded/unknown caller file must not be guessed as \"confirmed \
          default package\" just because its package is also unrepresentable \
          as `Some`"

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -835,7 +835,7 @@ fn extension_is_in_scope_treats_default_package_as_same_package() {
     };
 
     assert!(
-        extension_is_in_scope(None, "helper", Some(&caller_file_data)),
+        extension_is_in_scope(None, "helper", None, Some(&caller_file_data)),
         "two default-package files (no `package` header on either side) must \
          be considered same-package, not unreachable"
     );
@@ -850,7 +850,7 @@ fn extension_is_in_scope_does_not_treat_unknown_caller_as_default_package() {
     use super::extension_is_in_scope;
 
     assert!(
-        !extension_is_in_scope(None, "helper", None),
+        !extension_is_in_scope(None, "helper", None, None),
         "an unloaded/unknown caller file must not be guessed as \"confirmed \
          default package\" just because its package is also unrepresentable \
          as `Some`"
@@ -1044,6 +1044,7 @@ fn catalog_method_return_type_folds_jar_supertype_inheritance() {
             package: Some("kotlinx.coroutines.flow".to_owned()),
             trailing_lambda: false,
             deprecated: false,
+            container: None,
         });
 
     let caller = Url::parse("file:///app/Repo.kt").unwrap();

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -1469,3 +1469,180 @@ fn receiver_based_resolution_also_substitutes_call_site_type_argument() {
          real receiver type is star-projected Flow<*>)"
     );
 }
+
+/// Confirms the gap `Resolver::field_type` exists to close:
+/// `find_field_type_in_class` only reads a class's own body, so a field
+/// declared only on a generic superclass (`viewModel.uiState` where
+/// `uiState` lives on `MviViewModel<S, E>`, not the specific subclass) is
+/// invisible to it — the scout report's `ContactAddressViewModel` evidence.
+///
+/// The base class and its subclass live in separate files (the realistic
+/// MVI shape, and how the GREEN/decoy siblings below are also built): were
+/// they in one file, `find_field_type_in_class`'s own-body check would
+/// accidentally "find" the base's `uiState` by whole-file line-proximity
+/// (see `infer_field_type_raw`'s `near_line` doc comment) despite it not
+/// being scoped to the queried class's container at all -- a separate,
+/// pre-existing quirk this test deliberately avoids conflating with the
+/// actual supertype-walk gap under test here.
+#[test]
+fn find_field_type_in_class_alone_misses_a_generic_superclass_field() {
+    use super::find_field_type_in_class;
+    use crate::indexer::Indexer;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    let base = Url::parse("file:///app/MviViewModel.kt").unwrap();
+    idx.index_content(
+        &base,
+        "package app\n\
+         abstract class MviViewModel<S, E> {\n\
+         \x20   val uiState: S = TODO()\n\
+         \x20   val effect: E = TODO()\n\
+         }\n",
+    );
+    let derived = Url::parse("file:///app/ContactAddressViewModel.kt").unwrap();
+    idx.index_content(
+        &derived,
+        "package app\n\
+         class ContactState\n\
+         class ContactEffect\n\
+         class ContactAddressViewModel : MviViewModel<ContactState, ContactEffect>()\n",
+    );
+
+    assert_eq!(
+        find_field_type_in_class(&idx, "ContactAddressViewModel", "uiState", &derived),
+        None,
+        "find_field_type_in_class must NOT find a field declared only on a \
+         superclass -- that is exactly the gap the supertype walk closes"
+    );
+}
+
+/// GREEN: `Resolver::field_type` folds the supertype walk in, so `uiState`
+/// (declared only on `MviViewModel<S, E>`) resolves for the derived class,
+/// substituting the direct supertype's own concrete type arguments
+/// (`ContactState`/`ContactEffect`) into the raw declared type `S`.
+#[test]
+fn catalog_field_type_folds_supertype_inheritance_with_generic_substitution() {
+    use crate::indexer::Indexer;
+    use crate::resolver::Resolver;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    let base = Url::parse("file:///app/MviViewModel.kt").unwrap();
+    idx.index_content(
+        &base,
+        "package app\n\
+         abstract class MviViewModel<S, E> {\n\
+         \x20   val uiState: S = TODO()\n\
+         \x20   val effect: E = TODO()\n\
+         }\n",
+    );
+    let derived = Url::parse("file:///app/ContactAddressViewModel.kt").unwrap();
+    idx.index_content(
+        &derived,
+        "package app\n\
+         class ContactState\n\
+         class ContactEffect\n\
+         class ContactAddressViewModel : MviViewModel<ContactState, ContactEffect>()\n",
+    );
+
+    let (field_type, _declaring_uri) = idx
+        .field_type("ContactAddressViewModel", "uiState", &derived)
+        .expect("uiState must resolve via the supertype walk");
+    assert_eq!(
+        field_type, "ContactState",
+        "the direct supertype's own generic argument (ContactState for S) \
+         must be substituted into the raw declared type"
+    );
+}
+
+/// Decoy: an unrelated sibling class reachable from the same file as the
+/// real ancestor also declares a field named `uiState`, with a different
+/// type, but is itself NOT anywhere in `ContactAddressViewModel`'s
+/// hierarchy. `find_field_type_via_supertypes` resolves each ancestor by
+/// walking real CST-recorded `supers` edges (`walk_hierarchy`) and looks up
+/// `uiState` scoped to that specific resolved ancestor class -- not an
+/// unscoped by-name scan across the file -- so the decoy's field must never
+/// surface, matching the discipline `find_name_scoped_to_container`'s
+/// existence elsewhere in this codebase already enforces for other lookups.
+#[test]
+fn catalog_field_type_supertype_walk_ignores_unrelated_same_named_sibling_field() {
+    use crate::indexer::Indexer;
+    use crate::resolver::Resolver;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    let base = Url::parse("file:///app/MviViewModel.kt").unwrap();
+    idx.index_content(
+        &base,
+        "package app\n\
+         // Unrelated: not a supertype of ContactAddressViewModel, but shares\n\
+         // the field name `uiState` with an incompatible type -- declared\n\
+         // well before the real ancestor so a proximity-based scan (rather\n\
+         // than genuine container scoping) could not accidentally pass.\n\
+         class UnrelatedSettingsHolder {\n\
+         \x20   val uiState: Boolean = TODO()\n\
+         }\n\
+         abstract class MviViewModel<S, E> {\n\
+         \x20   val uiState: S = TODO()\n\
+         }\n",
+    );
+    let derived = Url::parse("file:///app/ContactAddressViewModel.kt").unwrap();
+    idx.index_content(
+        &derived,
+        "package app\n\
+         class ContactState\n\
+         class ContactAddressViewModel : MviViewModel<ContactState, Unit>()\n",
+    );
+
+    let (field_type, _declaring_uri) = idx
+        .field_type("ContactAddressViewModel", "uiState", &derived)
+        .expect("uiState must resolve via the real supertype walk");
+    assert_eq!(
+        field_type, "ContactState",
+        "the real ancestor's uiState (substituted to ContactState) must win \
+         -- the unrelated sibling's same-named Boolean field must never be \
+         picked up by the supertype walk"
+    );
+}
+
+/// Regression, exercised through the *supertype-walk* path specifically:
+/// mirrors `find_field_type_in_class_terminates_on_a_mutual_field_reference_cycle`,
+/// but the queried class doesn't declare the field itself -- it inherits it
+/// from a superclass whose own inference re-enters the same
+/// field/variable-type mutual-recursion cycle PR #278 bounded
+/// (`find_field_type_in_class_impl` <-> `infer_variable_type_raw_impl`).
+/// `find_field_type_via_supertypes` must thread the *same* shared depth
+/// budget through, not add its own separate unguarded recursion, or this
+/// reopens the exact stack overflow that fix closed.
+#[test]
+fn find_field_type_via_supertypes_terminates_on_a_mutual_field_reference_cycle() {
+    use crate::indexer::Indexer;
+    use crate::resolver::Resolver;
+    use tower_lsp::lsp_types::Url;
+
+    fn uri(p: &str) -> Url {
+        Url::parse(&format!("file://{p}")).unwrap()
+    }
+
+    let idx = Indexer::new();
+    idx.index_content(
+        &uri("/A.kt"),
+        "package com.example\n\
+         open class A(val b: B) {\n\
+         \x20   val value = b.value\n\
+         }\n\
+         class DerivedA : A(TODO())\n",
+    );
+    idx.index_content(
+        &uri("/B.kt"),
+        "package com.example\nclass B(val a: A) {\n    val value = a.value\n}\n",
+    );
+
+    // Past the depth cap the walk bails at whatever partial (possibly
+    // approximate) answer it has -- no specific value is asserted, only that
+    // this call, reached via the supertype-walk fallback (DerivedA declares
+    // no `value` field itself), returns at all instead of overflowing the
+    // stack.
+    let _ = idx.field_type("DerivedA", "value", &uri("/A.kt"));
+}

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -669,6 +669,46 @@ fn extension_property_type_promotes_a_cache_backed_tier1_only_receiver() {
     });
 }
 
+/// Regression guard: `find_extension_fn_return_type_scoped` filtered
+/// `ExtensionEntry` candidates to `SymbolKind::FUNCTION`, so a member
+/// extension (indexed as `METHOD` because it is nested inside an interface)
+/// was skipped entirely. The signature is made long enough that its `detail`
+/// is truncated past the return type (`MAX_DETAIL_CHARS`), forcing the
+/// source-signature fallback — which itself required `container.is_none()`
+/// and so, even after widening the kind filter, would still fail to find a
+/// member extension's own declaration.
+#[test]
+fn extension_fn_return_type_scoped_resolves_member_extension_via_truncated_detail() {
+    use super::find_extension_fn_return_type;
+    use crate::indexer::Indexer;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    let scope_uri = Url::parse("file:///sdk/ColumnScope.kt").unwrap();
+    let long_param = "w".repeat(150);
+    idx.index_content(
+        &scope_uri,
+        &format!(
+            "package androidx.compose.foundation.layout\n\
+             class Modifier\n\
+             interface ColumnScope {{\n\
+             \x20   fun Modifier.weight({long_param}: Float): Modifier\n\
+             }}\n"
+        ),
+    );
+
+    let caller = Url::parse("file:///app/Screen.kt").unwrap();
+    idx.index_content(&caller, "package app\nfun s() {}\n");
+
+    assert_eq!(
+        find_extension_fn_return_type(&idx, "Modifier", "weight", Some(&caller)),
+        Some("Modifier".into()),
+        "a member extension's return type must resolve via the source-signature \
+         fallback once both the FUNCTION-only kind filter and the \
+         container.is_none() fallback requirement are widened"
+    );
+}
+
 /// `Resolver::function_return_type` is the import-aware catalog entry: it binds
 /// through the scope chain first, then falls back to a workspace-wide by-name
 /// lookup, returning a self-documenting [`ReturnType`]. This asserts the

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -735,6 +735,8 @@ fn resolve_extension_in_scope(
             entry.package.as_ref(),
             &entry.name,
             entry.container.as_ref(),
+            entry.visibility,
+            entry.file_uri == from_uri.as_str(),
             caller_file_data_ref,
         );
         if in_scope {
@@ -822,6 +824,8 @@ fn implicit_receiver_extension_match(
             entry.package.as_ref(),
             &entry.name,
             entry.container.as_ref(),
+            entry.visibility,
+            entry.file_uri == from_uri.as_str(),
             caller_file_data_ref,
         );
         if !in_scope {

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -747,9 +747,12 @@ fn resolve_extension_in_scope(
                         fd.symbols
                             .iter()
                             .find(|s| {
-                                s.name == name
-                                    && s.extension_receiver() == receiver_base
-                                    && s.container.is_none()
+                                crate::resolver::infer::extension_declaration_matches(
+                                    s,
+                                    name,
+                                    receiver_base,
+                                    entry.container.as_ref(),
+                                )
                             })
                             .map(|s| s.selection_range)
                     })
@@ -835,9 +838,12 @@ fn implicit_receiver_extension_match(
                 fd.symbols
                     .iter()
                     .find(|s| {
-                        s.name == name
-                            && s.extension_receiver() == receiver_base
-                            && s.container.is_none()
+                        crate::resolver::infer::extension_declaration_matches(
+                            s,
+                            name,
+                            receiver_base,
+                            entry.container.as_ref(),
+                        )
                     })
                     .cloned()
             });

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -734,6 +734,7 @@ fn resolve_extension_in_scope(
         let in_scope = crate::resolver::infer::extension_is_in_scope(
             entry.package.as_ref(),
             &entry.name,
+            entry.container.as_ref(),
             caller_file_data_ref,
         );
         if in_scope {
@@ -817,6 +818,7 @@ fn implicit_receiver_extension_match(
         let in_scope = crate::resolver::infer::extension_is_in_scope(
             entry.package.as_ref(),
             &entry.name,
+            entry.container.as_ref(),
             caller_file_data_ref,
         );
         if !in_scope {

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -828,6 +828,61 @@ fn resolve_qualified_uppercase_root_hierarchy_fallback_reaches_jar_superclass() 
     );
 }
 
+/// `Resolver::field_type`'s supertype walk (`find_field_type_via_supertypes`)
+/// is JAR-promotion-aware the same way `resolve_from_class_hierarchy` is
+/// above, so it can walk into a JAR-derived superclass whose stub symbols
+/// carry the same degenerate `.range == .selection_range` (no real body
+/// span). Unlike a member *function* (found via the container-scoped
+/// `find_in_workspace_defs` check), a JAR class's own member *property* has
+/// no indexed-detail resolution path yet (`infer_field_type_raw` never reads
+/// `jar_files`, only workspace `files`) — the point of this test is that the
+/// walk still terminates with a clean `None` instead of panicking on the
+/// JAR stub's degenerate range, not that the property resolves.
+#[test]
+fn catalog_field_type_supertype_walk_reaches_jar_superclass_without_panicking() {
+    use crate::sidecar::SidecarSymbol;
+
+    let sym = |name: &str, kind: &str, container: &str| SidecarSymbol {
+        name: name.to_owned(),
+        kind: kind.to_owned(),
+        container: container.to_owned(),
+        detail: format!("val {name}: String"),
+        doc: String::new(),
+        type_params: vec![],
+        extension_receiver_type: String::new(),
+        trailing_lambda: false,
+        deprecated: false,
+        pkg: "com.lib".to_owned(),
+        top_level: container.is_empty(),
+        supers: vec![],
+    };
+    let idx = Indexer::new();
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/abstract-viewmodel.jar"),
+        &[
+            sym("AbstractViewModel", "class", ""),
+            sym("uiState", "val", "AbstractViewModel"),
+        ],
+    );
+
+    let host_uri = uri("/ConcreteViewModel.kt");
+    idx.index_content(
+        &host_uri,
+        "package com.example\nclass ConcreteViewModel : AbstractViewModel()\n",
+    );
+
+    let result =
+        crate::resolver::Resolver::field_type(&idx, "ConcreteViewModel", "uiState", &host_uri);
+    assert!(
+        result.is_none(),
+        "a JAR class's own member property has no indexed-detail resolution \
+         path today (unlike an extension property); the walk must return \
+         None gracefully instead of panicking on the JAR stub's degenerate \
+         range, got {result:?}"
+    );
+}
+
 #[test]
 fn resolve_qualified_uppercase_root_hierarchy_fallback_works_from_a_different_call_site_file() {
     // Same fixture as `resolve_qualified_uppercase_root_falls_back_to_class_hierarchy`,

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -3958,6 +3958,50 @@ fn jar_extension_appears_in_dot_completion() {
     );
 }
 
+#[test]
+fn member_extension_is_excluded_from_generic_dot_completion() {
+    // Regression guard: `container: Some(_)` (a Compose-style member extension
+    // such as `interface ColumnScope { fun Modifier.weight(...) }`) must not
+    // enter the generic receiver-type dot-completion path. Kotlin has no
+    // import syntax for an interface member, so offering it here would pair
+    // the completion with an auto-import edit `weight`'s real declaration can
+    // never satisfy.
+    let idx = Indexer::new();
+    idx.extension_by_receiver
+        .entry("Modifier".to_owned())
+        .or_default()
+        .push(crate::types::ExtensionEntry {
+            file_uri: "file:///sdk/ColumnScope.kt".to_owned(),
+            name: "weight".to_owned(),
+            kind: tower_lsp::lsp_types::SymbolKind::METHOD,
+            detail: "fun Modifier.weight(weight: Float): Modifier".to_owned(),
+            visibility: crate::types::Visibility::Public,
+            package: Some("androidx.compose.foundation.layout".to_owned()),
+            trailing_lambda: false,
+            deprecated: false,
+            container: Some("ColumnScope".to_owned()),
+        });
+
+    let caller_uri = Url::parse("file:///app/Screen.kt").unwrap();
+    idx.index_content(
+        &caller_uri,
+        concat!(
+            "package app\n",
+            "class Modifier\n",
+            "fun caller(m: Modifier) {\n",
+            "    m.weight\n",
+            "}\n",
+        ),
+    );
+
+    let items = complete_dot(&idx, "Modifier", &caller_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        !labels.contains(&"weight"),
+        "a member extension must not be offered through generic dot completion: {labels:?}"
+    );
+}
+
 /// Regression test for a real lazy-JAR-loading gap: `extension_by_receiver`
 /// is populated exclusively by Tier-2 materialization (`build_jar_file_data`)
 /// — Tier 1's `populate_tier1_from_manifest` never wrote to it, and neither

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -3913,6 +3913,7 @@ fn jar_extension_appears_in_dot_completion() {
             package: Some("androidx.lifecycle".to_owned()),
             trailing_lambda: false,
             deprecated: false,
+            container: None,
         });
 
     // 2. fun CoroutineScope.launch(block: suspend CoroutineScope.() -> Unit): Job
@@ -3929,6 +3930,7 @@ fn jar_extension_appears_in_dot_completion() {
             package: Some("kotlinx.coroutines".to_owned()),
             trailing_lambda: true,
             deprecated: false,
+            container: None,
         });
 
     let vm_uri = Url::parse("file:///app/MyViewModel.kt").unwrap();
@@ -4283,6 +4285,7 @@ fn library_deprecated_internal_extensions_hidden() {
             package: Some("androidx.lifecycle".to_owned()),
             trailing_lambda: false,
             deprecated: false,
+            container: None,
         });
 
     let mk = |detail: &str, vis, deprecated| crate::types::ExtensionEntry {
@@ -4294,6 +4297,7 @@ fn library_deprecated_internal_extensions_hidden() {
         package: Some("kotlinx.coroutines".to_owned()),
         trailing_lambda: true,
         deprecated,
+        container: None,
     };
     {
         let mut slot = idx
@@ -4374,6 +4378,7 @@ fn extension_overloads_collapse_to_single_entry() {
             package: Some("androidx.lifecycle".to_owned()),
             trailing_lambda: false,
             deprecated: false,
+            container: None,
         });
     let mk = |first_param: &str, pkg: &str, defaults: bool| crate::types::ExtensionEntry {
         file_uri: "jar:file:///coroutines-core.jar/Builders.class".to_owned(),
@@ -4390,6 +4395,7 @@ fn extension_overloads_collapse_to_single_entry() {
         package: Some(pkg.to_owned()),
         trailing_lambda: true,
         deprecated: false,
+        container: None,
     };
     {
         let mut slot = idx
@@ -4451,6 +4457,7 @@ fn deprecated_workspace_extension_kept_tagged() {
             package: Some("androidx.lifecycle".to_owned()),
             trailing_lambda: false,
             deprecated: false,
+            container: None,
         });
     // A WORKSPACE-sourced deprecated extension on CoroutineScope (file:// URI).
     idx.index_content(
@@ -4917,6 +4924,173 @@ fn find_definition_qualified_prefers_own_member_over_scope_function_fallback() {
         !locs.is_empty() && locs.iter().all(|l| l.uri == use_uri),
         "must resolve to ConfigBuilder's own `apply()`, not the stdlib scope-function \
          fallback; got {:?}",
+        locs.iter().map(|l| l.uri.as_str()).collect::<Vec<_>>()
+    );
+}
+
+/// Primitive D (member-extension visibility): `fun Modifier.weight(...)`
+/// declared as a MEMBER of `interface ColumnScope` — the real Compose
+/// `ColumnScope`/`Modifier.weight` shape — must resolve via goto-definition
+/// even though the caller file imports nothing from `ColumnScope`'s package.
+/// Kotlin has no import syntax for a member of an interface, so real call
+/// sites never import `weight`; `extension_is_in_scope` must not reject it
+/// on the ordinary top-level-extension import rule.
+#[test]
+fn member_extension_function_resolves_without_import() {
+    let idx = Indexer::new();
+    let scope_uri = Url::parse("file:///compose/ColumnScope.kt").unwrap();
+    idx.index_content(
+        &scope_uri,
+        concat!(
+            "package androidx.compose.foundation.layout\n",
+            "interface ColumnScope {\n",
+            "    fun Modifier.weight(weight: Float): Modifier\n",
+            "}\n",
+        ),
+    );
+
+    // No `import androidx.compose.foundation.layout.ColumnScope` (and Kotlin has
+    // no per-member import syntax for it anyway) — a real Compose call site.
+    let use_uri = Url::parse("file:///app/Screen.kt").unwrap();
+    idx.index_content(
+        &use_uri,
+        concat!(
+            "package app\n",
+            "fun screen() {\n",
+            "    Column {\n",
+            "        Modifier.weight(1f)\n",
+            "    }\n",
+            "}\n",
+        ),
+    );
+
+    let locs = idx.find_definition_qualified("weight", Some("Modifier"), &use_uri);
+    assert!(
+        locs.iter().any(|l| l.uri == scope_uri),
+        "Modifier.weight(...) must resolve to ColumnScope's member extension \\
+         declaration despite the caller file importing nothing from its package; \\
+         got {:?}",
+        locs.iter().map(|l| l.uri.as_str()).collect::<Vec<_>>()
+    );
+}
+
+/// Decoy 1 (regression guard, highest-value test in this primitive):
+/// an ORDINARY top-level extension function (`container == None`) declared
+/// in an unimported package must still be rejected by `extension_is_in_scope`
+/// exactly as before this primitive — `extension_is_in_scope` is shared by
+/// every extension-function lookup in the codebase, not just member
+/// extensions, so this proves the new member-extension short-circuit does not
+/// accidentally widen visibility for the ordinary case.
+///
+/// Tests `extension_is_in_scope` directly rather than through
+/// `find_definition_qualified`: `resolve_qualified` (`resolver/resolve.rs`)
+/// has its own pre-existing, unrelated fallback for a receiver type with no
+/// indexed class declaration (matches the first same-named extension entry
+/// with no scope check at all) — a separate, already-existing gap this
+/// primitive does not touch. Routing this decoy through the full
+/// goto-definition pipeline would risk conflating that unrelated gap with
+/// the specific regression this decoy is meant to guard.
+#[test]
+fn top_level_extension_function_in_unimported_package_still_out_of_scope() {
+    use crate::resolver::infer::extension_is_in_scope;
+    use crate::types::FileData;
+
+    let caller_file_data = FileData {
+        package: Some("app".to_string()),
+        ..Default::default()
+    };
+    let extension_package = "com.example.lib".to_string();
+
+    assert!(
+        !extension_is_in_scope(
+            Some(&extension_package),
+            "myExtension",
+            None, // ordinary top-level extension: container == None
+            Some(&caller_file_data),
+        ),
+        "an ordinary top-level extension in an unimported package must remain \\
+         out of scope"
+    );
+}
+
+/// The direct, pipeline-independent counterpart to the two tests above: a
+/// MEMBER extension (`entry_container` is `Some`) in a package the caller
+/// neither shares nor imports must still be in scope per the D2 rule. Tested
+/// directly against `extension_is_in_scope` (not through
+/// `find_definition_qualified`) for the same reason given on the decoy test
+/// above — this isolates the D2 short-circuit itself from the unrelated
+/// pipeline fallback.
+#[test]
+fn member_extension_in_unimported_package_is_in_scope_via_container_short_circuit() {
+    use crate::resolver::infer::extension_is_in_scope;
+    use crate::types::FileData;
+
+    let caller_file_data = FileData {
+        package: Some("app".to_string()),
+        ..Default::default()
+    };
+    let extension_package = "androidx.compose.foundation.layout".to_string();
+    let container = "ColumnScope".to_string();
+
+    assert!(
+        extension_is_in_scope(
+            Some(&extension_package),
+            "weight",
+            Some(&container),
+            Some(&caller_file_data),
+        ),
+        "a member extension must be in scope regardless of package/import \\
+         coverage — Kotlin has no import syntax for a member of an interface"
+    );
+}
+
+/// Decoy 2 (documented pre-existing limitation, not a regression): two
+/// unrelated interfaces both declaring a member extension named `weight` on
+/// the same receiver type. This primitive inherits the same "first match
+/// wins, no overload-set semantics" limitation `resolve_extension_in_scope`
+/// already has for ordinary top-level extensions — not a new gap.
+#[test]
+fn ambiguous_member_extension_name_collision_first_match_wins() {
+    let idx = Indexer::new();
+    let first_uri = Url::parse("file:///compose/ColumnScope.kt").unwrap();
+    idx.index_content(
+        &first_uri,
+        concat!(
+            "package androidx.compose.foundation.layout\n",
+            "interface ColumnScope {\n",
+            "    fun Modifier.weight(weight: Float): Modifier\n",
+            "}\n",
+        ),
+    );
+    let second_uri = Url::parse("file:///lib/UnrelatedScope.kt").unwrap();
+    idx.index_content(
+        &second_uri,
+        concat!(
+            "package com.example.lib\n",
+            "interface UnrelatedScope {\n",
+            "    fun Modifier.weight(weight: Float): Modifier\n",
+            "}\n",
+        ),
+    );
+
+    let use_uri = Url::parse("file:///app/Screen.kt").unwrap();
+    idx.index_content(
+        &use_uri,
+        concat!(
+            "package app\n",
+            "fun screen() {\n",
+            "    Modifier.weight(1f)\n",
+            "}\n",
+        ),
+    );
+
+    let locs = idx.find_definition_qualified("weight", Some("Modifier"), &use_uri);
+    assert_eq!(
+        locs.len(),
+        1,
+        "colliding same-named member extensions resolve to a single first \\
+         match, not an overload set -- a pre-existing, unchanged limitation; \\
+         got {:?}",
         locs.iter().map(|l| l.uri.as_str()).collect::<Vec<_>>()
     );
 }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -5041,6 +5041,76 @@ fn member_extension_function_resolves_without_import() {
     );
 }
 
+/// Primitive D follow-up: the member-extension short-circuit in
+/// `extension_is_in_scope` unconditionally returns `true` whenever
+/// `entry_container.is_some()`, without ever consulting `ExtensionEntry::visibility`
+/// — so a `private fun Modifier.weight(...)` declared as a member of
+/// `ColumnScope` would be treated as in scope for a completely unrelated
+/// file/package that has no business seeing it. Kotlin's `private`/`protected`
+/// access rules are an axis entirely separate from the "no live dispatch-receiver
+/// tracking" trade-off Primitive D's own design intentionally accepted.
+///
+/// Tested directly against `extension_is_in_scope`, not through
+/// `find_definition_qualified`, for the same reason given on the decoy test
+/// below: `resolve_qualified` has its own separate, pre-existing, unrelated
+/// fallback for a receiver type with no indexed class declaration (matches the
+/// first same-named extension entry with no scope check of any kind) that
+/// would otherwise mask which mechanism actually rejected the call.
+#[test]
+fn private_member_extension_in_another_file_is_out_of_scope() {
+    use crate::resolver::infer::extension_is_in_scope;
+    use crate::types::{FileData, Visibility};
+
+    let caller_file_data = FileData {
+        package: Some("app".to_string()),
+        ..Default::default()
+    };
+    let extension_package = "androidx.compose.foundation.layout".to_string();
+    let container = "ColumnScope".to_string();
+
+    assert!(
+        !extension_is_in_scope(
+            Some(&extension_package),
+            "weight",
+            Some(&container),
+            Visibility::Private,
+            false, // caller is not the declaring file
+            Some(&caller_file_data),
+        ),
+        "a private member extension must not be in scope for an unrelated caller \\
+         in a different file"
+    );
+}
+
+/// The same-file counterpart to the test above: Kotlin's own visibility rules
+/// permit access to a `private` declaration from within its own file, so
+/// `is_same_file: true` must still return `true` here — the fix must not
+/// blanket-reject every private member extension regardless of caller.
+#[test]
+fn private_member_extension_in_same_file_is_in_scope() {
+    use crate::resolver::infer::extension_is_in_scope;
+    use crate::types::{FileData, Visibility};
+
+    let caller_file_data = FileData {
+        package: Some("androidx.compose.foundation.layout".to_string()),
+        ..Default::default()
+    };
+    let extension_package = "androidx.compose.foundation.layout".to_string();
+    let container = "ColumnScope".to_string();
+
+    assert!(
+        extension_is_in_scope(
+            Some(&extension_package),
+            "weight",
+            Some(&container),
+            Visibility::Private,
+            true, // caller is the declaring file
+            Some(&caller_file_data),
+        ),
+        "a private member extension must remain in scope from its own declaring file"
+    );
+}
+
 /// Decoy 1 (regression guard, highest-value test in this primitive):
 /// an ORDINARY top-level extension function (`container == None`) declared
 /// in an unimported package must still be rejected by `extension_is_in_scope`
@@ -5073,6 +5143,8 @@ fn top_level_extension_function_in_unimported_package_still_out_of_scope() {
             Some(&extension_package),
             "myExtension",
             None, // ordinary top-level extension: container == None
+            crate::types::Visibility::Public,
+            false,
             Some(&caller_file_data),
         ),
         "an ordinary top-level extension in an unimported package must remain \\
@@ -5104,6 +5176,8 @@ fn member_extension_in_unimported_package_is_in_scope_via_container_short_circui
             Some(&extension_package),
             "weight",
             Some(&container),
+            crate::types::Visibility::Public,
+            false,
             Some(&caller_file_data),
         ),
         "a member extension must be in scope regardless of package/import \\

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -4964,13 +4964,36 @@ fn member_extension_function_resolves_without_import() {
         ),
     );
 
+    // The declaration's own `selection_range`, read directly off the index —
+    // the expected value the goto-definition `Location` below must match.
+    // Asserting only the URI (as this test originally did) let a
+    // `Range::default()` fallback — pointing at the right file but the wrong
+    // spot — slip through undetected.
+    let expected_range = idx
+        .files
+        .get(scope_uri.as_str())
+        .and_then(|fd| {
+            fd.symbols
+                .iter()
+                .find(|s| s.name == "weight")
+                .map(|s| s.selection_range)
+        })
+        .expect("weight must be indexed in ColumnScope.kt");
+
     let locs = idx.find_definition_qualified("weight", Some("Modifier"), &use_uri);
+    let matched = locs.iter().find(|l| l.uri == scope_uri);
     assert!(
-        locs.iter().any(|l| l.uri == scope_uri),
+        matched.is_some(),
         "Modifier.weight(...) must resolve to ColumnScope's member extension \\
          declaration despite the caller file importing nothing from its package; \\
          got {:?}",
         locs.iter().map(|l| l.uri.as_str()).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        matched.unwrap().range,
+        expected_range,
+        "goto-definition must point at weight's actual declaration range, not a \\
+         Range::default() fallback from a container.is_none() lookup mismatch"
     );
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -385,6 +385,13 @@ pub(crate) struct ExtensionEntry {
     pub trailing_lambda: bool,
     /// True when the declaring symbol carries an `@Deprecated` annotation.
     pub deprecated: bool,
+    /// The enclosing class/interface's simple name, when this extension is a
+    /// MEMBER extension function (declared inside a class/interface body) —
+    /// e.g. `Some("ColumnScope")` for `ColumnScope`'s `fun Modifier.weight(...)`.
+    /// `None` for an ordinary top-level extension function. Drives a
+    /// different visibility rule in `extension_is_in_scope` — see its own
+    /// doc comment for why a member extension is never import-scoped.
+    pub container: Option<String>,
 }
 
 /// One import statement parsed from a Kotlin file.

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -633,7 +633,7 @@ fn abandon_stale_jar_scan(
 /// (rather than inlined in `spawn_jar_indexing`) so the gating behavior is
 /// directly unit-testable without the sidecar/tokio machinery that makes
 /// `spawn_jar_indexing` itself untestable in this crate's unit-test harness.
-fn compiled_jar_paths_with_android_sdk(
+pub(crate) fn compiled_jar_paths_with_android_sdk(
     workspace_root: Option<PathBuf>,
     workspace_uses_gradle_cache: bool,
     mut gradle_paths: Vec<PathBuf>,

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -463,6 +463,18 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             let gradle_count = gradle_paths.len();
             let mut paths = gradle_paths;
 
+            // Android SDK's compiled `android.jar`, discovered independently of the
+            // Gradle-cache gate above — an Android SDK can be installed on a machine
+            // regardless of whether this particular workspace's JVM-sources gate is
+            // open, and `android.jar` never lives in the Gradle module cache anyway.
+            if let Some(root) = indexer.workspace_root.get() {
+                for jar in crate::workspace_json::detect_android_sdk_jar_path(&root) {
+                    if !paths.contains(&jar) {
+                        paths.push(jar);
+                    }
+                }
+            }
+
             // Explicitly-configured jars (workspace.json `jarPaths` + init-options
             // `jarPaths`), so non-Gradle projects (Make/Bazel/manual) get symbols too.
             // Filesystem I/O (read workspace.json, walk dirs) runs here off-thread.

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -461,19 +461,11 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 Vec::new()
             };
             let gradle_count = gradle_paths.len();
-            let mut paths = gradle_paths;
-
-            // Android SDK's compiled `android.jar`, discovered independently of the
-            // Gradle-cache gate above — an Android SDK can be installed on a machine
-            // regardless of whether this particular workspace's JVM-sources gate is
-            // open, and `android.jar` never lives in the Gradle module cache anyway.
-            if let Some(root) = indexer.workspace_root.get() {
-                for jar in crate::workspace_json::detect_android_sdk_jar_path(&root) {
-                    if !paths.contains(&jar) {
-                        paths.push(jar);
-                    }
-                }
-            }
+            let mut paths = compiled_jar_paths_with_android_sdk(
+                indexer.workspace_root.get(),
+                workspace_uses_gradle_cache,
+                gradle_paths,
+            );
 
             // Explicitly-configured jars (workspace.json `jarPaths` + init-options
             // `jarPaths`), so non-Gradle projects (Make/Bazel/manual) get symbols too.
@@ -628,6 +620,34 @@ fn abandon_stale_jar_scan(
         );
     }
     let _ = jar_done_tx.send(());
+}
+
+/// Appends the Android SDK's compiled `android.jar` to `gradle_paths`, gated
+/// on the same `workspace_uses_gradle_cache` verdict the Gradle-cache scan
+/// itself uses. `android.jar` never lives in the Gradle module cache, but its
+/// Tier-1 manifest cost is real (measured: 3.18s cold / 550ms warm for a
+/// single real `android.jar`) — a workspace with no JVM sources (the same
+/// condition `workspace_uses_gradle_cache` already gates the Gradle-cache
+/// pipeline on, see its own call site's comment) must not pay it, matching
+/// the precedent this gate exists to enforce. Extracted as its own function
+/// (rather than inlined in `spawn_jar_indexing`) so the gating behavior is
+/// directly unit-testable without the sidecar/tokio machinery that makes
+/// `spawn_jar_indexing` itself untestable in this crate's unit-test harness.
+fn compiled_jar_paths_with_android_sdk(
+    workspace_root: Option<PathBuf>,
+    workspace_uses_gradle_cache: bool,
+    mut gradle_paths: Vec<PathBuf>,
+) -> Vec<PathBuf> {
+    if workspace_uses_gradle_cache {
+        if let Some(root) = workspace_root {
+            for jar in crate::workspace_json::detect_android_sdk_jar_path(&root) {
+                if !gradle_paths.contains(&jar) {
+                    gradle_paths.push(jar);
+                }
+            }
+        }
+    }
+    gradle_paths
 }
 
 #[cfg(test)]

--- a/src/workspace/scan_handler_tests.rs
+++ b/src/workspace/scan_handler_tests.rs
@@ -247,3 +247,77 @@ fn crawl_no_longer_eagerly_materializes_every_jar() {
          cheap, always-eager"
     );
 }
+
+// ─── Android SDK jar-path gating (spawn_jar_indexing's compiled-JAR list) ────
+
+#[test]
+fn android_jar_is_included_when_workspace_uses_gradle_cache() {
+    let dir = tempfile::tempdir().unwrap();
+    let fake_sdk = dir.path().join("sdk");
+    let platform_dir = fake_sdk.join("platforms").join("android-34");
+    std::fs::create_dir_all(&platform_dir).unwrap();
+    std::fs::write(platform_dir.join("android.jar"), b"fake jar").unwrap();
+    std::fs::write(
+        dir.path().join("local.properties"),
+        format!("sdk.dir={}\n", fake_sdk.display()),
+    )
+    .unwrap();
+
+    let paths = super::compiled_jar_paths_with_android_sdk(
+        Some(dir.path().to_path_buf()),
+        true,
+        Vec::new(),
+    );
+
+    assert_eq!(
+        paths.len(),
+        1,
+        "android.jar must be added when the workspace uses the Gradle-cache pipeline"
+    );
+    assert!(
+        paths[0].ends_with("android-34/android.jar")
+            || paths[0].ends_with("android-34\\android.jar")
+    );
+}
+
+#[test]
+fn android_jar_is_skipped_when_workspace_does_not_use_gradle_cache() {
+    let dir = tempfile::tempdir().unwrap();
+    let fake_sdk = dir.path().join("sdk");
+    let platform_dir = fake_sdk.join("platforms").join("android-34");
+    std::fs::create_dir_all(&platform_dir).unwrap();
+    std::fs::write(platform_dir.join("android.jar"), b"fake jar").unwrap();
+    std::fs::write(
+        dir.path().join("local.properties"),
+        format!("sdk.dir={}\n", fake_sdk.display()),
+    )
+    .unwrap();
+
+    // A real Android SDK is present on disk, but this workspace has no JVM
+    // sources — the same condition that makes the Gradle-cache pipeline
+    // itself skip. The android.jar detection must not bypass that gate.
+    let paths = super::compiled_jar_paths_with_android_sdk(
+        Some(dir.path().to_path_buf()),
+        false,
+        Vec::new(),
+    );
+
+    assert!(
+        paths.is_empty(),
+        "a non-JVM (or not-yet-JVM) workspace must not pay android.jar's \
+         Tier-1 manifest cost, matching the same reason the Gradle-cache \
+         pipeline is gated; got {paths:?}"
+    );
+}
+
+#[test]
+fn android_jar_gate_preserves_existing_gradle_paths() {
+    let existing = vec![std::path::PathBuf::from("/fake/gradle-cache/some-lib.jar")];
+
+    let paths_when_gated_off =
+        super::compiled_jar_paths_with_android_sdk(None, false, existing.clone());
+    assert_eq!(
+        paths_when_gated_off, existing,
+        "gating android.jar off must not disturb the Gradle-cache paths already collected"
+    );
+}

--- a/src/workspace_json.rs
+++ b/src/workspace_json.rs
@@ -401,12 +401,7 @@ fn parse_include_calls(content: &str) -> Vec<String> {
 /// contains the Android platform Java sources.  Returns an empty `Vec`
 /// when no SDK is found or the SDK has no `sources/` directory.
 pub(crate) fn detect_android_sdk_source_paths(workspace_root: &Path) -> Vec<PathBuf> {
-    let sdk_dir = sdk_dir_from_local_properties(workspace_root)
-        .or_else(|| std::env::var("ANDROID_HOME").ok().map(PathBuf::from))
-        .or_else(|| std::env::var("ANDROID_SDK_ROOT").ok().map(PathBuf::from))
-        .filter(|p| p.is_dir());
-
-    let Some(sdk) = sdk_dir else {
+    let Some(sdk) = resolve_android_sdk_root(workspace_root) else {
         return Vec::new();
     };
 
@@ -416,23 +411,7 @@ pub(crate) fn detect_android_sdk_source_paths(workspace_root: &Path) -> Vec<Path
     }
 
     // Find highest android-XX API level present under sdk/sources/.
-    let best = std::fs::read_dir(&sources_root)
-        .ok()
-        .into_iter()
-        .flatten()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().ok().map(|t| t.is_dir()).unwrap_or(false))
-        .filter_map(|e| {
-            let name = e.file_name();
-            let api: u32 = name
-                .to_string_lossy()
-                .strip_prefix("android-")?
-                .parse()
-                .ok()?;
-            Some((api, e.path()))
-        })
-        .max_by_key(|(api, _)| *api)
-        .map(|(_, path)| path);
+    let best = highest_api_level_dir(&sources_root);
 
     match best {
         Some(path) => {
@@ -441,6 +420,66 @@ pub(crate) fn detect_android_sdk_source_paths(workspace_root: &Path) -> Vec<Path
         }
         None => Vec::new(),
     }
+}
+
+/// Auto-detect the Android platform's compiled `android.jar`.
+///
+/// Uses the same SDK-root discovery as `detect_android_sdk_source_paths`
+/// (`local.properties`' `sdk.dir`, then `$ANDROID_HOME`, then
+/// `$ANDROID_SDK_ROOT`), but returns the highest `platforms/android-XX/
+/// android.jar` present — a different subdirectory of the SDK than
+/// `sources/android-XX`, since a developer can have a platform installed
+/// without its optional sources component, or vice versa. Returns an empty
+/// `Vec` when no SDK, no `platforms/` directory, or no `android.jar` inside
+/// any `android-XX` platform directory is found.
+pub(crate) fn detect_android_sdk_jar_path(workspace_root: &Path) -> Vec<PathBuf> {
+    let Some(sdk) = resolve_android_sdk_root(workspace_root) else {
+        return Vec::new();
+    };
+
+    let platforms_root = sdk.join("platforms");
+    if !platforms_root.is_dir() {
+        return Vec::new();
+    }
+
+    // Find the highest android-XX API level whose android.jar actually
+    // exists on disk — a platform directory can exist without the JAR in a
+    // partial SDK install, so presence must be checked, not assumed.
+    let best = std::fs::read_dir(&platforms_root)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().ok().map(|t| t.is_dir()).unwrap_or(false))
+        .filter_map(|e| {
+            let api = parse_android_api_level(&e.file_name().to_string_lossy())?;
+            let jar = e.path().join("android.jar");
+            jar.is_file().then_some((api, jar))
+        })
+        .max_by_key(|(api, _)| *api)
+        .map(|(_, jar)| jar);
+
+    match best {
+        Some(path) => {
+            log::info!(
+                "android-sdk: auto-detected compiled JAR at {}",
+                path.display()
+            );
+            vec![path]
+        }
+        None => Vec::new(),
+    }
+}
+
+/// Resolve the local Android SDK root directory, checking (in order)
+/// `local.properties`' `sdk.dir`, then `$ANDROID_HOME`, then
+/// `$ANDROID_SDK_ROOT`. Shared by `detect_android_sdk_source_paths` and
+/// `detect_android_sdk_jar_path` so the lookup logic exists in one place.
+fn resolve_android_sdk_root(workspace_root: &Path) -> Option<PathBuf> {
+    sdk_dir_from_local_properties(workspace_root)
+        .or_else(|| std::env::var("ANDROID_HOME").ok().map(PathBuf::from))
+        .or_else(|| std::env::var("ANDROID_SDK_ROOT").ok().map(PathBuf::from))
+        .filter(|p| p.is_dir())
 }
 
 /// Read `sdk.dir` from `<workspace_root>/local.properties`.
@@ -454,6 +493,37 @@ fn sdk_dir_from_local_properties(workspace_root: &Path) -> Option<PathBuf> {
             None
         }
     })
+}
+
+/// Returns the subdirectory of `root` named `android-XX` (or `android-XX.Y`)
+/// with the highest API level, per `parse_android_api_level`.
+fn highest_api_level_dir(root: &Path) -> Option<PathBuf> {
+    std::fs::read_dir(root)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().ok().map(|t| t.is_dir()).unwrap_or(false))
+        .filter_map(|e| {
+            let api = parse_android_api_level(&e.file_name().to_string_lossy())?;
+            Some((api, e.path()))
+        })
+        .max_by_key(|(api, _)| *api)
+        .map(|(_, path)| path)
+}
+
+/// Parses an `android-XX` or `android-XX.Y` SDK directory name into a
+/// comparable `(major, minor)` API level. Modern Android SDK installs use a
+/// decimal extension-level suffix for some platforms (e.g. `android-36.1`,
+/// `android-37.0`, confirmed present on a real developer machine alongside
+/// plain `android-36`) — this must sort higher than a same-major plain
+/// directory, and plain directories are treated as minor level `0`.
+fn parse_android_api_level(dir_name: &str) -> Option<(u32, u32)> {
+    let level = dir_name.strip_prefix("android-")?;
+    match level.split_once('.') {
+        Some((major, minor)) => Some((major.parse().ok()?, minor.parse().ok()?)),
+        None => Some((level.parse().ok()?, 0)),
+    }
 }
 
 #[cfg(test)]

--- a/src/workspace_json.rs
+++ b/src/workspace_json.rs
@@ -512,17 +512,28 @@ fn highest_api_level_dir(root: &Path) -> Option<PathBuf> {
         .map(|(_, path)| path)
 }
 
-/// Parses an `android-XX` or `android-XX.Y` SDK directory name into a
-/// comparable `(major, minor)` API level. Modern Android SDK installs use a
-/// decimal extension-level suffix for some platforms (e.g. `android-36.1`,
-/// `android-37.0`, confirmed present on a real developer machine alongside
-/// plain `android-36`) — this must sort higher than a same-major plain
-/// directory, and plain directories are treated as minor level `0`.
-fn parse_android_api_level(dir_name: &str) -> Option<(u32, u32)> {
+/// Parses an `android-XX`, `android-XX.Y`, or `android-XX-extZZ` SDK
+/// directory name into a comparable `(major, minor, ext)` API level. Modern
+/// Android SDK installs use a decimal extension-level suffix for some
+/// platforms (e.g. `android-36.1`, `android-37.0`, confirmed present on a
+/// real developer machine alongside plain `android-36`) — this must sort
+/// higher than a same-major plain directory, and plain directories are
+/// treated as minor level `0`. SDK Extension APIs (a separate, additive
+/// versioning axis — see Android's own SDK Extensions documentation) install
+/// under a `-extZZ`-suffixed directory name instead (e.g. `android-36-ext14`
+/// alongside plain `android-36`); an extension level must outrank the plain
+/// base of the same major version, since its `android.jar` is additive to
+/// the base platform, not a replacement for a different major/minor axis —
+/// plain directories are treated as extension level `0`.
+fn parse_android_api_level(dir_name: &str) -> Option<(u32, u32, u32)> {
     let level = dir_name.strip_prefix("android-")?;
+    let (level, ext) = match level.split_once("-ext") {
+        Some((base, ext_level)) => (base, ext_level.parse().ok()?),
+        None => (level, 0),
+    };
     match level.split_once('.') {
-        Some((major, minor)) => Some((major.parse().ok()?, minor.parse().ok()?)),
-        None => Some((level.parse().ok()?, 0)),
+        Some((major, minor)) => Some((major.parse().ok()?, minor.parse().ok()?, ext)),
+        None => Some((level.parse().ok()?, 0, ext)),
     }
 }
 

--- a/src/workspace_json_tests.rs
+++ b/src/workspace_json_tests.rs
@@ -292,6 +292,157 @@ fn sdk_dir_from_local_properties_with_whitespace() {
     assert!(paths[0].ends_with("android-35"));
 }
 
+// ─── Android SDK compiled-JAR detection tests ────────────────────────────────
+
+#[test]
+fn jar_path_picks_highest_api_level_with_jar_present() {
+    let dir = TempDir::new().unwrap();
+    let fake_sdk = dir.path().join("sdk");
+    for api in ["android-33", "android-34"] {
+        let platform_dir = fake_sdk.join("platforms").join(api);
+        fs::create_dir_all(&platform_dir).unwrap();
+        fs::write(platform_dir.join("android.jar"), b"fake jar").unwrap();
+    }
+    fs::write(
+        dir.path().join("local.properties"),
+        format!("sdk.dir={}\n", fake_sdk.display()),
+    )
+    .unwrap();
+
+    let paths = detect_android_sdk_jar_path(dir.path());
+    assert_eq!(paths.len(), 1);
+    assert!(
+        paths[0].ends_with("android-34/android.jar")
+            || paths[0].ends_with("android-34\\android.jar")
+    );
+}
+
+#[test]
+fn jar_path_skips_platform_dir_missing_the_jar() {
+    let dir = TempDir::new().unwrap();
+    let fake_sdk = dir.path().join("sdk");
+    // android-34 is the higher API level but its android.jar is missing
+    // (partial install) — android-33 must win instead.
+    fs::create_dir_all(fake_sdk.join("platforms").join("android-34")).unwrap();
+    let platform_33 = fake_sdk.join("platforms").join("android-33");
+    fs::create_dir_all(&platform_33).unwrap();
+    fs::write(platform_33.join("android.jar"), b"fake jar").unwrap();
+    fs::write(
+        dir.path().join("local.properties"),
+        format!("sdk.dir={}\n", fake_sdk.display()),
+    )
+    .unwrap();
+
+    let paths = detect_android_sdk_jar_path(dir.path());
+    assert_eq!(paths.len(), 1);
+    assert!(
+        paths[0].ends_with("android-33/android.jar")
+            || paths[0].ends_with("android-33\\android.jar")
+    );
+}
+
+#[test]
+fn jar_path_independent_of_sources_only_install() {
+    let dir = TempDir::new().unwrap();
+    let fake_sdk = dir.path().join("sdk");
+    // Sources are present for android-35, but there is no matching
+    // platforms/android-35/android.jar — the two detectors must not
+    // cross-contaminate each other's result.
+    fs::create_dir_all(fake_sdk.join("sources").join("android-35")).unwrap();
+    fs::write(
+        dir.path().join("local.properties"),
+        format!("sdk.dir={}\n", fake_sdk.display()),
+    )
+    .unwrap();
+
+    let jar_paths = detect_android_sdk_jar_path(dir.path());
+    assert!(jar_paths.is_empty());
+    let source_paths = detect_android_sdk_source_paths(dir.path());
+    assert_eq!(source_paths.len(), 1);
+    assert!(source_paths[0].ends_with("android-35"));
+}
+
+#[test]
+fn jar_path_no_sdk_root_returns_empty() {
+    let dir = TempDir::new().unwrap();
+    let fake_sdk = dir.path().join("sdk");
+    // sdk.dir points at a directory with no platforms/ subdirectory at all.
+    fs::create_dir_all(&fake_sdk).unwrap();
+    fs::write(
+        dir.path().join("local.properties"),
+        format!("sdk.dir={}\n", fake_sdk.display()),
+    )
+    .unwrap();
+
+    let paths = detect_android_sdk_jar_path(dir.path());
+    assert!(paths.is_empty());
+}
+
+#[test]
+fn jar_path_platforms_dir_with_no_valid_jar_returns_empty() {
+    let dir = TempDir::new().unwrap();
+    let fake_sdk = dir.path().join("sdk");
+    // platforms/ exists, and even has an android-XX-named directory, but
+    // no android.jar inside it — a different empty shape than "no SDK at all".
+    fs::create_dir_all(fake_sdk.join("platforms").join("android-33")).unwrap();
+    fs::write(
+        dir.path().join("local.properties"),
+        format!("sdk.dir={}\n", fake_sdk.display()),
+    )
+    .unwrap();
+
+    let paths = detect_android_sdk_jar_path(dir.path());
+    assert!(paths.is_empty());
+}
+
+#[test]
+fn jar_path_handles_extension_level_directory_names() {
+    // Real Android SDK installs (confirmed on this machine) name newer
+    // platform directories with a decimal extension level, e.g.
+    // `android-37.0`/`android-36.1`, not just plain integers. The highest
+    // level must still be picked correctly across mixed naming styles.
+    let dir = TempDir::new().unwrap();
+    let fake_sdk = dir.path().join("sdk");
+    for api in ["android-36", "android-36.1", "android-37.0"] {
+        let platform_dir = fake_sdk.join("platforms").join(api);
+        fs::create_dir_all(&platform_dir).unwrap();
+        fs::write(platform_dir.join("android.jar"), b"fake jar").unwrap();
+    }
+    fs::write(
+        dir.path().join("local.properties"),
+        format!("sdk.dir={}\n", fake_sdk.display()),
+    )
+    .unwrap();
+
+    let paths = detect_android_sdk_jar_path(dir.path());
+    assert_eq!(paths.len(), 1);
+    assert!(
+        paths[0].ends_with("android-37.0/android.jar")
+            || paths[0].ends_with("android-37.0\\android.jar")
+    );
+}
+
+#[test]
+fn source_paths_handles_extension_level_directory_names() {
+    // Regression guard for the shared version-comparison helper: the
+    // pre-existing source-path detector must also correctly rank a decimal
+    // extension-level directory as higher than a plain-integer one.
+    let dir = TempDir::new().unwrap();
+    let fake_sdk = dir.path().join("sdk");
+    for api in ["android-36", "android-36.1"] {
+        fs::create_dir_all(fake_sdk.join("sources").join(api)).unwrap();
+    }
+    fs::write(
+        dir.path().join("local.properties"),
+        format!("sdk.dir={}\n", fake_sdk.display()),
+    )
+    .unwrap();
+
+    let paths = detect_android_sdk_source_paths(dir.path());
+    assert_eq!(paths.len(), 1);
+    assert!(paths[0].ends_with("android-36.1"));
+}
+
 // ─── jarPaths ─────────────────────────────────────────────────────────────────
 
 #[test]

--- a/src/workspace_json_tests.rs
+++ b/src/workspace_json_tests.rs
@@ -443,6 +443,37 @@ fn source_paths_handles_extension_level_directory_names() {
     assert!(paths[0].ends_with("android-36.1"));
 }
 
+#[test]
+fn jar_path_handles_extension_platform_directory_names() {
+    // Real Android SDK installs can also have Extension platform directories
+    // named `android-<major>-ext<N>` (e.g. `android-36-ext14`) alongside a
+    // plain `android-<major>` base directory — a different naming scheme
+    // from the decimal-minor one above. Both must be recognized, and the
+    // extension directory (additive to its base level) must outrank the
+    // plain base of the same major version.
+    let dir = TempDir::new().unwrap();
+    let fake_sdk = dir.path().join("sdk");
+    for api in ["android-36", "android-36-ext14"] {
+        let platform_dir = fake_sdk.join("platforms").join(api);
+        fs::create_dir_all(&platform_dir).unwrap();
+        fs::write(platform_dir.join("android.jar"), b"fake jar").unwrap();
+    }
+    fs::write(
+        dir.path().join("local.properties"),
+        format!("sdk.dir={}\n", fake_sdk.display()),
+    )
+    .unwrap();
+
+    let paths = detect_android_sdk_jar_path(dir.path());
+    assert_eq!(paths.len(), 1);
+    assert!(
+        paths[0].ends_with("android-36-ext14/android.jar")
+            || paths[0].ends_with("android-36-ext14\\android.jar"),
+        "expected the extension-level directory to outrank the plain base, got: {:?}",
+        paths[0]
+    );
+}
+
 // ─── jarPaths ─────────────────────────────────────────────────────────────────
 
 #[test]

--- a/tests/cli_diagnose.rs
+++ b/tests/cli_diagnose.rs
@@ -82,7 +82,7 @@ fn diagnose_only(root: &Path, rel_path: &str, only: &str) -> std::process::Outpu
 /// environment, exactly like `GRADLE_USER_HOME`/`XDG_CACHE_HOME` are
 /// overridden — otherwise a real host SDK leaks into every `diagnose` test.
 #[test]
-fn build_diagnose_command_isolates_the_host_android_sdk() {
+fn diagnose_cli_process_isolates_the_host_android_sdk() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
     let file = root.join("src/Foo.kt");

--- a/tests/cli_diagnose.rs
+++ b/tests/cli_diagnose.rs
@@ -19,22 +19,38 @@ fn write_fixture(dir: &Path, rel_path: &str, content: &str) {
     std::fs::write(&full, content).unwrap();
 }
 
-/// Run `kmp-lsp diagnose --root <root> <file>` and return stdout lines.
+/// Build the `kmp-lsp diagnose --root <root> <file>` `Command`, isolated
+/// from the host's real Gradle cache AND real Android SDK.
 ///
 /// The spawned CLI is HERMETIC: `GRADLE_USER_HOME` and `XDG_CACHE_HOME` point
 /// into the fixture root, so `diagnose`'s Gradle-JAR pass (which resolves
 /// `jar_phase` to a terminal state — required for semantic diagnostics to run
 /// at all) never scans the developer's real multi-hundred-JAR cache. Without
 /// this, each test paid seconds of real-cache indexing on a dev machine and
-/// asserted against environment-dependent jar symbols.
-fn diagnose(root: &Path, rel_path: &str) -> Vec<String> {
-    let file = root.join(rel_path);
-    let out = Command::new(BIN)
-        .args(["diagnose", "--root"])
+/// asserted against environment-dependent jar symbols. `ANDROID_HOME`/
+/// `ANDROID_SDK_ROOT` are removed for the identical reason `lsp_smoke.rs`
+/// removes them from its spawned server: `diagnose` now also wires in
+/// `detect_android_sdk_jar_path` (CLI paths gained the same Android-SDK-jar
+/// detection the LSP server path already had), so a real host SDK would
+/// turn every parallel `diagnose` test process into a redundant,
+/// CPU-contended JAR-manifest pass — the same class of bug that caused a
+/// real CI timeout for `lsp_smoke.rs` before it gained this isolation.
+fn build_diagnose_command(root: &Path, file: &Path) -> Command {
+    let mut cmd = Command::new(BIN);
+    cmd.args(["diagnose", "--root"])
         .arg(root)
-        .arg(&file)
+        .arg(file)
         .env("GRADLE_USER_HOME", root.join(".isolated-gradle"))
         .env("XDG_CACHE_HOME", root.join(".isolated-cache"))
+        .env_remove("ANDROID_HOME")
+        .env_remove("ANDROID_SDK_ROOT");
+    cmd
+}
+
+/// Run `kmp-lsp diagnose --root <root> <file>` and return stdout lines.
+fn diagnose(root: &Path, rel_path: &str) -> Vec<String> {
+    let file = root.join(rel_path);
+    let out = build_diagnose_command(root, &file)
         .output()
         .expect("failed to spawn kmp-lsp");
     assert!(
@@ -55,15 +71,34 @@ fn diagnose(root: &Path, rel_path: &str) -> Vec<String> {
 /// also assert on exit status / stderr for the invalid-name error case.
 fn diagnose_only(root: &Path, rel_path: &str, only: &str) -> std::process::Output {
     let file = root.join(rel_path);
-    Command::new(BIN)
-        .args(["diagnose", "--root"])
-        .arg(root)
-        .arg(&file)
+    build_diagnose_command(root, &file)
         .args(["--only", only])
-        .env("GRADLE_USER_HOME", root.join(".isolated-gradle"))
-        .env("XDG_CACHE_HOME", root.join(".isolated-cache"))
         .output()
         .expect("failed to spawn kmp-lsp")
+}
+
+/// Regression test for the isolation gap itself: `build_diagnose_command`
+/// must remove `ANDROID_HOME`/`ANDROID_SDK_ROOT` from the spawned process's
+/// environment, exactly like `GRADLE_USER_HOME`/`XDG_CACHE_HOME` are
+/// overridden — otherwise a real host SDK leaks into every `diagnose` test.
+#[test]
+fn build_diagnose_command_isolates_the_host_android_sdk() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let file = root.join("src/Foo.kt");
+    let cmd = build_diagnose_command(root, &file);
+
+    let envs: std::collections::HashMap<_, _> = cmd.get_envs().collect();
+    assert_eq!(
+        envs.get(std::ffi::OsStr::new("ANDROID_HOME")),
+        Some(&None),
+        "ANDROID_HOME must be explicitly removed from the spawned process's environment"
+    );
+    assert_eq!(
+        envs.get(std::ffi::OsStr::new("ANDROID_SDK_ROOT")),
+        Some(&None),
+        "ANDROID_SDK_ROOT must be explicitly removed from the spawned process's environment"
+    );
 }
 
 // ── --only filtering ─────────────────────────────────────────────────────────
@@ -566,10 +601,7 @@ fn syntax_error_reported_by_diagnose() {
     write_fixture(root, "workspace.json", r#"{"sourcePaths":[]}"#);
     write_fixture(root, "src/Bad.kt", "class Foo {\n    fun bar() {\n");
     let file = root.join("src/Bad.kt");
-    let out = Command::new(BIN)
-        .args(["diagnose", "--root"])
-        .arg(root)
-        .arg(&file)
+    let out = build_diagnose_command(root, &file)
         .output()
         .expect("failed to spawn kmp-lsp");
     let stdout = String::from_utf8_lossy(&out.stdout);

--- a/tests/lsp_smoke.rs
+++ b/tests/lsp_smoke.rs
@@ -70,6 +70,13 @@ impl LspClient {
             .args(["--stdio"])
             .env("KMP_LSP_WORKSPACE_ROOT", &canonical)
             .env("GRADLE_USER_HOME", &empty_gradle_home)
+            // Remove the real Android SDK from view for the same reason
+            // GRADLE_USER_HOME is isolated above: a real android.jar on the
+            // host turned every parallel smoke-test process into a
+            // redundant, CPU-contended JAR-manifest pass, timing these tests
+            // out on CI runners that ship a pre-installed SDK.
+            .env_remove("ANDROID_HOME")
+            .env_remove("ANDROID_SDK_ROOT")
             .current_dir(&canonical)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())


### PR DESCRIPTION
## Summary
- Fixes resolution of Kotlin **member extension functions** — a function with its own extension receiver declared as a *member* of an enclosing interface (e.g. Compose's `interface ColumnScope { fun Modifier.weight(...): Modifier }`). Real call sites (`Modifier.weight(1f)` inside a `Column { ... }` block) never import `weight` — Kotlin has no import syntax for a member of an interface — but `extension_is_in_scope` was unconditionally applying the ordinary top-level-extension import/package visibility rule, rejecting every real-world call site.
- Threads `container: Option<String>` through `ExtensionEntry` (already extracted onto `SymbolEntry`/sidecar symbols, just dropped in transit at all 3 construction sites) and adds a container-aware short-circuit to `extension_is_in_scope`: a member extension is always in scope (this codebase doesn't track live implicit-receiver scope in the string domain by design — see the linked design doc for why the alternative, CST-consulting fix would violate this repo's established `resolver`/`indexer::infer` domain boundary).
- **Found and fixed a second, deeper root cause the design doc missed**: `push_def_symbols` only ran extension-receiver extraction for `SymbolKind::FUNCTION`, but a member function nested in a class/interface body is classified `METHOD` — so a member extension's receiver was never extracted in the first place, independent of the container-plumbing fix above. Broadened the gate to include `METHOD`.
- Traced the design doc's flagged "shared-predicate blast radius" risk (this fix touches `extension_is_in_scope`, consulted by every extension-function lookup including the call-arg diagnostics path) and closed it with a real test rather than leaving it as a documented gap: `resolve_call_signature`'s own `receiver_matches` predicate is entirely separate and already excludes member extensions unconditionally, so this fix cannot regress arg-count diagnostics — verified by toggling the short-circuit off and confirming an identical (empty) diagnostic result.

## Verified impact (real 13,242-file corpus, stacked on Primitive B)
- `weight`/`align` (351 combined Gap occurrences before this fix) disappear entirely from the top-20 offenders after.
- `CstResolved` count rises by 842 on top of Primitive B's baseline.

## Design doc
`docs/superpowers/specs/2026-08-24-android-sdk-and-compose-scope-gap-remediation-design.md`

## Test plan
- [x] `cargo test --bin kmp-lsp` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] RED/GREEN TDD: member-extension resolution, ordinary-top-level-extension regression guard (the highest-value test here, since this predicate is shared by every extension lookup in the codebase), same-name-collision documentation test, call-arg diagnostics blast-radius test
- [x] Re-measured against the real Moneta corpus after landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ