### PR TITLE
fix(resolve): ambiguity-safe hierarchy-walk tail with com.android.internal denylist

### DIFF
--- a/src/cli/extract_sources.rs
+++ b/src/cli/extract_sources.rs
@@ -41,6 +41,7 @@ pub(crate) fn version_key(version: &str) -> Vec<VersionPart> {
 
 // ── Gradle cache path parsing ─────────────────────────────────────────────────
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub(crate) struct GradleMeta {
     pub(crate) group: String,
     pub(crate) artifact: String,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -185,7 +185,9 @@ async fn build_index_inner(root: &Path, source_paths: Vec<String>) -> Arc<Indexe
     // real `workspace.json` module data is present.
     let module_dependencies = crate::workspace_json::load_module_dependencies(root);
     if !module_dependencies.is_empty() {
-        *idx.module_dependencies.write().unwrap() = module_dependencies;
+        *idx.module_dependencies
+            .write()
+            .unwrap_or_else(|e| e.into_inner()) = module_dependencies;
     }
     Arc::clone(&idx)
         .index_workspace_full(&canonical, Arc::new(NoopReporter))

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -172,7 +172,10 @@ async fn build_index_inner(root: &Path, source_paths: Vec<String>) -> Arc<Indexe
     }
     // Populate workspace source roots from workspace.json so resolver/infer rg fallbacks
     // are scoped when the CLI is run in a project with configured module sourceRoots.
-    let workspace_roots: Vec<String> = crate::workspace_json::load_source_paths(root)
+    // Uses `canonical`, not `root`: `<WORKSPACE>` substitution must produce absolute
+    // paths so later `starts_with` checks against absolute `file://` URIs actually match
+    // when the CLI is invoked with a relative root (e.g. `.`).
+    let workspace_roots: Vec<String> = crate::workspace_json::load_source_paths(&canonical)
         .into_iter()
         .map(|p| p.to_string_lossy().into_owned())
         .collect();
@@ -182,8 +185,9 @@ async fn build_index_inner(root: &Path, source_paths: Vec<String>) -> Arc<Indexe
     // Per-module real Gradle dependency data, for the hierarchy-walk
     // ambiguity-safe tail's module-scoped narrowing (see
     // `resolver::resolve::ambiguity_safe_tail_with_denylist`). Empty when no
-    // real `workspace.json` module data is present.
-    let module_dependencies = crate::workspace_json::load_module_dependencies(root);
+    // real `workspace.json` module data is present. Also uses `canonical` for
+    // the same reason as `load_source_paths` above.
+    let module_dependencies = crate::workspace_json::load_module_dependencies(&canonical);
     if !module_dependencies.is_empty() {
         *idx.module_dependencies
             .write()

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -179,6 +179,14 @@ async fn build_index_inner(root: &Path, source_paths: Vec<String>) -> Arc<Indexe
     if !workspace_roots.is_empty() {
         *idx.workspace_source_roots.write().unwrap() = workspace_roots;
     }
+    // Per-module real Gradle dependency data, for the hierarchy-walk
+    // ambiguity-safe tail's module-scoped narrowing (see
+    // `resolver::resolve::ambiguity_safe_tail_with_denylist`). Empty when no
+    // real `workspace.json` module data is present.
+    let module_dependencies = crate::workspace_json::load_module_dependencies(root);
+    if !module_dependencies.is_empty() {
+        *idx.module_dependencies.write().unwrap() = module_dependencies;
+    }
     Arc::clone(&idx)
         .index_workspace_full(&canonical, Arc::new(NoopReporter))
         .await;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -277,6 +277,16 @@ pub(crate) struct Indexer {
     /// search-scope restriction. Auto-detected build-layout paths, Android SDK sources,
     /// and ~/.kmp-lsp/sources are also excluded.
     pub(crate) workspace_source_roots: RwLock<Vec<String>>,
+    /// Per-module real Gradle dependency sets, keyed by each module's own
+    /// content-root directory (see `workspace_json::load_module_dependencies`).
+    /// Used only to narrow an ambiguous hierarchy-walk candidate set to the
+    /// calling file's own module's actual dependencies — empty (no narrowing
+    /// available) whenever no real `workspace.json` is present. Written once
+    /// per workspace-scan by [`crate::workspace::Actor`]; read-paths elsewhere
+    /// (`resolver::resolve::ambiguity_safe_tail_with_denylist`) observe it.
+    pub(crate) module_dependencies: RwLock<
+        HashMap<PathBuf, std::collections::HashSet<crate::cli::extract_sources::GradleMeta>>,
+    >,
     /// URIs of files indexed from `sourcePaths` that lie outside the workspace root.
     /// These are treated as library sources: available for hover/definition/autocomplete
     /// but excluded from findReferences and rename.
@@ -747,6 +757,7 @@ impl Indexer {
             ignore_matcher: RwLock::new(None),
             source_paths_raw: RwLock::new(Vec::new()),
             workspace_source_roots: RwLock::new(Vec::new()),
+            module_dependencies: RwLock::new(HashMap::new()),
             library_uris: DashSet::new(),
             extracted_jar_sources: DashMap::new(),
             importable_fqns: std::sync::RwLock::new(std::collections::HashMap::new()),

--- a/src/path_util.rs
+++ b/src/path_util.rs
@@ -115,6 +115,42 @@ pub(crate) fn file_stem_from_uri(uri: &Url) -> Option<String> {
     }
 }
 
+/// Convert a `file://` URL to a `PathBuf`, robust to Windows's drive-letter
+/// requirement in `Url::to_file_path()` (see `file_stem_from_uri`'s doc
+/// comment above for the same requirement). Prefers `to_file_path()`, which
+/// percent-decodes correctly; falls back to building the path directly from
+/// the URL's raw path string when `to_file_path()` rejects the URI, which
+/// happens on Windows for any `file://` URI whose first path segment isn't
+/// a drive letter (a shape this codebase's own test fixtures use throughout).
+pub(crate) fn path_from_uri(uri: &Url) -> Option<PathBuf> {
+    if let Ok(path) = uri.to_file_path() {
+        return Some(path);
+    }
+    // The fallback only makes sense for a genuine `file://` URI whose path
+    // segments `to_file_path()` rejected over the drive-letter check; a
+    // `jar:`-scheme URI (or any other opaque, cannot-be-a-base URI) has no
+    // filesystem path at all, so it must still resolve to `None` here, not
+    // to a bogus `PathBuf` built from its opaque scheme-specific data.
+    if uri.scheme() != "file" || uri.cannot_be_a_base() {
+        return None;
+    }
+    path_from_url_path_string(uri.path())
+}
+
+/// Builds a `PathBuf` directly from a URL path string (e.g. `/t/app/Bar.kt`).
+/// `Path`'s component parser treats `/` as a separator on every platform,
+/// Windows included, so the result still compares correctly with
+/// `Path::starts_with` against a root built the same way. Does not
+/// percent-decode, the same limitation `file_stem_from_uri`'s fallback
+/// already accepts.
+fn path_from_url_path_string(path: &str) -> Option<PathBuf> {
+    if path.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(path))
+    }
+}
+
 #[cfg(test)]
 #[path = "path_util_tests.rs"]
 mod tests;

--- a/src/path_util_tests.rs
+++ b/src/path_util_tests.rs
@@ -77,3 +77,49 @@ fn stem_multiple_dots() {
     // `rfind('.')` so only the last extension is stripped.
     assert_eq!(file_stem_from_uri(&u).as_deref(), Some("Foo.bar"));
 }
+
+#[test]
+fn path_from_uri_drive_letter_uri_resolves_the_full_path() {
+    let uri = Url::parse("file:///C:/pkg/Foo.kt").unwrap();
+    let path = path_from_uri(&uri).unwrap();
+    assert_eq!(path.file_name().unwrap(), "Foo.kt");
+}
+
+#[test]
+fn path_from_uri_no_drive_letter_uri_still_resolves_a_matching_path() {
+    // No drive letter — `Url::to_file_path()` rejects this on Windows (see
+    // this module's own doc comment), so `path_from_uri` must fall back to
+    // building the `PathBuf` from the URL's raw path string instead.
+    let uri = Url::parse("file:///t/app/Bar.kt").unwrap();
+    let path = path_from_uri(&uri).unwrap();
+    let content_root = PathBuf::from("/t/app");
+    assert!(
+        path.starts_with(&content_root),
+        "expected {path:?} to start with {content_root:?}"
+    );
+}
+
+#[test]
+fn path_from_url_path_string_builds_a_path_that_starts_with_its_own_prefix() {
+    // Exercises the Windows-only fallback branch directly, since
+    // `Url::to_file_path()` never fails for an absolute-looking URI on Unix
+    // (there is no drive-letter requirement there), so `path_from_uri`
+    // itself can't reach this branch in a Linux test run.
+    let path = path_from_url_path_string("/t/app/Bar.kt").unwrap();
+    assert!(path.starts_with(PathBuf::from("/t/app")));
+    assert_eq!(path.file_name().unwrap(), "Bar.kt");
+}
+
+#[test]
+fn path_from_url_path_string_rejects_an_empty_path() {
+    assert_eq!(path_from_url_path_string(""), None);
+}
+
+#[test]
+fn path_from_uri_rejects_a_jar_scheme_uri() {
+    // A `jar:file://...` URI is opaque (cannot-be-a-base) and has no
+    // filesystem path of its own; the drive-letter fallback must not
+    // mistake its opaque data for a real path.
+    let uri = Url::parse("jar:file:///home/user/x.jar").unwrap();
+    assert_eq!(path_from_uri(&uri), None);
+}

--- a/src/resolver/hierarchy.rs
+++ b/src/resolver/hierarchy.rs
@@ -36,7 +36,7 @@ pub(crate) const MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK: usize = 3;
 pub(crate) fn walk_hierarchy<'a, T, F>(
     idx: &'a Indexer,
     start_class: &str,
-    start_uri: &str,
+    start_uri: &'a str,
     caller: CallerContext<'a>,
     max_depth: usize,
     sidecar_budget: usize,
@@ -45,6 +45,16 @@ pub(crate) fn walk_hierarchy<'a, T, F>(
 where
     F: Fn(&Indexer, &str, &str, CallerContext<'_>) -> Vec<T>,
 {
+    // The walk's own unchanging origin, for module-scoped ambiguity narrowing
+    // (`module_scoped_tie_break`) — prefer `caller.uri`, which most callers
+    // already populate with the real editing file for an unrelated purpose
+    // (see e.g. `find_field_type_via_class_hierarchy`), and fall back to
+    // `start_uri`, which equals the real editing file at every remaining
+    // call site that leaves `caller` at its default. Threaded unchanged
+    // through every recursive hop below — never updated to a hop's own
+    // resolved URI — because past hop 1 that per-hop URI is frequently a
+    // `jar:` synthetic URI with no owning module of its own.
+    let origin_uri = caller.uri.unwrap_or(start_uri);
     let mut walker = HierarchyWalker {
         idx,
         caller,
@@ -53,6 +63,7 @@ where
         visited: HashSet::from([(start_uri.to_owned(), start_class.to_owned())]),
         items: Vec::new(),
         sidecar_budget,
+        origin_uri,
     };
     walker.recurse(start_class, start_uri, 0);
     walker.items
@@ -71,6 +82,10 @@ where
     /// Remaining blocking-IPC promotion attempts for THIS walk (see
     /// [`MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK`]).
     sidecar_budget: usize,
+    /// The real file this walk started from — unchanging across every hop,
+    /// unlike the per-hop `class_uri` that `recurse` walks with. See
+    /// [`walk_hierarchy`]'s doc comment for how it's derived.
+    origin_uri: &'a str,
 }
 
 impl<'a, T, F> HierarchyWalker<'a, T, F>
@@ -82,9 +97,13 @@ where
             return;
         }
 
-        for (super_name, super_uri) in
-            supertype_targets(self.idx, class_name, class_uri, &mut self.sidecar_budget)
-        {
+        for (super_name, super_uri) in supertype_targets(
+            self.idx,
+            class_name,
+            class_uri,
+            &mut self.sidecar_budget,
+            self.origin_uri,
+        ) {
             if !self.visited.insert((super_uri.clone(), super_name.clone())) {
                 continue;
             }
@@ -104,6 +123,7 @@ fn supertype_targets(
     class_name: &str,
     class_uri: &str,
     sidecar_budget: &mut usize,
+    origin_uri: &str,
 ) -> Vec<(String, String)> {
     use tower_lsp::lsp_types::Url;
     let Ok(uri) = Url::parse(class_uri) else {
@@ -112,6 +132,9 @@ fn supertype_targets(
     let Some(file_data) = super::ensure_file_data(idx, &uri) else {
         return vec![];
     };
+    // Parsed once per hop, not required to succeed: a bad `origin_uri` only
+    // costs the module-scoped tie-break below, never the rest of this walk.
+    let origin_url = Url::parse(origin_uri).ok();
 
     super_names_for_class(&file_data, class_name)
         .into_iter()
@@ -132,10 +155,18 @@ fn supertype_targets(
             // to disambiguate a same-named collision against (compiled JARs carry
             // no import statements) -- see the hierarchy-walk-unscoped-name-
             // collision design doc. Scoped to this one call site; the other seven
-            // `resolve_symbol_no_rg` callers are unaffected.
-            super::resolve_symbol_hierarchy_ambiguity_safe(idx, &super_name, &uri)
-                .into_iter()
-                .map(move |loc| (super_name.clone(), loc.uri.to_string()))
+            // `resolve_symbol_no_rg` callers are unaffected. `origin_url` (the
+            // walk's real starting file, not this hop's `uri`) is passed
+            // separately so the module-scoped tie-break can still find real
+            // Gradle dependency data past hop 1.
+            super::resolve_symbol_hierarchy_ambiguity_safe(
+                idx,
+                &super_name,
+                &uri,
+                origin_url.as_ref(),
+            )
+            .into_iter()
+            .map(move |loc| (super_name.clone(), loc.uri.to_string()))
         })
         .collect()
 }

--- a/src/resolver/hierarchy.rs
+++ b/src/resolver/hierarchy.rs
@@ -127,7 +127,13 @@ fn supertype_targets(
             // (`class X : com.lib.Base()`) — the accessor handles the
             // bare-leaf fallback.
             crate::indexer::jar::ensure_jar_definitions_for(idx, &super_name, sidecar_budget);
-            super::resolve_symbol_no_rg(idx, &super_name, &uri)
+            // Ambiguity-safe, not `resolve_symbol_no_rg`'s raw first-match tail: at
+            // hop 2+ `uri` is frequently a `jar:` synthetic URI with no import list
+            // to disambiguate a same-named collision against (compiled JARs carry
+            // no import statements) -- see the hierarchy-walk-unscoped-name-
+            // collision design doc. Scoped to this one call site; the other seven
+            // `resolve_symbol_no_rg` callers are unaffected.
+            super::resolve_symbol_hierarchy_ambiguity_safe(idx, &super_name, &uri)
                 .into_iter()
                 .map(move |loc| (super_name.clone(), loc.uri.to_string()))
         })

--- a/src/resolver/hierarchy_tests.rs
+++ b/src/resolver/hierarchy_tests.rs
@@ -1,8 +1,9 @@
 use super::{
-    receiver_type_agreement, supertype_chain_contains, ReceiverTypeAgreement,
-    MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
+    receiver_type_agreement, supertype_chain_contains, supertype_targets, walk_hierarchy,
+    ReceiverTypeAgreement, MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
 };
 use crate::indexer::Indexer;
+use crate::types::CallerContext;
 use tower_lsp::lsp_types::Url;
 
 fn uri(path: &str) -> Url {
@@ -109,5 +110,165 @@ fn transitive_supertype_is_inherited() {
             MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK
         ),
         ReceiverTypeAgreement::Inherited
+    );
+}
+
+// ─── Primitive 1: ambiguity-safe hierarchy-walk tail ───────────────────────
+
+/// An unscoped tail lookup that finds two same-named, non-denylisted
+/// candidates must decline rather than pick one arbitrarily. Pre-fix, this
+/// picked whichever candidate the index happened to insert first
+/// (`resolve_symbol_no_rg`'s raw first-match tail); post-fix it returns no
+/// supertype target for this hop at all.
+#[test]
+fn ambiguous_same_name_supertype_declines_instead_of_guessing() {
+    let indexer = Indexer::new();
+    // Two unrelated classes both named `Activity`, indexed before the class
+    // whose supertype walk will collide on that bare name — insertion order
+    // is exactly what the old first-match tail picked from.
+    indexer.index_content(
+        &uri("/decoy/Activity.kt"),
+        "package com.example.decoy\nclass Activity\n",
+    );
+    indexer.index_content(
+        &uri("/real/Activity.kt"),
+        "package com.example.real\nclass Activity\n",
+    );
+    // `Bar`'s own file has no import for `Activity`, so resolving its
+    // supertype falls all the way through to the ambiguous tail.
+    let bar_uri = uri("/app/Bar.kt");
+    indexer.index_content(&bar_uri, "class Bar : Activity()\n");
+
+    let mut budget = MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK;
+    let targets = supertype_targets(&indexer, "Bar", bar_uri.as_str(), &mut budget);
+    assert!(
+        targets.is_empty(),
+        "expected the ambiguous tail to decline, got {targets:?}"
+    );
+}
+
+// ─── Primitive 3: narrow com.android.internal.* denylist tie-break ────────
+
+/// The one evidenced denylist entry: a `com.android.internal.*` candidate
+/// is dropped from an otherwise-ambiguous 2-way tie, leaving the other
+/// candidate as the unique (and therefore usable) match.
+#[test]
+fn denylisted_package_candidate_is_deprioritized_in_favor_of_the_other() {
+    let indexer = Indexer::new();
+    // The denylisted decoy is indexed first, matching the real repro's
+    // insertion order — a naive first-match tail would have picked it.
+    indexer.index_content(
+        &uri("/internal/Activity.kt"),
+        "package com.android.internal.telephony\nclass Activity\n",
+    );
+    indexer.index_content(
+        &uri("/android/Activity.kt"),
+        "package android.app\nclass Activity\n",
+    );
+    let bar_uri = uri("/app/Bar.kt");
+    indexer.index_content(&bar_uri, "class Bar : Activity()\n");
+
+    let mut budget = MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK;
+    let targets = supertype_targets(&indexer, "Bar", bar_uri.as_str(), &mut budget);
+    assert_eq!(
+        targets.len(),
+        1,
+        "expected exactly one target, got {targets:?}"
+    );
+    assert_eq!(targets[0].0, "Activity");
+    assert!(
+        targets[0].1.ends_with("/android/Activity.kt"),
+        "expected the non-denylisted android.app.Activity, got {targets:?}"
+    );
+}
+
+/// Regression guard: a package prefix that is NOT on the denylist must
+/// never be deprioritized, even when it ties with another candidate — this
+/// guards against the denylist silently growing into a broad preference
+/// system (see the design doc's self-critique).
+#[test]
+fn unlisted_package_prefix_is_never_deprioritized() {
+    let indexer = Indexer::new();
+    // Neither candidate matches the denylist — both are equally
+    // legitimate-looking third-party packages. The tie-break must not
+    // invent a preference between them.
+    indexer.index_content(
+        &uri("/vendor1/Activity.kt"),
+        "package com.vendor.one\nclass Activity\n",
+    );
+    indexer.index_content(
+        &uri("/vendor2/Activity.kt"),
+        "package com.vendor.two\nclass Activity\n",
+    );
+    let bar_uri = uri("/app/Bar.kt");
+    indexer.index_content(&bar_uri, "class Bar : Activity()\n");
+
+    let mut budget = MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK;
+    let targets = supertype_targets(&indexer, "Bar", bar_uri.as_str(), &mut budget);
+    assert!(
+        targets.is_empty(),
+        "expected still-ambiguous decline (no denylist match), got {targets:?}"
+    );
+}
+
+// ─── Acceptance: combined 4-hop walk with a denylisted decoy at the tail ──
+
+/// Synthetic reproduction of the real Moneta corpus shape (`AppCompatActivity
+/// → FragmentActivity → ComponentActivity → Activity`) with a deliberate
+/// `com.android.internal.*` decoy at the last hop, standing in for the real
+/// `DctConstants.Activity` collision. Does not depend on a real corpus or a
+/// live Gradle cache.
+#[test]
+fn four_hop_walk_reaches_the_real_ancestor_past_a_denylisted_decoy() {
+    let indexer = Indexer::new();
+    let call_us_uri = uri("/app/CallUsActivity.kt");
+    indexer.index_content(
+        &call_us_uri,
+        "package com.example.app\nclass CallUsActivity : AppCompatActivity()\n",
+    );
+    indexer.index_content(
+        &uri("/appcompat/AppCompatActivity.kt"),
+        "package androidx.appcompat.app\nclass AppCompatActivity : FragmentActivity()\n",
+    );
+    indexer.index_content(
+        &uri("/fragment/FragmentActivity.kt"),
+        "package androidx.fragment.app\nclass FragmentActivity : ComponentActivity()\n",
+    );
+    indexer.index_content(
+        &uri("/core/ComponentActivity.kt"),
+        "package androidx.core.app\nclass ComponentActivity : Activity()\n",
+    );
+    // Decoy indexed first, matching the real repro's insertion order.
+    indexer.index_content(
+        &uri("/internal/Activity.kt"),
+        "package com.android.internal.telephony\nclass Activity\n",
+    );
+    indexer.index_content(
+        &uri("/android/Activity.kt"),
+        "package android.app\nclass Activity\n",
+    );
+
+    let items = walk_hierarchy(
+        &indexer,
+        "CallUsActivity",
+        call_us_uri.as_str(),
+        CallerContext::default(),
+        12,
+        MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
+        |_, super_name, super_uri, _| vec![(super_name.to_string(), super_uri.to_string())],
+    );
+
+    assert!(
+        items
+            .iter()
+            .any(|(name, target_uri)| name == "Activity"
+                && target_uri.ends_with("/android/Activity.kt")),
+        "expected the walk to reach android.app.Activity, got {items:?}"
+    );
+    assert!(
+        !items
+            .iter()
+            .any(|(name, target_uri)| name == "Activity" && target_uri.contains("/internal/")),
+        "must never resolve to the com.android.internal decoy, got {items:?}"
     );
 }

--- a/src/resolver/hierarchy_tests.rs
+++ b/src/resolver/hierarchy_tests.rs
@@ -4,9 +4,10 @@ use super::{
 };
 use crate::cli::extract_sources::GradleMeta;
 use crate::indexer::Indexer;
-use crate::types::CallerContext;
+use crate::types::{CallerContext, FileData};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::Arc;
 use tower_lsp::lsp_types::{Location, Url};
 
 fn uri(path: &str) -> Url {
@@ -143,7 +144,13 @@ fn ambiguous_same_name_supertype_declines_instead_of_guessing() {
     indexer.index_content(&bar_uri, "class Bar : Activity()\n");
 
     let mut budget = MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK;
-    let targets = supertype_targets(&indexer, "Bar", bar_uri.as_str(), &mut budget);
+    let targets = supertype_targets(
+        &indexer,
+        "Bar",
+        bar_uri.as_str(),
+        &mut budget,
+        bar_uri.as_str(),
+    );
     assert!(
         targets.is_empty(),
         "expected the ambiguous tail to decline, got {targets:?}"
@@ -172,7 +179,13 @@ fn denylisted_package_candidate_is_deprioritized_in_favor_of_the_other() {
     indexer.index_content(&bar_uri, "class Bar : Activity()\n");
 
     let mut budget = MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK;
-    let targets = supertype_targets(&indexer, "Bar", bar_uri.as_str(), &mut budget);
+    let targets = supertype_targets(
+        &indexer,
+        "Bar",
+        bar_uri.as_str(),
+        &mut budget,
+        bar_uri.as_str(),
+    );
     assert_eq!(
         targets.len(),
         1,
@@ -207,7 +220,13 @@ fn unlisted_package_prefix_is_never_deprioritized() {
     indexer.index_content(&bar_uri, "class Bar : Activity()\n");
 
     let mut budget = MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK;
-    let targets = supertype_targets(&indexer, "Bar", bar_uri.as_str(), &mut budget);
+    let targets = supertype_targets(
+        &indexer,
+        "Bar",
+        bar_uri.as_str(),
+        &mut budget,
+        bar_uri.as_str(),
+    );
     assert!(
         targets.is_empty(),
         "expected still-ambiguous decline (no denylist match), got {targets:?}"
@@ -339,7 +358,13 @@ fn module_scoped_tie_break_narrows_jar_collision_to_the_calling_modules_dependen
     indexer.index_content(&bar_uri, "class Bar : Activity()\n");
 
     let mut budget = MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK;
-    let targets = supertype_targets(&indexer, "Bar", bar_uri.as_str(), &mut budget);
+    let targets = supertype_targets(
+        &indexer,
+        "Bar",
+        bar_uri.as_str(),
+        &mut budget,
+        bar_uri.as_str(),
+    );
     assert_eq!(
         targets,
         vec![("Activity".to_owned(), real_jar_uri.to_string())],
@@ -378,10 +403,139 @@ fn no_module_dependency_data_still_declines_on_jar_collision() {
     indexer.index_content(&bar_uri, "class Bar : Activity()\n");
 
     let mut budget = MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK;
-    let targets = supertype_targets(&indexer, "Bar", bar_uri.as_str(), &mut budget);
+    let targets = supertype_targets(
+        &indexer,
+        "Bar",
+        bar_uri.as_str(),
+        &mut budget,
+        bar_uri.as_str(),
+    );
     assert!(
         targets.is_empty(),
         "expected the ambiguous tail to still decline with no module \
          dependency data available, got {targets:?}"
+    );
+}
+
+// ─── Module-scoped narrowing must reach a hop-4 collision, not just hop 1 ──
+//
+// Regression guard for the wiring bug found on PR #286: beyond hop 1 of a
+// hierarchy walk, the per-hop `class_uri`/`from_uri` a candidate is resolved
+// from is the PREVIOUS hop's own resolved location — a `jar:` URI once any
+// ancestor lives in a compiled JAR, which `owning_module_dependencies` can
+// never map to a module. Unlike the test above (which resolves every hop via
+// `indexer.index_content`, so every `class_uri` stays a real `file://` URI
+// the whole way and never actually exercises the jar: case), this test makes
+// hops 1-3 JAR-backed so hop 4 — where the real collision lives — is reached
+// with a `jar:` `class_uri`, and only the calling file at hop 0 has a real
+// `file://` URI.
+
+/// Minimal jar-backed `FileData`: `symbols` stays empty, so
+/// `super_names_for_class`'s class-name lookup misses and it falls back to
+/// returning every entry in `supers` — exactly what a single-super JAR entry
+/// needs here, without hand-building a full symbol table.
+fn jar_backed_file_data(super_name: &str) -> FileData {
+    FileData {
+        supers: vec![(0, super_name.to_owned(), Vec::new())],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn module_scoped_tie_break_narrows_a_hop_four_jar_collision_using_the_walks_real_origin() {
+    let indexer = Indexer::new();
+    let call_us_uri = uri("/app/CallUsActivity.kt");
+    indexer.index_content(
+        &call_us_uri,
+        "package com.example.app\nclass CallUsActivity : AppCompatActivity()\n",
+    );
+
+    let appcompat_uri = gradle_cache_jar_uri("androidx.appcompat", "appcompat", "1.6.1");
+    let fragment_uri = gradle_cache_jar_uri("androidx.fragment", "fragment", "1.6.1");
+    let component_uri = gradle_cache_jar_uri("androidx.activity", "activity", "1.7.0");
+    let decoy_activity_uri = gradle_cache_jar_uri("com.example.decoy", "decoy-lib", "1.0.0");
+    let real_activity_uri = gradle_cache_jar_uri("android", "android-stubs", "34.0.0");
+
+    indexer.jar_definitions.insert(
+        "AppCompatActivity".to_owned(),
+        vec![Location {
+            uri: appcompat_uri.clone(),
+            range: Default::default(),
+        }],
+    );
+    indexer.jar_definitions.insert(
+        "FragmentActivity".to_owned(),
+        vec![Location {
+            uri: fragment_uri.clone(),
+            range: Default::default(),
+        }],
+    );
+    indexer.jar_definitions.insert(
+        "ComponentActivity".to_owned(),
+        vec![Location {
+            uri: component_uri.clone(),
+            range: Default::default(),
+        }],
+    );
+    // The hop-4 collision: two same-named `Activity` JAR candidates. Decoy
+    // indexed first, matching this file's established insertion-order convention.
+    indexer.jar_definitions.insert(
+        "Activity".to_owned(),
+        vec![
+            Location {
+                uri: decoy_activity_uri,
+                range: Default::default(),
+            },
+            Location {
+                uri: real_activity_uri.clone(),
+                range: Default::default(),
+            },
+        ],
+    );
+
+    indexer.jar_files.insert(
+        appcompat_uri.to_string(),
+        Arc::new(jar_backed_file_data("FragmentActivity")),
+    );
+    indexer.jar_files.insert(
+        fragment_uri.to_string(),
+        Arc::new(jar_backed_file_data("ComponentActivity")),
+    );
+    indexer.jar_files.insert(
+        component_uri.to_string(),
+        Arc::new(jar_backed_file_data("Activity")),
+    );
+
+    // Only the calling file's module (`/t/app`, `CallUsActivity`'s own content
+    // root) depends on the real `android:android-stubs` artifact — the decoy
+    // belongs to an unrelated dependency the calling module never declared.
+    let mut dependencies_by_content_root: HashMap<PathBuf, HashSet<GradleMeta>> = HashMap::new();
+    dependencies_by_content_root.insert(
+        PathBuf::from("/t/app"),
+        HashSet::from([GradleMeta {
+            group: "android".to_owned(),
+            artifact: "android-stubs".to_owned(),
+            version: "34.0.0".to_owned(),
+        }]),
+    );
+    *indexer.module_dependencies.write().unwrap() = dependencies_by_content_root;
+
+    let items = walk_hierarchy(
+        &indexer,
+        "CallUsActivity",
+        call_us_uri.as_str(),
+        CallerContext::default(),
+        12,
+        MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
+        |_, super_name, super_uri, _| vec![(super_name.to_string(), super_uri.to_string())],
+    );
+
+    assert!(
+        items
+            .iter()
+            .any(|(name, target_uri)| name == "Activity"
+                && *target_uri == real_activity_uri.to_string()),
+        "expected the walk to reach the calling module's real dependency past \
+         the hop-4 collision using the walk's real origin file, got {items:?}"
     );
 }

--- a/src/resolver/hierarchy_tests.rs
+++ b/src/resolver/hierarchy_tests.rs
@@ -233,6 +233,69 @@ fn unlisted_package_prefix_is_never_deprioritized() {
     );
 }
 
+/// Regression guard for the Copilot-flagged gap in PR #286:
+/// `is_denylisted_supertype_package` only ever looked up `indexer.files`, so
+/// a candidate declared in a compiled-only JAR entry (no `-sources.jar`
+/// companion — its parsed `FileData` lives in `indexer.jar_files` instead)
+/// was never recognized as denylisted even when its real package matched
+/// `com.android.internal.*`. Same two-candidate shape as
+/// `denylisted_package_candidate_is_deprioritized_in_favor_of_the_other`
+/// above, but both candidates are JAR-only (`jar_definitions` +
+/// `jar_files`, never `indexer.files`).
+#[test]
+fn denylisted_jar_only_package_candidate_is_deprioritized_in_favor_of_the_other() {
+    let indexer = Indexer::new();
+    let decoy_jar_uri = gradle_cache_jar_uri("com.android.internal", "telephony-stubs", "1.0.0");
+    let real_jar_uri = gradle_cache_jar_uri("android", "android-stubs", "34.0.0");
+    // The denylisted decoy is indexed first, matching this file's established
+    // convention of seeding the wrong candidate first.
+    indexer.jar_definitions.insert(
+        "Activity".to_owned(),
+        vec![
+            Location {
+                uri: decoy_jar_uri.clone(),
+                range: Default::default(),
+            },
+            Location {
+                uri: real_jar_uri.clone(),
+                range: Default::default(),
+            },
+        ],
+    );
+    indexer.jar_files.insert(
+        decoy_jar_uri.to_string(),
+        Arc::new(FileData {
+            package: Some("com.android.internal.telephony".to_owned()),
+            ..Default::default()
+        }),
+    );
+    indexer.jar_files.insert(
+        real_jar_uri.to_string(),
+        Arc::new(FileData {
+            package: Some("android.app".to_owned()),
+            ..Default::default()
+        }),
+    );
+
+    let bar_uri = uri("/app/Bar.kt");
+    indexer.index_content(&bar_uri, "class Bar : Activity()\n");
+
+    let mut budget = MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK;
+    let targets = supertype_targets(
+        &indexer,
+        "Bar",
+        bar_uri.as_str(),
+        &mut budget,
+        bar_uri.as_str(),
+    );
+    assert_eq!(
+        targets,
+        vec![("Activity".to_owned(), real_jar_uri.to_string())],
+        "expected the JAR-only com.android.internal.* candidate to be \
+         deprioritized in favor of the non-denylisted one, got {targets:?}"
+    );
+}
+
 // ─── Acceptance: combined 4-hop walk with a denylisted decoy at the tail ──
 
 /// Synthetic reproduction of the real Moneta corpus shape (`AppCompatActivity

--- a/src/resolver/hierarchy_tests.rs
+++ b/src/resolver/hierarchy_tests.rs
@@ -2,9 +2,12 @@ use super::{
     receiver_type_agreement, supertype_chain_contains, supertype_targets, walk_hierarchy,
     ReceiverTypeAgreement, MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
 };
+use crate::cli::extract_sources::GradleMeta;
 use crate::indexer::Indexer;
 use crate::types::CallerContext;
-use tower_lsp::lsp_types::Url;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use tower_lsp::lsp_types::{Location, Url};
 
 fn uri(path: &str) -> Url {
     Url::parse(&format!("file:///t{path}")).unwrap()
@@ -270,5 +273,115 @@ fn four_hop_walk_reaches_the_real_ancestor_past_a_denylisted_decoy() {
             .iter()
             .any(|(name, target_uri)| name == "Activity" && target_uri.contains("/internal/")),
         "must never resolve to the com.android.internal decoy, got {items:?}"
+    );
+}
+
+// ─── Module-scoped narrowing (real-workspace-json-schema wiring) ──────────
+//
+// See `docs/superpowers/specs/2026-08-25-real-workspace-json-schema-and-
+// consumption-design.md` §5: when the `com.android.internal.*` denylist
+// alone still leaves more than one candidate, a second tie-break narrows
+// using the calling file's own module's real Gradle dependency set (loaded
+// from `workspace.json` into `Indexer::module_dependencies` — see
+// `workspace_json::load_module_dependencies`). Neither candidate here has a
+// package known to `indexer.files` (both are JAR-only `Location`s, never
+// indexed as real files), so the denylist tie-break is a no-op in both
+// tests below and the module-scoped tie-break is what's actually exercised.
+
+/// A Gradle-cache-shaped `jar:` URI for `(group, artifact, version)`, mirroring
+/// the real layout `parse_jar_meta` parses:
+/// `.../modules-2/files-2.1/<group>/<artifact>/<version>/<hash>/<file>.jar`.
+fn gradle_cache_jar_uri(group: &str, artifact: &str, version: &str) -> Url {
+    Url::parse(&format!(
+        "jar:file:///home/user/.gradle/caches/modules-2/files-2.1/{group}/{artifact}/{version}/deadbeef/{artifact}-{version}.jar"
+    ))
+    .unwrap()
+}
+
+/// Two same-named JAR-backed candidates for `Activity`, one from a dependency
+/// of the calling module (`com.example.real:real-lib:2.0.0`), one from an
+/// unrelated library (`com.example.decoy:decoy-lib:1.0.0`) that the calling
+/// module does NOT depend on. `Indexer::module_dependencies` records only the
+/// real dependency for the calling file's own content root (`/t/app`).
+#[test]
+fn module_scoped_tie_break_narrows_jar_collision_to_the_calling_modules_dependency() {
+    let indexer = Indexer::new();
+    let decoy_jar_uri = gradle_cache_jar_uri("com.example.decoy", "decoy-lib", "1.0.0");
+    let real_jar_uri = gradle_cache_jar_uri("com.example.real", "real-lib", "2.0.0");
+    // Decoy indexed first, matching this file's established convention of
+    // seeding the wrong candidate first so a first-match tail would pick it.
+    indexer.jar_definitions.insert(
+        "Activity".to_owned(),
+        vec![
+            Location {
+                uri: decoy_jar_uri,
+                range: Default::default(),
+            },
+            Location {
+                uri: real_jar_uri.clone(),
+                range: Default::default(),
+            },
+        ],
+    );
+
+    let mut dependencies_by_content_root: HashMap<PathBuf, HashSet<GradleMeta>> = HashMap::new();
+    dependencies_by_content_root.insert(
+        PathBuf::from("/t/app"),
+        HashSet::from([GradleMeta {
+            group: "com.example.real".to_owned(),
+            artifact: "real-lib".to_owned(),
+            version: "2.0.0".to_owned(),
+        }]),
+    );
+    *indexer.module_dependencies.write().unwrap() = dependencies_by_content_root;
+
+    let bar_uri = uri("/app/Bar.kt");
+    indexer.index_content(&bar_uri, "class Bar : Activity()\n");
+
+    let mut budget = MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK;
+    let targets = supertype_targets(&indexer, "Bar", bar_uri.as_str(), &mut budget);
+    assert_eq!(
+        targets,
+        vec![("Activity".to_owned(), real_jar_uri.to_string())],
+        "expected the tie-break to narrow to the calling module's own \
+         real-lib dependency, got {targets:?}"
+    );
+}
+
+/// Same two-candidate JAR collision as above, but with no `workspace.json`
+/// module data loaded at all (`Indexer::module_dependencies` stays at its
+/// default empty map). Behavior must be unchanged from before this wiring
+/// existed: still decline on ambiguity, exactly like the plain
+/// `com.android.internal.*`-denylist-only behavior.
+#[test]
+fn no_module_dependency_data_still_declines_on_jar_collision() {
+    let indexer = Indexer::new();
+    let decoy_jar_uri = gradle_cache_jar_uri("com.example.decoy", "decoy-lib", "1.0.0");
+    let real_jar_uri = gradle_cache_jar_uri("com.example.real", "real-lib", "2.0.0");
+    indexer.jar_definitions.insert(
+        "Activity".to_owned(),
+        vec![
+            Location {
+                uri: decoy_jar_uri,
+                range: Default::default(),
+            },
+            Location {
+                uri: real_jar_uri,
+                range: Default::default(),
+            },
+        ],
+    );
+    // `indexer.module_dependencies` is left at its `Indexer::new()` default:
+    // an empty map, standing in for "no workspace.json present."
+
+    let bar_uri = uri("/app/Bar.kt");
+    indexer.index_content(&bar_uri, "class Bar : Activity()\n");
+
+    let mut budget = MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK;
+    let targets = supertype_targets(&indexer, "Bar", bar_uri.as_str(), &mut budget);
+    assert!(
+        targets.is_empty(),
+        "expected the ambiguous tail to still decline with no module \
+         dependency data available, got {targets:?}"
     );
 }

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -30,8 +30,8 @@ pub(crate) use infer::{
 pub(crate) use infer_lines::extract_collection_element_type;
 pub(crate) use resolve::{
     ensure_file_data, fqns_for_name, receiver_provides_member, resolve_callee_definition,
-    resolve_implicit_receiver_callee, resolve_in_scope_strict, resolve_symbol_no_rg,
-    resolve_symbol_scoped_only,
+    resolve_implicit_receiver_callee, resolve_in_scope_strict,
+    resolve_symbol_hierarchy_ambiguity_safe, resolve_symbol_no_rg, resolve_symbol_scoped_only,
 };
 
 // Re-exports used only in tests.

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -97,13 +97,17 @@ pub(crate) enum ResolveIo {
     ScopedOnly,
     /// Same IO profile as `NoRg`, but the global-defs tail fallback is
     /// ambiguity-safe: a unique match wins outright; an ambiguous (N>1)
-    /// match gets one narrow tie-break (dropping any candidate whose
-    /// declared package starts with a denylisted prefix, e.g.
-    /// `com.android.internal.`) before still declining if more than one
-    /// candidate remains. Used only by the hierarchy walk's own recursion
-    /// beyond hop 1 (`supertype_targets`), where `from_uri` becomes a
-    /// `jar:` synthetic URI with no import list to disambiguate against —
-    /// see `docs/superpowers/specs/2026-08-25-hierarchy-walk-unscoped-name-collision-design.md`.
+    /// match gets two narrow tie-breaks in sequence — dropping any
+    /// candidate whose declared package starts with a denylisted prefix
+    /// (e.g. `com.android.internal.`), then narrowing to candidates whose
+    /// own JAR is a real dependency of the calling file's module (when
+    /// `workspace.json` module-dependency data is available) — before
+    /// still declining if more than one candidate remains. Used only by
+    /// the hierarchy walk's own recursion beyond hop 1 (`supertype_targets`),
+    /// where `from_uri` becomes a `jar:` synthetic URI with no import list
+    /// to disambiguate against — see
+    /// `docs/superpowers/specs/2026-08-25-hierarchy-walk-unscoped-name-collision-design.md`
+    /// and `docs/superpowers/specs/2026-08-25-real-workspace-json-schema-and-consumption-design.md`.
     HierarchyAmbiguitySafe,
 }
 

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -532,15 +532,25 @@ fn candidate_gradle_meta(location: &Location) -> Option<crate::cli::extract_sour
 }
 
 /// Whether `location`'s declaring file has a package matching one of
-/// [`HIERARCHY_WALK_DENYLISTED_PACKAGE_PREFIXES`]. Locations with no known
-/// package (e.g. a not-yet-materialized compiled-JAR entry, absent from
-/// `indexer.files`) are never treated as denylisted — the tie-break must
-/// only ever remove a candidate it can positively prove is denylisted.
+/// [`HIERARCHY_WALK_DENYLISTED_PACKAGE_PREFIXES`]. Checks `indexer.files`
+/// first, then `indexer.jar_files` — a compiled-only JAR entry (no
+/// `-sources.jar` companion) has its parsed data in `jar_files` only, never
+/// `files` (same two-map lookup order as
+/// [`crate::indexer::infer::sig::collect_params_from_file`]). Locations with
+/// no known package in either map are never treated as denylisted — the
+/// tie-break must only ever remove a candidate it can positively prove is
+/// denylisted.
 fn is_denylisted_supertype_package(indexer: &Indexer, location: &Location) -> bool {
     let Some(package) = indexer
         .files
         .get(location.uri.as_str())
         .and_then(|f| f.package.clone())
+        .or_else(|| {
+            indexer
+                .jar_files
+                .get(location.uri.as_str())
+                .and_then(|f| f.package.clone())
+        })
     else {
         return false;
     };

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -179,7 +179,8 @@ fn resolve_symbol_with_io(
         let segments: Vec<&str> = name.split('.').collect();
         // Start at the first type (uppercase) segment, skipping package prefixes.
         if let Some(start) = segments.iter().position(|s| s.starts_with_uppercase()) {
-            let outer_locs = resolve_chain(indexer, segments[start], from_uri, io, true, None);
+            let outer_locs =
+                resolve_chain(indexer, segments[start], from_uri, io, true, None, None);
             if let Some(outer_loc) = outer_locs.first() {
                 // A package-qualified plain type (`demo.Foo`) has no nested
                 // segments after the type — the resolved type itself is the target.
@@ -201,7 +202,7 @@ fn resolve_symbol_with_io(
         }
     }
 
-    resolve_chain(indexer, name, from_uri, io, true, None)
+    resolve_chain(indexer, name, from_uri, io, true, None, None)
 }
 
 /// Resolve a call's callee name, filtering same-file candidates by `shape`
@@ -215,7 +216,7 @@ pub(crate) fn resolve_callee_definition(
     uri: &Url,
     shape: CallShape,
 ) -> Vec<Location> {
-    resolve_chain(indexer, name, uri, ResolveIo::Full, true, Some(shape))
+    resolve_chain(indexer, name, uri, ResolveIo::Full, true, Some(shape), None)
 }
 
 /// The single prioritised resolution chain, parameterised by IO policy.
@@ -232,6 +233,12 @@ pub(crate) fn resolve_callee_definition(
 ///
 /// `shape` is forwarded to step 1 only (see [`resolve_local`]) — every existing
 /// caller passes `None`; only [`resolve_callee_definition`] passes a real shape.
+///
+/// `hierarchy_walk_origin_uri` is forwarded to the tail fallback only, and only
+/// matters for [`ResolveIo::HierarchyAmbiguitySafe`] — every other caller passes
+/// `None`; only [`resolve_symbol_hierarchy_ambiguity_safe`] passes the hierarchy
+/// walk's real starting file (see [`crate::resolver::hierarchy::walk_hierarchy`]),
+/// which can differ from `from_uri` past hop 1 of that walk.
 fn resolve_chain(
     indexer: &Indexer,
     name: &str,
@@ -239,6 +246,7 @@ fn resolve_chain(
     io: ResolveIo,
     with_hierarchy: bool,
     shape: Option<CallShape>,
+    hierarchy_walk_origin_uri: Option<&Url>,
 ) -> Vec<Location> {
     // Behavioural knobs derived from the policy (see the `ResolveIo` table):
     //  - `full_io`: cold-index + local-decl + swift + hierarchy + project-wide rg
@@ -400,9 +408,11 @@ fn resolve_chain(
                 vec![]
             }
         }
-        ResolveIo::HierarchyAmbiguitySafe => {
-            ambiguity_safe_tail_with_denylist(indexer, from_uri, indexer.lookup_definitions(name))
-        }
+        ResolveIo::HierarchyAmbiguitySafe => ambiguity_safe_tail_with_denylist(
+            indexer,
+            hierarchy_walk_origin_uri.unwrap_or(from_uri),
+            indexer.lookup_definitions(name),
+        ),
     }
 }
 
@@ -428,18 +438,18 @@ const HIERARCHY_WALK_DENYLISTED_PACKAGE_PREFIXES: &[&str] = &["com.android.inter
 /// data, while module-scoping only ever narrows what the denylist couldn't.
 fn ambiguity_safe_tail_with_denylist(
     indexer: &Indexer,
-    from_uri: &Url,
-    locs: Vec<Location>,
+    hierarchy_walk_origin_uri: &Url,
+    locations: Vec<Location>,
 ) -> Vec<Location> {
-    if locs.len() == 1 {
-        return locs;
+    if locations.len() == 1 {
+        return locations;
     }
-    if locs.is_empty() {
+    if locations.is_empty() {
         return vec![];
     }
-    let filtered: Vec<Location> = locs
+    let filtered: Vec<Location> = locations
         .into_iter()
-        .filter(|loc| !is_denylisted_supertype_package(indexer, loc))
+        .filter(|location| !is_denylisted_supertype_package(indexer, location))
         .collect();
     if filtered.len() == 1 {
         return filtered;
@@ -447,28 +457,31 @@ fn ambiguity_safe_tail_with_denylist(
     if filtered.len() < 2 {
         return vec![];
     }
-    module_scoped_tie_break(indexer, from_uri, filtered)
+    module_scoped_tie_break(indexer, hierarchy_walk_origin_uri, filtered)
 }
 
 /// Second tie-break for [`ambiguity_safe_tail_with_denylist`]: when the
 /// denylist alone still leaves more than one candidate, narrow using the
-/// calling file's own module's real Gradle dependency set (see
-/// `workspace_json::load_module_dependencies`) — a candidate survives only
-/// if its own JAR's `(group, artifact, version)` is a dependency of the
-/// module `from_uri` belongs to. Declines (returns empty), exactly as before
-/// this narrowing existed, whenever no per-module data is available for
-/// `from_uri`'s module or the narrowing still leaves more than one candidate.
+/// hierarchy walk's real starting file's own module's real Gradle dependency
+/// set (see `workspace_json::load_module_dependencies`) — a candidate
+/// survives only if its own JAR's `(group, artifact, version)` is a
+/// dependency of the module `hierarchy_walk_origin_uri` belongs to. Declines
+/// (returns empty), exactly as before this narrowing existed, whenever no
+/// per-module data is available for that module or the narrowing still
+/// leaves more than one candidate.
 fn module_scoped_tie_break(
     indexer: &Indexer,
-    from_uri: &Url,
-    locs: Vec<Location>,
+    hierarchy_walk_origin_uri: &Url,
+    locations: Vec<Location>,
 ) -> Vec<Location> {
-    let Some(dependencies) = owning_module_dependencies(indexer, from_uri) else {
+    let Some(dependencies) = owning_module_dependencies(indexer, hierarchy_walk_origin_uri) else {
         return vec![];
     };
-    let narrowed: Vec<Location> = locs
+    let narrowed: Vec<Location> = locations
         .into_iter()
-        .filter(|loc| candidate_gradle_meta(loc).is_some_and(|meta| dependencies.contains(&meta)))
+        .filter(|location| {
+            candidate_gradle_meta(location).is_some_and(|meta| dependencies.contains(&meta))
+        })
         .collect();
     if narrowed.len() == 1 {
         narrowed
@@ -484,8 +497,9 @@ fn module_scoped_tie_break(
 /// `build.gradle.kts`-nearest-ancestor heuristic). A cheap lookup against
 /// already-loaded, pre-parsed state — no file I/O or parsing on this path.
 /// Returns `None` when `from_uri` isn't a real file path (e.g. a `jar:`
-/// synthetic URI, as `from_uri` becomes beyond hop 1 of a hierarchy walk) or
-/// no `workspace.json` module data was loaded for this workspace.
+/// synthetic URI — [`module_scoped_tie_break`]'s caller passes the hierarchy
+/// walk's real starting file for this reason, not the current hop's own URI)
+/// or no `workspace.json` module data was loaded for this workspace.
 fn owning_module_dependencies(
     indexer: &Indexer,
     from_uri: &Url,
@@ -510,22 +524,22 @@ fn owning_module_dependencies(
 /// [`crate::jar_extract::parse_jar_entry_uri`] only handles the latter shape,
 /// so it is not reused here. Returns `None` for a non-`jar:` URI or an
 /// unparseable jar path, never a wrong guess.
-fn candidate_gradle_meta(loc: &Location) -> Option<crate::cli::extract_sources::GradleMeta> {
-    let rest = loc.uri.as_str().strip_prefix("jar:")?;
+fn candidate_gradle_meta(location: &Location) -> Option<crate::cli::extract_sources::GradleMeta> {
+    let rest = location.uri.as_str().strip_prefix("jar:")?;
     let jar_part = rest.split_once("!/").map_or(rest, |(jar, _)| jar);
     let jar_path = crate::path_util::path_from_uri(&Url::parse(jar_part).ok()?)?;
     crate::cli::extract_sources::parse_jar_meta(&jar_path)
 }
 
-/// Whether `loc`'s declaring file has a package matching one of
+/// Whether `location`'s declaring file has a package matching one of
 /// [`HIERARCHY_WALK_DENYLISTED_PACKAGE_PREFIXES`]. Locations with no known
 /// package (e.g. a not-yet-materialized compiled-JAR entry, absent from
 /// `indexer.files`) are never treated as denylisted — the tie-break must
 /// only ever remove a candidate it can positively prove is denylisted.
-fn is_denylisted_supertype_package(indexer: &Indexer, loc: &Location) -> bool {
+fn is_denylisted_supertype_package(indexer: &Indexer, location: &Location) -> bool {
     let Some(package) = indexer
         .files
-        .get(loc.uri.as_str())
+        .get(location.uri.as_str())
         .and_then(|f| f.package.clone())
     else {
         return false;
@@ -549,7 +563,7 @@ fn find_in_star_imports(indexer: &Indexer, name: &str, star_pkgs: &[String]) -> 
 /// its own doc comment for the exact IO policy, since restating it here is
 /// how this comment drifted out of sync with it the first time).
 pub(crate) fn resolve_symbol_no_rg(indexer: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
-    resolve_chain(indexer, name, from_uri, ResolveIo::NoRg, false, None)
+    resolve_chain(indexer, name, from_uri, ResolveIo::NoRg, false, None, None)
 }
 
 /// Ambiguity-safe sibling of [`resolve_symbol_no_rg`], scoped to the
@@ -557,10 +571,17 @@ pub(crate) fn resolve_symbol_no_rg(indexer: &Indexer, name: &str, from_uri: &Url
 /// `resolver/hierarchy.rs`) — see [`ResolveIo::HierarchyAmbiguitySafe`].
 /// Does not alter `resolve_symbol_no_rg` itself or any of its other
 /// callers' behavior.
+///
+/// `hierarchy_walk_origin_uri` is the hierarchy walk's real starting file
+/// (see [`crate::resolver::hierarchy::walk_hierarchy`]'s doc comment),
+/// forwarded here from `supertype_targets` so the module-scoped tie-break
+/// can still find real Gradle dependency data past hop 1, where `from_uri`
+/// itself has become the previous hop's own (often `jar:`) resolved URI.
 pub(crate) fn resolve_symbol_hierarchy_ambiguity_safe(
     indexer: &Indexer,
     name: &str,
     from_uri: &Url,
+    hierarchy_walk_origin_uri: Option<&Url>,
 ) -> Vec<Location> {
     resolve_chain(
         indexer,
@@ -569,6 +590,7 @@ pub(crate) fn resolve_symbol_hierarchy_ambiguity_safe(
         ResolveIo::HierarchyAmbiguitySafe,
         false,
         None,
+        hierarchy_walk_origin_uri,
     )
 }
 
@@ -580,7 +602,15 @@ pub(crate) fn resolve_symbol_scoped_only(
     name: &str,
     from_uri: &Url,
 ) -> Vec<Location> {
-    resolve_chain(indexer, name, from_uri, ResolveIo::ScopedOnly, false, None)
+    resolve_chain(
+        indexer,
+        name,
+        from_uri,
+        ResolveIo::ScopedOnly,
+        false,
+        None,
+        None,
+    )
 }
 
 /// Index-only type resolver for the diagnostics hot path.
@@ -616,7 +646,15 @@ pub(crate) fn resolve_type_index_only(
 
 /// Inner helper: resolves a simple (non-dotted) type name using the index-only chain.
 fn resolve_type_index_only_simple(indexer: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
-    resolve_chain(indexer, name, from_uri, ResolveIo::IndexOnly, false, None)
+    resolve_chain(
+        indexer,
+        name,
+        from_uri,
+        ResolveIo::IndexOnly,
+        false,
+        None,
+        None,
+    )
 }
 
 // ─── missing-import diagnostic helpers ────────────────────────────────────────

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -397,7 +397,7 @@ fn resolve_chain(
             }
         }
         ResolveIo::HierarchyAmbiguitySafe => {
-            ambiguity_safe_tail_with_denylist(indexer, indexer.lookup_definitions(name))
+            ambiguity_safe_tail_with_denylist(indexer, from_uri, indexer.lookup_definitions(name))
         }
     }
 }
@@ -414,14 +414,23 @@ fn resolve_chain(
 const HIERARCHY_WALK_DENYLISTED_PACKAGE_PREFIXES: &[&str] = &["com.android.internal."];
 
 /// Tail fallback for [`ResolveIo::HierarchyAmbiguitySafe`]: a unique
-/// candidate wins outright; an ambiguous set gets one narrow tie-break
-/// (dropping [`HIERARCHY_WALK_DENYLISTED_PACKAGE_PREFIXES`] matches) before
-/// still declining unless that leaves exactly one candidate.
-fn ambiguity_safe_tail_with_denylist(indexer: &Indexer, locs: Vec<Location>) -> Vec<Location> {
+/// candidate wins outright; an ambiguous set gets two narrow tie-breaks in
+/// sequence — first [`HIERARCHY_WALK_DENYLISTED_PACKAGE_PREFIXES`] (unconditional,
+/// project-wide), then [`module_scoped_tie_break`] (real per-module Gradle
+/// dependency data, when available) — before still declining unless one of
+/// them leaves exactly one candidate. See the real-workspace-json-schema
+/// design doc's §5 for why this ordering (denylist first, module-scoping
+/// second) is correct: the denylist is unconditional and needs no loaded
+/// data, while module-scoping only ever narrows what the denylist couldn't.
+fn ambiguity_safe_tail_with_denylist(
+    indexer: &Indexer,
+    from_uri: &Url,
+    locs: Vec<Location>,
+) -> Vec<Location> {
     if locs.len() == 1 {
         return locs;
     }
-    if locs.len() < 2 {
+    if locs.is_empty() {
         return vec![];
     }
     let filtered: Vec<Location> = locs
@@ -429,10 +438,79 @@ fn ambiguity_safe_tail_with_denylist(indexer: &Indexer, locs: Vec<Location>) -> 
         .filter(|loc| !is_denylisted_supertype_package(indexer, loc))
         .collect();
     if filtered.len() == 1 {
-        filtered
+        return filtered;
+    }
+    if filtered.len() < 2 {
+        return vec![];
+    }
+    module_scoped_tie_break(indexer, from_uri, filtered)
+}
+
+/// Second tie-break for [`ambiguity_safe_tail_with_denylist`]: when the
+/// denylist alone still leaves more than one candidate, narrow using the
+/// calling file's own module's real Gradle dependency set (see
+/// `workspace_json::load_module_dependencies`) — a candidate survives only
+/// if its own JAR's `(group, artifact, version)` is a dependency of the
+/// module `from_uri` belongs to. Declines (returns empty), exactly as before
+/// this narrowing existed, whenever no per-module data is available for
+/// `from_uri`'s module or the narrowing still leaves more than one candidate.
+fn module_scoped_tie_break(
+    indexer: &Indexer,
+    from_uri: &Url,
+    locs: Vec<Location>,
+) -> Vec<Location> {
+    let Some(dependencies) = owning_module_dependencies(indexer, from_uri) else {
+        return vec![];
+    };
+    let narrowed: Vec<Location> = locs
+        .into_iter()
+        .filter(|loc| candidate_gradle_meta(loc).is_some_and(|meta| dependencies.contains(&meta)))
+        .collect();
+    if narrowed.len() == 1 {
+        narrowed
     } else {
         vec![]
     }
+}
+
+/// Looks up `from_uri`'s owning module's real Gradle dependency set: the
+/// content-root directory that is the longest-prefix match of `from_uri`'s
+/// file path (see `workspace_json::load_module_dependencies`'s own doc
+/// comment for why this is the correct module-identity lookup, not a
+/// `build.gradle.kts`-nearest-ancestor heuristic). A cheap lookup against
+/// already-loaded, pre-parsed state — no file I/O or parsing on this path.
+/// Returns `None` when `from_uri` isn't a real file path (e.g. a `jar:`
+/// synthetic URI, as `from_uri` becomes beyond hop 1 of a hierarchy walk) or
+/// no `workspace.json` module data was loaded for this workspace.
+fn owning_module_dependencies(
+    indexer: &Indexer,
+    from_uri: &Url,
+) -> Option<HashSet<crate::cli::extract_sources::GradleMeta>> {
+    let file_path = from_uri.to_file_path().ok()?;
+    let dependencies_by_content_root = indexer
+        .module_dependencies
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    dependencies_by_content_root
+        .iter()
+        .filter(|(content_root, _)| file_path.starts_with(content_root.as_path()))
+        .max_by_key(|(content_root, _)| content_root.as_os_str().len())
+        .map(|(_, dependencies)| dependencies.clone())
+}
+
+/// Resolves a candidate hierarchy-walk `Location`'s own JAR path to its
+/// Gradle coordinates, via the existing [`crate::cli::extract_sources::parse_jar_meta`]
+/// (design doc §2 point 3's cross-check opportunity). Handles both a
+/// compiled-only JAR URI (`jar:file://<jar>`, no entry — how `jar_definitions`
+/// locations are shaped) and a sources-JAR entry URI (`jar:file://<jar>!/<entry>`);
+/// [`crate::jar_extract::parse_jar_entry_uri`] only handles the latter shape,
+/// so it is not reused here. Returns `None` for a non-`jar:` URI or an
+/// unparseable jar path, never a wrong guess.
+fn candidate_gradle_meta(loc: &Location) -> Option<crate::cli::extract_sources::GradleMeta> {
+    let rest = loc.uri.as_str().strip_prefix("jar:")?;
+    let jar_part = rest.split_once("!/").map_or(rest, |(jar, _)| jar);
+    let jar_path = Url::parse(jar_part).ok()?.to_file_path().ok()?;
+    crate::cli::extract_sources::parse_jar_meta(&jar_path)
 }
 
 /// Whether `loc`'s declaring file has a package matching one of

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -95,6 +95,16 @@ pub(crate) enum ResolveIo {
     /// match here beat a differently-named function's own, more precise
     /// resolution downstream — see the caller's doc comment).
     ScopedOnly,
+    /// Same IO profile as `NoRg`, but the global-defs tail fallback is
+    /// ambiguity-safe: a unique match wins outright; an ambiguous (N>1)
+    /// match gets one narrow tie-break (dropping any candidate whose
+    /// declared package starts with a denylisted prefix, e.g.
+    /// `com.android.internal.`) before still declining if more than one
+    /// candidate remains. Used only by the hierarchy walk's own recursion
+    /// beyond hop 1 (`supertype_targets`), where `from_uri` becomes a
+    /// `jar:` synthetic URI with no import list to disambiguate against —
+    /// see `docs/superpowers/specs/2026-08-25-hierarchy-walk-unscoped-name-collision-design.md`.
+    HierarchyAmbiguitySafe,
 }
 
 /// Resolve `name` as seen from `from_uri`, returning all known definition
@@ -368,6 +378,7 @@ fn resolve_chain(
     // Tail fallback — global definitions index (includes JAR symbols).
     //  - NoRg: first match.   - IndexOnly: unique match only (ambiguity-safe).
     //  - ScopedOnly: no tail at all (empty) -- see the variant's doc comment.
+    //  - HierarchyAmbiguitySafe: unique match, else a narrow denylist tie-break.
     //  - Full: never reached (returns inside the rg branch above).
     match io {
         ResolveIo::Full | ResolveIo::ScopedOnly => vec![],
@@ -385,7 +396,61 @@ fn resolve_chain(
                 vec![]
             }
         }
+        ResolveIo::HierarchyAmbiguitySafe => {
+            ambiguity_safe_tail_with_denylist(indexer, indexer.lookup_definitions(name))
+        }
     }
+}
+
+/// Package prefixes that can never be a legitimate app-facing supertype —
+/// checked only as a last-resort tie-break by
+/// [`ambiguity_safe_tail_with_denylist`] once a hierarchy-walk lookup has
+/// already found more than one same-named candidate. Deliberately narrow
+/// (currently a single entry, the one directly evidenced by the real
+/// repro): a denylist can only ever fail to help, never introduce a new
+/// wrong preference the way a broader "prefer this package family"
+/// heuristic could — see the design doc's self-critique. Do not grow this
+/// into a general preference-ranking system.
+const HIERARCHY_WALK_DENYLISTED_PACKAGE_PREFIXES: &[&str] = &["com.android.internal."];
+
+/// Tail fallback for [`ResolveIo::HierarchyAmbiguitySafe`]: a unique
+/// candidate wins outright; an ambiguous set gets one narrow tie-break
+/// (dropping [`HIERARCHY_WALK_DENYLISTED_PACKAGE_PREFIXES`] matches) before
+/// still declining unless that leaves exactly one candidate.
+fn ambiguity_safe_tail_with_denylist(indexer: &Indexer, locs: Vec<Location>) -> Vec<Location> {
+    if locs.len() == 1 {
+        return locs;
+    }
+    if locs.len() < 2 {
+        return vec![];
+    }
+    let filtered: Vec<Location> = locs
+        .into_iter()
+        .filter(|loc| !is_denylisted_supertype_package(indexer, loc))
+        .collect();
+    if filtered.len() == 1 {
+        filtered
+    } else {
+        vec![]
+    }
+}
+
+/// Whether `loc`'s declaring file has a package matching one of
+/// [`HIERARCHY_WALK_DENYLISTED_PACKAGE_PREFIXES`]. Locations with no known
+/// package (e.g. a not-yet-materialized compiled-JAR entry, absent from
+/// `indexer.files`) are never treated as denylisted — the tie-break must
+/// only ever remove a candidate it can positively prove is denylisted.
+fn is_denylisted_supertype_package(indexer: &Indexer, loc: &Location) -> bool {
+    let Some(package) = indexer
+        .files
+        .get(loc.uri.as_str())
+        .and_then(|f| f.package.clone())
+    else {
+        return false;
+    };
+    HIERARCHY_WALK_DENYLISTED_PACKAGE_PREFIXES
+        .iter()
+        .any(|prefix| package.starts_with(prefix))
 }
 
 /// Returns the first Location found by scanning star-import packages.
@@ -403,6 +468,26 @@ fn find_in_star_imports(indexer: &Indexer, name: &str, star_pkgs: &[String]) -> 
 /// how this comment drifted out of sync with it the first time).
 pub(crate) fn resolve_symbol_no_rg(indexer: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
     resolve_chain(indexer, name, from_uri, ResolveIo::NoRg, false, None)
+}
+
+/// Ambiguity-safe sibling of [`resolve_symbol_no_rg`], scoped to the
+/// hierarchy walk's own recursion (`supertype_targets` in
+/// `resolver/hierarchy.rs`) — see [`ResolveIo::HierarchyAmbiguitySafe`].
+/// Does not alter `resolve_symbol_no_rg` itself or any of its other
+/// callers' behavior.
+pub(crate) fn resolve_symbol_hierarchy_ambiguity_safe(
+    indexer: &Indexer,
+    name: &str,
+    from_uri: &Url,
+) -> Vec<Location> {
+    resolve_chain(
+        indexer,
+        name,
+        from_uri,
+        ResolveIo::HierarchyAmbiguitySafe,
+        false,
+        None,
+    )
 }
 
 /// Like [`resolve_symbol_no_rg`] but without its global-defs tail fallback --

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -486,7 +486,7 @@ fn owning_module_dependencies(
     indexer: &Indexer,
     from_uri: &Url,
 ) -> Option<HashSet<crate::cli::extract_sources::GradleMeta>> {
-    let file_path = from_uri.to_file_path().ok()?;
+    let file_path = crate::path_util::path_from_uri(from_uri)?;
     let dependencies_by_content_root = indexer
         .module_dependencies
         .read()
@@ -509,7 +509,7 @@ fn owning_module_dependencies(
 fn candidate_gradle_meta(loc: &Location) -> Option<crate::cli::extract_sources::GradleMeta> {
     let rest = loc.uri.as_str().strip_prefix("jar:")?;
     let jar_part = rest.split_once("!/").map_or(rest, |(jar, _)| jar);
-    let jar_path = Url::parse(jar_part).ok()?.to_file_path().ok()?;
+    let jar_path = crate::path_util::path_from_uri(&Url::parse(jar_part).ok()?)?;
     crate::cli::extract_sources::parse_jar_meta(&jar_path)
 }
 

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -232,6 +232,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             .store(config.pin_workspace, std::sync::atomic::Ordering::Relaxed);
         self.write_source_paths(data.source_paths.clone());
         self.write_workspace_source_roots(&data.root);
+        self.write_module_dependencies(&data.root);
         self.state.write().await.set_state(data.clone());
         data
     }
@@ -262,6 +263,26 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
         match self.indexer.workspace_source_roots.write() {
             Ok(mut guard) => *guard = roots,
             Err(error) => log::warn!("Actor: failed to write workspace_source_roots: {error}"),
+        }
+    }
+
+    /// Loads real, per-module Gradle dependency data from `workspace.json` (see
+    /// `workspace_json::load_module_dependencies`) so the hierarchy-walk
+    /// ambiguity tie-break can narrow a same-named collision to the calling
+    /// file's own module's actual dependencies. Empty when no real
+    /// `workspace.json` module data is present — narrowing then simply
+    /// declines, same as before this data existed.
+    fn write_module_dependencies(&self, root: &std::path::Path) {
+        let dependencies = crate::workspace_json::load_module_dependencies(root);
+        if !dependencies.is_empty() {
+            log::info!(
+                "workspace.json: loaded module dependencies for {} content root(s)",
+                dependencies.len()
+            );
+        }
+        match self.indexer.module_dependencies.write() {
+            Ok(mut guard) => *guard = dependencies,
+            Err(error) => log::warn!("Actor: failed to write module_dependencies: {error}"),
         }
     }
 

--- a/src/workspace_json.rs
+++ b/src/workspace_json.rs
@@ -20,9 +20,8 @@ use std::path::{Path, PathBuf};
 
 const SOURCE_TYPES: &[&str] = &["java-source", "java-test"];
 const WORKSPACE_PLACEHOLDER: &str = "<WORKSPACE>";
-// No production caller yet; the real-schema GAV-resolution functions below
-// (`library_gradle_meta`, `load_module_dependencies`) await resolver wiring.
-#[allow(dead_code)]
+/// Prefix of the real, decades-old IntelliJ Gradle-synced library naming
+/// convention (`library_gradle_meta_from_name`'s fallback GAV parse).
 const GRADLE_LIBRARY_NAME_PREFIX: &str = "Gradle: ";
 
 #[derive(Deserialize)]
@@ -30,10 +29,7 @@ struct WorkspaceData {
     #[serde(default)]
     modules: Vec<ModuleData>,
     /// Every dependency-resolvable library in the project, keyed by `name`
-    /// from each module's `dependencies[]` entries. Populated by real
-    /// producers (the official `kotlin-lsp` importer or a third-party Gradle
-    /// plugin); no production caller yet — see `load_module_dependencies`.
-    #[allow(dead_code)]
+    /// from each module's `dependencies[]` entries — see `load_module_dependencies`.
     #[serde(default)]
     libraries: Vec<LibraryData>,
     /// Optional list of external library source directories.
@@ -53,17 +49,17 @@ struct WorkspaceData {
 struct ModuleData {
     /// Parsed for schema fidelity; module identity for dependency-scoping
     /// purposes keys off `content_roots[].path`, not this name, so it has no
-    /// reader yet in this slice.
+    /// reader in this slice — see `load_module_dependencies`.
     #[allow(dead_code)]
     #[serde(default)]
     name: String,
     #[serde(default, rename = "contentRoots")]
     content_roots: Vec<ContentRootData>,
-    /// No production caller yet; consumed by `load_module_dependencies`'s
-    /// tests today, pending resolver wiring.
-    #[allow(dead_code)]
     #[serde(default)]
     dependencies: Vec<DependencyData>,
+    /// Parsed for schema fidelity; module identity for dependency-scoping
+    /// purposes keys off `content_roots[].path` (see `load_module_dependencies`),
+    /// not this Gradle-project-path field, so it has no reader in this slice.
     #[allow(dead_code)]
     #[serde(default, rename = "externalProjectId")]
     external_project_id: Option<String>,
@@ -79,7 +75,6 @@ struct ModuleData {
 #[serde(tag = "type", rename_all = "camelCase")]
 enum DependencyData {
     Library {
-        #[allow(dead_code)]
         name: String,
         /// Parsed for schema fidelity; dependency scope (compile/test/
         /// runtime/provided) doesn't yet filter GAV resolution in this slice.
@@ -91,8 +86,8 @@ enum DependencyData {
     /// file carrying one deserializes correctly, but no logic in this slice
     /// reads it — wiring project-graph awareness from this variant is out of
     /// scope here (see design doc's Non-goals).
-    #[allow(dead_code)]
     Module {
+        #[allow(dead_code)]
         name: String,
     },
     InheritedSdk,
@@ -111,9 +106,6 @@ enum DependencyData {
 
 #[derive(Deserialize)]
 struct ContentRootData {
-    /// No production caller yet; consumed by `load_module_dependencies`'s
-    /// tests today, pending resolver wiring.
-    #[allow(dead_code)]
     #[serde(default)]
     path: String,
     #[serde(default, rename = "sourceRoots")]
@@ -131,16 +123,18 @@ struct SourceRootData {
 /// each module's `Library`-typed `dependencies[]` entries.
 #[derive(Debug, Deserialize)]
 pub(crate) struct LibraryData {
-    #[allow(dead_code)]
     name: String,
     /// Reserved for a future path-based JAR match (design doc §2 point 3:
     /// an indexed JAR's path can equal a root's `path` after placeholder
     /// substitution, sidestepping GAV parsing) — not consumed by the
-    /// GAV-string resolution this slice implements.
+    /// GAV-string resolution this slice implements. The candidate-side
+    /// cross-check this slice *does* implement
+    /// (`resolver::resolve::candidate_gradle_meta`) goes the other direction:
+    /// it derives GAV straight from a hierarchy-walk candidate's own JAR path
+    /// via `parse_jar_meta`, without needing this field at all.
     #[allow(dead_code)]
     #[serde(default)]
     roots: Vec<LibraryRootData>,
-    #[allow(dead_code)]
     #[serde(default)]
     properties: Option<LibraryProperties>,
 }
@@ -160,14 +154,12 @@ fn default_library_root_type() -> String {
     "CLASSES".to_owned()
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct LibraryProperties {
     #[serde(default)]
     attributes: Option<LibraryAttributes>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct LibraryAttributes {
     #[serde(default, rename = "groupId")]
@@ -309,7 +301,6 @@ pub(crate) fn load_configured_jar_paths(workspace_root: &Path) -> Vec<PathBuf> {
 ///
 /// No production caller yet — shared by `load_module_dependencies` and its
 /// tests, pending resolver wiring (design doc §5, deferred).
-#[allow(dead_code)]
 fn parse_workspace_data(workspace_root: &Path) -> Option<WorkspaceData> {
     let json_path = workspace_root.join("workspace.json");
     if !json_path.exists() {
@@ -339,7 +330,6 @@ fn parse_workspace_data(workspace_root: &Path) -> Option<WorkspaceData> {
 ///
 /// No production caller yet — exercised directly by tests, pending resolver
 /// wiring (design doc §5, deferred).
-#[allow(dead_code)]
 pub(crate) fn library_gradle_meta(library: &LibraryData) -> Option<GradleMeta> {
     if let Some(gradle_meta) = library_gradle_meta_from_attributes(library) {
         return Some(gradle_meta);
@@ -350,7 +340,6 @@ pub(crate) fn library_gradle_meta(library: &LibraryData) -> Option<GradleMeta> {
 /// Structured GAV resolution from `properties.attributes`. Requires all
 /// three of `groupId`/`artifactId`/`version` to be present — a partial
 /// attribute set is treated the same as absent, never guessed at.
-#[allow(dead_code)]
 fn library_gradle_meta_from_attributes(library: &LibraryData) -> Option<GradleMeta> {
     let attributes = library.properties.as_ref()?.attributes.as_ref()?;
     Some(GradleMeta {
@@ -366,7 +355,6 @@ fn library_gradle_meta_from_attributes(library: &LibraryData) -> Option<GradleMe
 /// colon-separated segments — including the third-party plugin's
 /// `"Gradle: "`-prefixed synthetic Android SDK entry, which is real-shaped
 /// despite being synthetic and so parses like any other library name.
-#[allow(dead_code)]
 fn library_gradle_meta_from_name(name: &str) -> Option<GradleMeta> {
     let coordinate = name.strip_prefix(GRADLE_LIBRARY_NAME_PREFIX)?;
     let segments: Vec<&str> = coordinate.split(':').collect();
@@ -393,7 +381,6 @@ fn library_gradle_meta_from_name(name: &str) -> Option<GradleMeta> {
 ///
 /// No production caller yet — built and tested standalone for the resolver's
 /// future JAR-collision-scoping use, per this slice's own scope boundary.
-#[allow(dead_code)]
 pub(crate) fn load_module_dependencies(
     workspace_root: &Path,
 ) -> HashMap<PathBuf, HashSet<GradleMeta>> {
@@ -435,7 +422,6 @@ pub(crate) fn load_module_dependencies(
 /// Resolves a single module's `Library`-typed `dependencies[]` entries to
 /// their `GradleMeta`, looking each dependency's `name` up in the workspace's
 /// project-wide `libraries[]` registry.
-#[allow(dead_code)]
 fn module_gradle_dependencies(
     module: &ModuleData,
     libraries_by_name: &HashMap<&str, &LibraryData>,

--- a/src/workspace_json.rs
+++ b/src/workspace_json.rs
@@ -13,16 +13,29 @@
 //! - `"java-source"` — production Kotlin/Java sources
 //! - `"java-test"` — test Kotlin/Java sources
 
+use crate::cli::extract_sources::GradleMeta;
 use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 const SOURCE_TYPES: &[&str] = &["java-source", "java-test"];
 const WORKSPACE_PLACEHOLDER: &str = "<WORKSPACE>";
+// No production caller yet; the real-schema GAV-resolution functions below
+// (`library_gradle_meta`, `load_module_dependencies`) await resolver wiring.
+#[allow(dead_code)]
+const GRADLE_LIBRARY_NAME_PREFIX: &str = "Gradle: ";
 
 #[derive(Deserialize)]
 struct WorkspaceData {
     #[serde(default)]
     modules: Vec<ModuleData>,
+    /// Every dependency-resolvable library in the project, keyed by `name`
+    /// from each module's `dependencies[]` entries. Populated by real
+    /// producers (the official `kotlin-lsp` importer or a third-party Gradle
+    /// plugin); no production caller yet — see `load_module_dependencies`.
+    #[allow(dead_code)]
+    #[serde(default)]
+    libraries: Vec<LibraryData>,
     /// Optional list of external library source directories.
     /// When present (even as `[]`), these override the global `~/.kmp-lsp/sources` default.
     /// Supports the `<WORKSPACE>` placeholder (substituted with the workspace root path).
@@ -38,12 +51,71 @@ struct WorkspaceData {
 
 #[derive(Deserialize)]
 struct ModuleData {
+    /// Parsed for schema fidelity; module identity for dependency-scoping
+    /// purposes keys off `content_roots[].path`, not this name, so it has no
+    /// reader yet in this slice.
+    #[allow(dead_code)]
+    #[serde(default)]
+    name: String,
     #[serde(default, rename = "contentRoots")]
     content_roots: Vec<ContentRootData>,
+    /// No production caller yet; consumed by `load_module_dependencies`'s
+    /// tests today, pending resolver wiring.
+    #[allow(dead_code)]
+    #[serde(default)]
+    dependencies: Vec<DependencyData>,
+    #[allow(dead_code)]
+    #[serde(default, rename = "externalProjectId")]
+    external_project_id: Option<String>,
+}
+
+/// One entry of a module's `dependencies[]` list, internally tagged on
+/// `"type"` — the real schema's own discriminator shape (verified against
+/// `Kotlin/kotlin-lsp`'s `model.kt`). A `#[serde(other)]` catch-all covers a
+/// future/unrecognized `type` value so parsing degrades to "entry ignored,"
+/// never a hard error — matching this file's existing "never panic on
+/// malformed input" convention.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+enum DependencyData {
+    Library {
+        #[allow(dead_code)]
+        name: String,
+        /// Parsed for schema fidelity; dependency scope (compile/test/
+        /// runtime/provided) doesn't yet filter GAV resolution in this slice.
+        #[allow(dead_code)]
+        #[serde(default)]
+        scope: Option<String>,
+    },
+    /// An intra-project module-to-module dependency edge. Modeled so a real
+    /// file carrying one deserializes correctly, but no logic in this slice
+    /// reads it — wiring project-graph awareness from this variant is out of
+    /// scope here (see design doc's Non-goals).
+    #[allow(dead_code)]
+    Module {
+        name: String,
+    },
+    InheritedSdk,
+    ModuleSource,
+    /// A JDK/SDK dependency entry, e.g. `{"type":"sdk","name":"17","kind":"jdk"}`.
+    /// Modeled so it is never misinterpreted as a `Library` entry during GAV
+    /// resolution; its fields have no reader in this slice.
+    #[allow(dead_code)]
+    Sdk {
+        name: String,
+        kind: String,
+    },
+    #[serde(other)]
+    Unrecognized,
 }
 
 #[derive(Deserialize)]
 struct ContentRootData {
+    /// No production caller yet; consumed by `load_module_dependencies`'s
+    /// tests today, pending resolver wiring.
+    #[allow(dead_code)]
+    #[serde(default)]
+    path: String,
     #[serde(default, rename = "sourceRoots")]
     source_roots: Vec<SourceRootData>,
 }
@@ -53,6 +125,57 @@ struct SourceRootData {
     path: String,
     #[serde(rename = "type", default)]
     root_type: String,
+}
+
+/// A project-wide library entry from `libraries[]`, referenced by name from
+/// each module's `Library`-typed `dependencies[]` entries.
+#[derive(Debug, Deserialize)]
+pub(crate) struct LibraryData {
+    #[allow(dead_code)]
+    name: String,
+    /// Reserved for a future path-based JAR match (design doc §2 point 3:
+    /// an indexed JAR's path can equal a root's `path` after placeholder
+    /// substitution, sidestepping GAV parsing) — not consumed by the
+    /// GAV-string resolution this slice implements.
+    #[allow(dead_code)]
+    #[serde(default)]
+    roots: Vec<LibraryRootData>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    properties: Option<LibraryProperties>,
+}
+
+/// One `roots[]` entry of a `LibraryData`. Parsed for schema fidelity and the
+/// future path-based matching noted on `LibraryData::roots`; unread by this
+/// slice's GAV-string-based resolution.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct LibraryRootData {
+    path: String,
+    #[serde(rename = "type", default = "default_library_root_type")]
+    root_type: String,
+}
+
+fn default_library_root_type() -> String {
+    "CLASSES".to_owned()
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct LibraryProperties {
+    #[serde(default)]
+    attributes: Option<LibraryAttributes>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct LibraryAttributes {
+    #[serde(default, rename = "groupId")]
+    group_id: Option<String>,
+    #[serde(default, rename = "artifactId")]
+    artifact_id: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
 }
 
 /// Reads `<workspace_root>/workspace.json` and returns source root paths.
@@ -177,6 +300,159 @@ pub(crate) fn load_configured_jar_paths(workspace_root: &Path) -> Vec<PathBuf> {
         Some(raw) => resolve_jar_path_specs(&raw, workspace_root),
         None => Vec::new(),
     }
+}
+
+/// Reads and parses `<workspace_root>/workspace.json` into the full
+/// `WorkspaceData` structure. Returns `None` (with a log warning, except for
+/// the common "no file present" case) on any I/O or parse failure — never
+/// panics, matching every other loader in this file.
+///
+/// No production caller yet — shared by `load_module_dependencies` and its
+/// tests, pending resolver wiring (design doc §5, deferred).
+#[allow(dead_code)]
+fn parse_workspace_data(workspace_root: &Path) -> Option<WorkspaceData> {
+    let json_path = workspace_root.join("workspace.json");
+    if !json_path.exists() {
+        return None;
+    }
+    let content = match std::fs::read_to_string(&json_path) {
+        Ok(text) => text,
+        Err(error) => {
+            log::warn!("workspace.json: failed to read: {error}");
+            return None;
+        }
+    };
+    match serde_json::from_str(&content) {
+        Ok(data) => Some(data),
+        Err(error) => {
+            log::warn!("workspace.json: failed to parse: {error}");
+            None
+        }
+    }
+}
+
+/// Resolves a `LibraryData` entry to its Gradle group/artifact/version, in
+/// priority order: structured `properties.attributes` first, then a
+/// `"Gradle: <group>:<artifact>:<version>"`-shaped `name` fallback. Returns
+/// `None` (never a wrong guess) when neither shape matches — e.g. a
+/// hand-added local library.
+///
+/// No production caller yet — exercised directly by tests, pending resolver
+/// wiring (design doc §5, deferred).
+#[allow(dead_code)]
+pub(crate) fn library_gradle_meta(library: &LibraryData) -> Option<GradleMeta> {
+    if let Some(gradle_meta) = library_gradle_meta_from_attributes(library) {
+        return Some(gradle_meta);
+    }
+    library_gradle_meta_from_name(&library.name)
+}
+
+/// Structured GAV resolution from `properties.attributes`. Requires all
+/// three of `groupId`/`artifactId`/`version` to be present — a partial
+/// attribute set is treated the same as absent, never guessed at.
+#[allow(dead_code)]
+fn library_gradle_meta_from_attributes(library: &LibraryData) -> Option<GradleMeta> {
+    let attributes = library.properties.as_ref()?.attributes.as_ref()?;
+    Some(GradleMeta {
+        group: attributes.group_id.clone()?,
+        artifact: attributes.artifact_id.clone()?,
+        version: attributes.version.clone()?,
+    })
+}
+
+/// Fallback GAV resolution by parsing the real, decades-old IntelliJ
+/// `"Gradle: <group>:<artifact>:<version>"` library-name convention. Returns
+/// `None` if the prefix is absent or the remainder isn't exactly three
+/// colon-separated segments — including the third-party plugin's
+/// `"Gradle: "`-prefixed synthetic Android SDK entry, which is real-shaped
+/// despite being synthetic and so parses like any other library name.
+#[allow(dead_code)]
+fn library_gradle_meta_from_name(name: &str) -> Option<GradleMeta> {
+    let coordinate = name.strip_prefix(GRADLE_LIBRARY_NAME_PREFIX)?;
+    let segments: Vec<&str> = coordinate.split(':').collect();
+    let [group, artifact, version] = segments[..] else {
+        return None;
+    };
+    Some(GradleMeta {
+        group: group.to_owned(),
+        artifact: artifact.to_owned(),
+        version: version.to_owned(),
+    })
+}
+
+/// Builds a per-module dependency map: every content-root directory a module
+/// owns (from its own `contentRoots[].path`, after `<WORKSPACE>`
+/// substitution) is associated with the `GradleMeta` set resolved from that
+/// module's `library`-typed `dependencies[]` entries. Non-`Library` entries
+/// (`Module`/`InheritedSdk`/`ModuleSource`/`Sdk`) are skipped by construction
+/// — matching on the `Library` arm makes passing a JDK-version string or a
+/// module name through GAV resolution impossible, not merely discouraged.
+///
+/// Returns an empty map (never panics) when `workspace.json` is missing,
+/// malformed, or carries no `libraries[]`/`dependencies[]` data.
+///
+/// No production caller yet — built and tested standalone for the resolver's
+/// future JAR-collision-scoping use, per this slice's own scope boundary.
+#[allow(dead_code)]
+pub(crate) fn load_module_dependencies(
+    workspace_root: &Path,
+) -> HashMap<PathBuf, HashSet<GradleMeta>> {
+    let Some(data) = parse_workspace_data(workspace_root) else {
+        return HashMap::new();
+    };
+
+    let libraries_by_name: HashMap<&str, &LibraryData> = data
+        .libraries
+        .iter()
+        .map(|library| (library.name.as_str(), library))
+        .collect();
+
+    let workspace_str = workspace_root.to_string_lossy();
+    let mut dependencies_by_content_root: HashMap<PathBuf, HashSet<GradleMeta>> = HashMap::new();
+
+    for module in &data.modules {
+        let module_dependencies = module_gradle_dependencies(module, &libraries_by_name);
+        if module_dependencies.is_empty() {
+            continue;
+        }
+        for content_root in &module.content_roots {
+            if content_root.path.is_empty() {
+                continue;
+            }
+            let resolved = content_root
+                .path
+                .replace(WORKSPACE_PLACEHOLDER, &workspace_str);
+            dependencies_by_content_root
+                .entry(PathBuf::from(resolved))
+                .or_default()
+                .extend(module_dependencies.iter().cloned());
+        }
+    }
+
+    dependencies_by_content_root
+}
+
+/// Resolves a single module's `Library`-typed `dependencies[]` entries to
+/// their `GradleMeta`, looking each dependency's `name` up in the workspace's
+/// project-wide `libraries[]` registry.
+#[allow(dead_code)]
+fn module_gradle_dependencies(
+    module: &ModuleData,
+    libraries_by_name: &HashMap<&str, &LibraryData>,
+) -> HashSet<GradleMeta> {
+    let mut module_dependencies = HashSet::new();
+    for dependency in &module.dependencies {
+        let DependencyData::Library { name, .. } = dependency else {
+            continue;
+        };
+        let Some(library) = libraries_by_name.get(name.as_str()) else {
+            continue;
+        };
+        if let Some(gradle_meta) = library_gradle_meta(library) {
+            module_dependencies.insert(gradle_meta);
+        }
+    }
+    module_dependencies
 }
 
 /// Resolve a list of jar/aar path specs into concrete compiled-jar files.

--- a/src/workspace_json.rs
+++ b/src/workspace_json.rs
@@ -299,8 +299,8 @@ pub(crate) fn load_configured_jar_paths(workspace_root: &Path) -> Vec<PathBuf> {
 /// the common "no file present" case) on any I/O or parse failure — never
 /// panics, matching every other loader in this file.
 ///
-/// No production caller yet — shared by `load_module_dependencies` and its
-/// tests, pending resolver wiring (design doc §5, deferred).
+/// Used by `load_module_dependencies` (workspace scan and CLI indexing) and
+/// directly by tests.
 fn parse_workspace_data(workspace_root: &Path) -> Option<WorkspaceData> {
     let json_path = workspace_root.join("workspace.json");
     if !json_path.exists() {
@@ -328,8 +328,8 @@ fn parse_workspace_data(workspace_root: &Path) -> Option<WorkspaceData> {
 /// `None` (never a wrong guess) when neither shape matches — e.g. a
 /// hand-added local library.
 ///
-/// No production caller yet — exercised directly by tests, pending resolver
-/// wiring (design doc §5, deferred).
+/// Used by `module_gradle_dependencies` as part of `load_module_dependencies`,
+/// and directly by tests.
 pub(crate) fn library_gradle_meta(library: &LibraryData) -> Option<GradleMeta> {
     if let Some(gradle_meta) = library_gradle_meta_from_attributes(library) {
         return Some(gradle_meta);
@@ -379,8 +379,9 @@ fn library_gradle_meta_from_name(name: &str) -> Option<GradleMeta> {
 /// Returns an empty map (never panics) when `workspace.json` is missing,
 /// malformed, or carries no `libraries[]`/`dependencies[]` data.
 ///
-/// No production caller yet — built and tested standalone for the resolver's
-/// future JAR-collision-scoping use, per this slice's own scope boundary.
+/// Called from the workspace scan handler and the CLI index build path to
+/// populate `Indexer::module_dependencies` for the resolver's
+/// JAR-collision-scoping tie-break.
 pub(crate) fn load_module_dependencies(
     workspace_root: &Path,
 ) -> HashMap<PathBuf, HashSet<GradleMeta>> {

--- a/src/workspace_json_tests.rs
+++ b/src/workspace_json_tests.rs
@@ -546,7 +546,7 @@ fn jar_paths_absent_returns_empty() {
 /// `library`-type dependency, and a matching `libraries[]` entry whose
 /// `properties.attributes` carries structured GAV coordinates.
 #[test]
-fn deserializes_real_schema_and_extracts_gav_from_properties() {
+fn real_schema_deserialization_extracts_gav_from_properties() {
     let dir = TempDir::new().unwrap();
     make_workspace_json(
         &dir,

--- a/src/workspace_json_tests.rs
+++ b/src/workspace_json_tests.rs
@@ -539,3 +539,210 @@ fn jar_paths_absent_returns_empty() {
     make_workspace_json(&dir, r#"{"sourcePaths": []}"#);
     assert!(load_configured_jar_paths(dir.path()).is_empty());
 }
+
+// ─── real workspace.json schema: libraries[] + dependencies[] ─────────────────
+
+/// Mirrors the design doc's cited PetClinic excerpt: a module with a
+/// `library`-type dependency, and a matching `libraries[]` entry whose
+/// `properties.attributes` carries structured GAV coordinates.
+#[test]
+fn deserializes_real_schema_and_extracts_gav_from_properties() {
+    let dir = TempDir::new().unwrap();
+    make_workspace_json(
+        &dir,
+        r#"{
+            "modules": [{
+                "name": "PetClinic.main",
+                "contentRoots": [{"path": "<WORKSPACE>/app"}],
+                "dependencies": [
+                    {"type": "library", "name": "Gradle: ch.qos.logback:logback-classic:1.5.16", "scope": "compile"}
+                ]
+            }],
+            "libraries": [{
+                "name": "Gradle: ch.qos.logback:logback-classic:1.5.16",
+                "type": "COMPILE",
+                "roots": [{"path": "<GRADLE_REPO>/logback-classic-1.5.16.jar"}],
+                "properties": {"attributes": {
+                    "groupId": "ch.qos.logback",
+                    "artifactId": "logback-classic",
+                    "version": "1.5.16",
+                    "baseVersion": "1.5.16"
+                }}
+            }]
+        }"#,
+    );
+
+    let workspace_data = parse_workspace_data(dir.path()).expect("real schema fixture must parse");
+    assert_eq!(workspace_data.libraries.len(), 1);
+    let gradle_meta =
+        library_gradle_meta(&workspace_data.libraries[0]).expect("properties path must resolve");
+    assert_eq!(gradle_meta.group, "ch.qos.logback");
+    assert_eq!(gradle_meta.artifact, "logback-classic");
+    assert_eq!(gradle_meta.version, "1.5.16");
+}
+
+#[test]
+fn library_gradle_meta_falls_back_to_name_string_when_properties_absent() {
+    let library = LibraryData {
+        name: "Gradle: org.jetbrains.kotlin:kotlin-stdlib:2.0.0".to_owned(),
+        roots: Vec::new(),
+        properties: None,
+    };
+    let gradle_meta = library_gradle_meta(&library).expect("name-string fallback must resolve");
+    assert_eq!(gradle_meta.group, "org.jetbrains.kotlin");
+    assert_eq!(gradle_meta.artifact, "kotlin-stdlib");
+    assert_eq!(gradle_meta.version, "2.0.0");
+}
+
+/// The third-party plugin's synthetic Android SDK library is also
+/// `"Gradle: "`-prefixed — it must parse like any other 3-segment name.
+#[test]
+fn library_gradle_meta_parses_synthetic_android_sdk_name() {
+    let library = LibraryData {
+        name: "Gradle: android:android:36".to_owned(),
+        roots: Vec::new(),
+        properties: None,
+    };
+    let gradle_meta = library_gradle_meta(&library).expect("synthetic name must still parse");
+    assert_eq!(gradle_meta.group, "android");
+    assert_eq!(gradle_meta.artifact, "android");
+    assert_eq!(gradle_meta.version, "36");
+}
+
+#[test]
+fn library_gradle_meta_returns_none_for_malformed_library() {
+    let library = LibraryData {
+        name: "a hand-added local jar".to_owned(),
+        roots: Vec::new(),
+        properties: None,
+    };
+    assert!(library_gradle_meta(&library).is_none());
+}
+
+/// An unrecognized `type` value on a dependency entry (simulating a future
+/// schema addition) must be ignored, not fail the whole module's parse.
+#[test]
+fn unknown_dependency_type_is_ignored_not_a_parse_error() {
+    let dir = TempDir::new().unwrap();
+    make_workspace_json(
+        &dir,
+        r#"{
+            "modules": [{
+                "name": "app.main",
+                "contentRoots": [{"path": "<WORKSPACE>/app"}],
+                "dependencies": [
+                    {"type": "futureKind", "name": "something-unknown"},
+                    {"type": "library", "name": "Gradle: com.example:known:1.0"}
+                ]
+            }],
+            "libraries": [{
+                "name": "Gradle: com.example:known:1.0",
+                "roots": []
+            }]
+        }"#,
+    );
+
+    let workspace_data =
+        parse_workspace_data(dir.path()).expect("unknown dependency type must not fail parsing");
+    assert_eq!(workspace_data.modules.len(), 1);
+    assert_eq!(workspace_data.modules[0].dependencies.len(), 2);
+}
+
+/// Matches the third-party plugin's documented deviations: `type` is the
+/// non-standard `"java-imported"`, no `module`/`sdk`-type dependency entries
+/// ever appear, and `externalProjectId` is never emitted.
+#[test]
+fn third_party_plugin_shape_does_not_break_parsing() {
+    let dir = TempDir::new().unwrap();
+    make_workspace_json(
+        &dir,
+        r#"{
+            "modules": [{
+                "name": "app.main",
+                "contentRoots": [{"path": "<WORKSPACE>/app"}],
+                "dependencies": [
+                    {"type": "library", "name": "Gradle: com.example:known:1.0", "scope": "compile"},
+                    {"type": "moduleSource"},
+                    {"type": "inheritedSdk"}
+                ]
+            }],
+            "libraries": [{
+                "name": "Gradle: com.example:known:1.0",
+                "type": "java-imported",
+                "roots": [{"path": "<GRADLE_REPO>/known-1.0.jar"}]
+            }]
+        }"#,
+    );
+
+    let workspace_data =
+        parse_workspace_data(dir.path()).expect("third-party plugin shape must parse");
+    assert!(workspace_data.modules[0].external_project_id.is_none());
+    let gradle_meta = library_gradle_meta(&workspace_data.libraries[0])
+        .expect("name-string fallback must still resolve despite java-imported type");
+    assert_eq!(gradle_meta.artifact, "known");
+}
+
+#[test]
+fn load_module_dependencies_scopes_each_module_to_its_own_content_roots() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("app")).unwrap();
+    fs::create_dir_all(dir.path().join("core")).unwrap();
+    make_workspace_json(
+        &dir,
+        r#"{
+            "modules": [
+                {
+                    "name": "app.main",
+                    "contentRoots": [{"path": "<WORKSPACE>/app"}],
+                    "dependencies": [
+                        {"type": "library", "name": "Gradle: com.example:shared:1.0"},
+                        {"type": "library", "name": "Gradle: com.example:app-only:2.0"}
+                    ]
+                },
+                {
+                    "name": "core.main",
+                    "contentRoots": [{"path": "<WORKSPACE>/core"}],
+                    "dependencies": [
+                        {"type": "library", "name": "Gradle: com.example:shared:1.0"},
+                        {"type": "library", "name": "Gradle: com.example:core-only:3.0"}
+                    ]
+                }
+            ],
+            "libraries": [
+                {"name": "Gradle: com.example:shared:1.0", "roots": []},
+                {"name": "Gradle: com.example:app-only:2.0", "roots": []},
+                {"name": "Gradle: com.example:core-only:3.0", "roots": []}
+            ]
+        }"#,
+    );
+
+    let dependencies_by_content_root = load_module_dependencies(dir.path());
+
+    let app_dependencies = dependencies_by_content_root
+        .get(&dir.path().join("app"))
+        .expect("app content root must be present");
+    let artifacts: std::collections::HashSet<&str> = app_dependencies
+        .iter()
+        .map(|gradle_meta| gradle_meta.artifact.as_str())
+        .collect();
+    assert!(artifacts.contains("shared"));
+    assert!(artifacts.contains("app-only"));
+    assert!(
+        !artifacts.contains("core-only"),
+        "core-only dependency leaked into app's scope: {artifacts:?}"
+    );
+
+    let core_dependencies = dependencies_by_content_root
+        .get(&dir.path().join("core"))
+        .expect("core content root must be present");
+    let artifacts: std::collections::HashSet<&str> = core_dependencies
+        .iter()
+        .map(|gradle_meta| gradle_meta.artifact.as_str())
+        .collect();
+    assert!(artifacts.contains("shared"));
+    assert!(artifacts.contains("core-only"));
+    assert!(
+        !artifacts.contains("app-only"),
+        "app-only dependency leaked into core's scope: {artifacts:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- `supertype_targets` (the recursive supertype-hierarchy walk) called `resolve_symbol_no_rg` unconditionally for every hop, whose `NoRg` tail is an unscoped "first match in an arbitrarily-ordered `Vec`" lookup with zero disambiguation. Fine for the function's 7 other callers (all have real per-file import context via `from_uri`), but genuinely wrong beyond hop 1 of the hierarchy walk — once an ancestor lives in a compiled JAR, `from_uri` becomes a `jar:` synthetic URI with no import list at all.
- Live-reproduced on the real Moneta corpus: a walk from `CallUsActivity : AppCompatActivity()` correctly resolves 3 hops via real import context, then silently substitutes an unrelated `com.android.internal.telephony.DctConstants.Activity` (a nested enum) for the intended `android.app.Activity` — both share the bare name `Activity`.
- Adds `ResolveIo::HierarchyAmbiguitySafe`: a unique candidate wins outright; an ambiguous set gets two tie-breaks in sequence before still declining:
  1. A narrow, unconditional denylist dropping candidates whose package starts with `com.android.internal.` — the one specific pattern directly evidenced by the reproduction above.
  2. **New in this update**: module-scoped narrowing using real, Gradle-resolved per-module dependency data. `workspace.json` turns out to be a real, externally-standardized format (also produced by the official JetBrains `kotlin-lsp` and a third-party Gradle plugin) carrying per-module `dependencies[]`/`libraries[]` data this codebase previously ignored entirely. When present, a candidate is kept only if its own JAR's `(group, artifact)` coordinate is in the calling file's owning module's real dependency set — giving zero-uncertainty scoping (Gradle already resolved transitivity) for exactly the class of problem a flat, project-wide denylist (`KNOWN_BUILD_TOOLING_ARTIFACTS`) structurally cannot solve (e.g. `kotlin-gradle-plugin` is a genuine dependency of one module and a decoy everywhere else).
- Scoped entirely to a new sibling function used only at the `supertype_targets` call site — `resolve_symbol_no_rg` itself and its other 7 callers are byte-for-byte unchanged.

## Design docs
- `docs/superpowers/specs/2026-08-25-hierarchy-walk-unscoped-name-collision-design.md` — the original ambiguity-safe-tail investigation and design.
- `docs/superpowers/specs/2026-08-25-real-workspace-json-schema-and-consumption-design.md` — the real `workspace.json` schema, verified against JetBrains's own source and a real Gradle-synced fixture, and the module-scoping design.

## Known limitation, disclosed not hidden
This does **not** make `finish()`-shaped calls resolve correctly end-to-end in every case. A second, independent bug (the `ResolveIo::Full` project-wide `rg` text-search fallback, which fires when the hierarchy walk comes up empty) can still produce its own wrong answer downstream when no per-module data is available. Module-scoped narrowing only helps when a real `workspace.json` (from a real Gradle-sync producer) is present — most projects today don't have one; this PR does not add kmp-lsp's own from-scratch generator for that case (deliberately deferred, separate follow-on).

## Test plan
- [x] `cargo test --bin kmp-lsp` (1838 tests) clean
- [x] Full `cargo test` (all 7 binaries) clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] RED/GREEN TDD throughout: synthetic same-simple-name collision fixtures, a 4-hop acceptance fixture reproducing the real corpus shape, real-schema round-trip + GAV-extraction tests (structured properties, name-string fallback, malformed input), module-scoped narrowing tested through the real `supertype_targets` entry point (both the narrows-correctly case and the no-data-available/unchanged-behavior case)
- [x] Regression benchmark (resolution-accuracy CLI, Moneta corpus, before/after): recall moved within normal run-to-run noise — the "some walks worked by luck" regression risk did not measurably materialize

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ