### PR TITLE
fix(indexer): exclude Kotlin Gradle Plugin's internal-only siblings and dalvik-dx

### DIFF
--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -116,7 +116,38 @@ const KNOWN_BUILD_TOOLING_ARTIFACTS: &[(&str, &str)] = &[
     ("com.android.tools.lint", "lint-checks"),
     ("com.android.tools.lint", "lint-model"),
     ("com.android.tools.lint", "lint-typedef-remover"),
+    // Kotlin Gradle Plugin's internal IDE-sync and build-tools-API
+    // implementation artifacts. Confirmed zero imports from these
+    // internally namespaced packages on the real Moneta corpus, and each
+    // ships a decoy for a common name (`Enum`, `Serializable`, or
+    // `Type`/`Options`/`Context`/`Handler` in `kotlin-build-tools-impl`'s
+    // large shaded ASM/diff-utility bundle).
+    ("org.jetbrains.kotlin", "kotlin-gradle-plugin-idea-proto"),
+    ("org.jetbrains.kotlin", "kotlin-build-tools-cri-impl"),
+    ("org.jetbrains.kotlin", "kotlin-build-tools-impl"),
+    // `dalvik-dx`: the repackaged legacy Android dexer/AOSP `dx` tool.
+    // Confirmed zero corpus imports of `com.android.dx`/`com.android.dex`.
+    ("com.jakewharton.android.repackaged", "dalvik-dx"),
 ];
+
+// `("org.jetbrains.kotlin", "kotlin-gradle-plugin")` is deliberately NOT
+// listed above. It is a confirmed decoy source for `Serializable`,
+// `Comparable`, `Cloneable`, `CharSequence`, `Enum`, `Throwable`, and
+// `Function` (48% of hierarchy-walk ambiguous-collision hits on the real
+// Moneta corpus), but the artifact is also genuinely imported by that same
+// corpus's own `build-logic/convention/src/main/kotlin` module:
+// `KotlinAndroidProjectExtension` and `KotlinJvmProjectExtension` are
+// defined *only* in this artifact (no other cached jar, including
+// `kotlin-gradle-plugin-api`, ships either class) and are directly
+// referenced there. Excluding it would make those two classes permanently
+// unresolvable, not just disambiguated — see this commit's message for the
+// empirical before/after measurement of both effects.
+//
+// `net.java.dev.jna`, `org.codehaus.groovy:groovy`, and
+// `org.apache.logging.log4j:log4j-core` were also checked (zero corpus
+// imports found) but are deliberately not added: unlike Kotlin Gradle
+// Plugin's internally namespaced packages, these are general-purpose
+// libraries genuinely used as real dependencies by other real projects.
 
 /// True when a Gradle-cache JAR belongs to a known build-tooling/compiler/
 /// IDE-platform artifact rather than an application dependency — see

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -921,6 +921,116 @@ fn scan_gradle_jars_split_keeps_lint_api_but_excludes_lint_tooling() {
 }
 
 #[test]
+fn scan_gradle_jars_split_excludes_internal_only_build_tooling_artifacts() {
+    // `kotlin-gradle-plugin` embeds internal compiler machinery under
+    // shaded common names (`Serializable`, `Comparable`, `Enum`, ...) that
+    // collide with real app hierarchy walks in 48% of measured ambiguous
+    // cases, but it is deliberately NOT excluded (it is genuinely imported
+    // by real build-logic convention-plugin source, see the comment above
+    // `KNOWN_BUILD_TOOLING_ARTIFACTS`). Its internal-only siblings
+    // (`kotlin-gradle-plugin-idea-proto`, `kotlin-build-tools-cri-impl`,
+    // `kotlin-build-tools-impl`) and the repackaged legacy Android dexer
+    // (`dalvik-dx`) have no such legitimate use and must still be excluded.
+    let tmpdir = tempfile::tempdir().unwrap();
+    write_compiled_jar(
+        tmpdir.path(),
+        "org.jetbrains.kotlin",
+        "kotlin-stdlib",
+        "2.2.21",
+        &[("kotlin/collections/CollectionsKt.class", "stub")],
+    );
+    write_compiled_jar(
+        tmpdir.path(),
+        "org.jetbrains.kotlin",
+        "kotlin-gradle-plugin",
+        "1.9.24",
+        &[(
+            "org/jetbrains/kotlin/gradle/tasks/KotlinCompile.class",
+            "stub",
+        )],
+    );
+    write_compiled_jar(
+        tmpdir.path(),
+        "org.jetbrains.kotlin",
+        "kotlin-gradle-plugin-idea-proto",
+        "2.4.10",
+        &[("org/jetbrains/kotlin/gradle/idea/proto/Enum.class", "stub")],
+    );
+    write_compiled_jar(
+        tmpdir.path(),
+        "org.jetbrains.kotlin",
+        "kotlin-build-tools-cri-impl",
+        "2.4.10",
+        &[(
+            "org/jetbrains/kotlin/buildtools/internal/cri/Serializable.class",
+            "stub",
+        )],
+    );
+    write_compiled_jar(
+        tmpdir.path(),
+        "org.jetbrains.kotlin",
+        "kotlin-build-tools-impl",
+        "2.4.10",
+        &[(
+            "org/jetbrains/kotlin/buildtools/internal/Type.class",
+            "stub",
+        )],
+    );
+    write_compiled_jar(
+        tmpdir.path(),
+        "com.jakewharton.android.repackaged",
+        "dalvik-dx",
+        "9.0.0_r3",
+        &[("com/android/dx/Type.class", "stub")],
+    );
+
+    let (compiled, _) = crate::indexer::jar::scan_gradle_jars_split(Some(tmpdir.path()));
+
+    let survivors: Vec<String> = compiled
+        .iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        survivors.iter().any(|path| path.contains("kotlin-stdlib")),
+        "real runtime jar kotlin-stdlib must survive the scan, got: {survivors:?}"
+    );
+    assert!(
+        survivors
+            .iter()
+            .any(|path| path.contains("kotlin-gradle-plugin-1.9.24")),
+        "kotlin-gradle-plugin itself must survive the scan -- it is genuinely \
+         imported by real build-logic convention-plugin source, got: {survivors:?}"
+    );
+    assert!(
+        !survivors
+            .iter()
+            .any(|path| path.contains("kotlin-gradle-plugin-idea-proto")),
+        "kotlin-gradle-plugin-idea-proto is internal-only and must be excluded, got: {survivors:?}"
+    );
+    assert!(
+        !survivors
+            .iter()
+            .any(|path| path.contains("kotlin-build-tools-cri-impl")),
+        "kotlin-build-tools-cri-impl is internal-only and must be excluded, got: {survivors:?}"
+    );
+    assert!(
+        !survivors
+            .iter()
+            .any(|path| path.contains("kotlin-build-tools-impl")),
+        "kotlin-build-tools-impl is internal-only and must be excluded, got: {survivors:?}"
+    );
+    assert!(
+        !survivors.iter().any(|path| path.contains("dalvik-dx")),
+        "dalvik-dx is the repackaged legacy Android dexer and must be excluded, got: {survivors:?}"
+    );
+    assert_eq!(
+        survivors.len(),
+        2,
+        "expected exactly kotlin-stdlib and kotlin-gradle-plugin to survive, got: {survivors:?}"
+    );
+}
+
+#[test]
 fn index_sources_jars_end_to_end_with_real_jar() {
     // End-to-end smoke: walk the real Gradle cache + extract + parse + insert.
     // One small JAR, one .kt file.  Exercises the slow I/O path that


### PR DESCRIPTION
## Summary
- An impact measurement of #286 (hierarchy-walk ambiguity-safe fix) found that **48% of all 111,277 ambiguous-collision hits** on the real Moneta corpus involve `org.jetbrains.kotlin:kotlin-gradle-plugin` — its internal compiler machinery defines decoy classes named `Serializable`, `Comparable`, `Cloneable`, `CharSequence`, `Enum`, `Throwable`, and `Function`, extremely common names nearly every real class's hierarchy touches.
- **`kotlin-gradle-plugin` itself is deliberately NOT added to the denylist.** The real corpus's own `build-logic/convention` module genuinely imports `KotlinAndroidProjectExtension`/`KotlinJvmProjectExtension`, which exist *only* in this artifact (not even in `kotlin-gradle-plugin-api`). Excluding it would make those permanently unresolvable, not just disambiguated.
- Its purely internal-only siblings have no such legitimate use and are added instead: `kotlin-gradle-plugin-idea-proto`, `kotlin-build-tools-cri-impl`, `kotlin-build-tools-impl`, and `com.jakewharton.android.repackaged:dalvik-dx` (the repackaged legacy Android dexer). Each verified individually to have zero imports from its internally-namespaced packages on the real Moneta corpus — same discipline the original denylist used, not a blanket exclusion.
- Investigated but deliberately **not** added: `log4j-core`, `groovy`, `jna`/`jna-platform` — plausibly build-tooling-shaped in this corpus's samples, but general-purpose libraries genuinely used as real dependencies by other real projects; excluding them wouldn't be safe as a blanket rule.

## Architectural context
An independent review confirmed no faster ground-truth source exists in this codebase's performance envelope for distinguishing real app dependencies from buildscript/plugin-classpath artifacts in the shared Gradle module cache (no directory/metadata signal for classpath category; live Gradle invocation is too slow; AGP's own generated dependency list is too narrow/optional). Extending this per-artifact-verified denylist is the deliberate, correct approach — not a shortcut around a better fix that was sitting unused.

## Measured impact
Confirmed via the same instrumentation approach as the original measurement: the 3 sibling artifacts + `dalvik-dx` now show **zero** collision occurrences post-fix. The dominant `kotlin-gradle-plugin` source correctly remains — excluding it would trade a disambiguation problem for a hard resolution failure in a real, narrow module.

## Test plan
- [x] `cargo test --bin kmp-lsp` (1826 tests) clean
- [x] Full `cargo test` (all 7 binaries) clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] RED/GREEN TDD: synthetic Gradle-cache fixture proving `kotlin-gradle-plugin` survives (real dependency) while its 4 internal-only siblings are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ