### PR TITLE
fix(resolve): consult in-scope extensions for variable-receiver member calls

### DIFF
--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -1068,6 +1068,11 @@ fn resolve_qualified(
     // Resolve the variable's type to its source file.
     let type_locs = resolve_symbol(indexer, outer_type, None, from_uri);
     let mut current_file: Option<String> = type_locs.first().map(|l| l.uri.to_string());
+    // The receiver's own base type name, tracked alongside `current_file` for
+    // the in-scope extension-function fallback below — kept even when
+    // `current_file` is `None` (a built-in/stdlib type like `String` has no
+    // indexed declaration file, but can still have in-scope extensions).
+    let mut current_type_base: String = outer_type.last_segment().to_string();
 
     // If there's a nested type component (e.g. `Factory` in `Outer.Factory`),
     // the members we want to search are inside that nested type.
@@ -1096,6 +1101,7 @@ fn resolve_qualified(
                     .first()
                     .map(|l| l.uri.to_string())
             };
+            current_type_base = seg.to_string();
         } else {
             // Field access: infer the declared type of this field.
             let Some(field_type) = infer_field_type(indexer, uri, seg) else {
@@ -1103,23 +1109,38 @@ fn resolve_qualified(
             };
             let locs = resolve_symbol(indexer, &field_type, None, from_uri);
             current_file = locs.first().map(|l| l.uri.to_string());
+            current_type_base = field_type.strip_nullable().last_segment().to_string();
         }
     }
 
-    // Search the resolved type's file for the target member.
-    let Some(ref resolved_uri) = current_file else {
-        return vec![];
-    };
-    let locs = find_name_in_uri(indexer, name, resolved_uri);
-    if !locs.is_empty() {
-        return locs;
+    // Search the resolved type's file for the target member, then its
+    // superclass/interface hierarchy — Kotlin member (including inherited)
+    // resolution always shadows a same-named extension function, so both are
+    // tried before falling to the extension-in-scope lookup below.
+    if let Some(ref resolved_uri) = current_file {
+        let locs = find_name_in_uri(indexer, name, resolved_uri);
+        if !locs.is_empty() {
+            return locs;
+        }
+        if let Ok(parsed_uri) = Url::parse(resolved_uri) {
+            let hierarchy_locs = resolve_from_class_hierarchy(indexer, name, &parsed_uri);
+            if !hierarchy_locs.is_empty() {
+                return hierarchy_locs;
+            }
+        }
     }
 
-    // Member not found directly — walk the superclass/interface hierarchy.
-    let Ok(parsed_uri) = Url::parse(resolved_uri) else {
-        return vec![];
-    };
-    resolve_from_class_hierarchy(indexer, name, &parsed_uri)
+    // No member or inherited member named `name` on the receiver's type (this
+    // also covers built-in/stdlib receivers like `String`/`Int`, which have
+    // no indexed declaration file at all, so `current_file` is `None`) — the
+    // call may still be a same-named, receiver-scoped extension function
+    // declared elsewhere in the workspace. Without this, callers fell
+    // straight through to the receiver-blind global bare-name search, which
+    // can't distinguish `String.toViewText` from an unrelated
+    // `SomeEnum.toViewText` and simply declines when both exist — a real,
+    // measured source of ambiguous member-call resolution (see the
+    // 2026-08-26 resolution-accuracy investigation).
+    resolve_extension_in_scope(indexer, &current_type_base, name, from_uri)
 }
 
 /// Step 1 — symbols defined in the same source file.

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -954,6 +954,55 @@ fn resolve_nested_type_via_variable_annotation() {
 }
 
 #[test]
+fn resolve_variable_receiver_extension_disambiguates_by_receiver_type() {
+    // `message.toViewText()` where `message: String` — `String` has no
+    // indexed declaration file (a built-in type) and no matching member.
+    // `String.toViewText` is only imported (not same-package), and an
+    // unrelated `EFrequency.toViewText` also exists elsewhere in the
+    // workspace with neither import nor same-package visibility from the
+    // call site. Before the fix, the lowercase-root branch gave up once the
+    // receiver type's own member/hierarchy search failed, so this fell
+    // through all the way to the receiver-blind global-definitions tail,
+    // which sees both candidates and declines (ambiguous) rather than
+    // picking either. The fix must instead resolve `message`'s real type
+    // (`String`) and use the existing receiver-scoped, import-aware
+    // extension lookup to find the one real, in-scope candidate.
+    let host_uri = Url::parse("file:///app/Host.kt").unwrap();
+    let string_ext_uri = Url::parse("file:///lib/a/StringExtensions.kt").unwrap();
+    let other_ext_uri = Url::parse("file:///lib/b/OtherExtensions.kt").unwrap();
+    let idx = Indexer::new();
+    idx.index_content(
+        &string_ext_uri,
+        "package com.lib.a\nfun String.toViewText(): String = this\n",
+    );
+    idx.index_content(
+        &other_ext_uri,
+        concat!(
+            "package com.lib.b\n",
+            "enum class EFrequency { WEEKLY }\n",
+            "fun EFrequency.toViewText(): String = name\n",
+        ),
+    );
+    idx.index_content(
+        &host_uri,
+        concat!(
+            "package com.app\n",
+            "import com.lib.a.toViewText\n",
+            "val message: String = \"hi\"\n",
+            "fun foo() { message.toViewText() }\n",
+        ),
+    );
+
+    let locs = resolve_symbol_index_only(&idx, "toViewText", Some("message"), &host_uri);
+    assert_eq!(
+        locs.len(),
+        1,
+        "expected exactly the String.toViewText extension, got {locs:?}"
+    );
+    assert_eq!(locs[0].uri, string_ext_uri);
+}
+
+#[test]
 fn resolve_dotted_name_traverses_deep_nesting() {
     // `Bar.Baz.Foo` passed directly as `name` (no qualifier) must walk the full
     // nested-type chain Bar → Baz → Foo, not just the first dot.


### PR DESCRIPTION
## Summary
- `resolve_qualified`'s lowercase-root (variable/parameter receiver) branch only checked the receiver type's own declared members + supertype hierarchy, then fell through to a receiver-blind global bare-name search when nothing matched — which is *always* the case for extension functions, and unconditionally the case for built-in/stdlib receiver types (`String`, `Int`, ...) that have no indexed declaration file at all.
- That global fallback can't tell apart two same-named extension functions declared for different receiver types, and declines (empty result) whenever more than one exists workspace-wide.
- Real-corpus evidence from the resolution-accuracy benchmark against Moneta: the ambiguous (`FilteredCandidate`) bucket is dominated by extension-function calls on variables (`toViewText`, `launch`, `log`, `async`, ...) — most of these names have only a handful of real, receiver-distinct candidates, not genuine multi-way collisions.
- Fix: after the member/hierarchy search comes up empty, fall back to the existing `resolve_extension_in_scope` (receiver-type-scoped, visibility/import-aware) lookup — already used by the uppercase-root `TypeName.member` branch — before giving up.

## Test plan
- [x] New regression test: `resolve_variable_receiver_extension_disambiguates_by_receiver_type` (RED confirmed before the fix, GREEN after)
- [x] Full test suite: `cargo test --bin kmp-lsp` — 1826 passed, 0 failed
- [x] `cargo fmt --check` / pre-commit clippy — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ