### PR TITLE
fix(sidecar): mark Kotlin default-valued parameters in rendered signatures

### DIFF
--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
@@ -245,7 +245,10 @@ private fun renderFunction(fn: KmFunction, receiver: KmType? = null, classTypePa
         if (receiver != null) { append(receiver.render(typeParams)); append('.') }
         append(fn.name)
         append('(')
-        fn.valueParameters.joinTo(this, ", ") { p -> "${p.name}: ${p.type?.render(typeParams) ?: "Any?"}" }
+        fn.valueParameters.joinTo(this, ", ") { p ->
+            val defaultMarker = if (p.declaresDefaultValue) " = ..." else ""
+            "${p.name}: ${p.type?.render(typeParams) ?: "Any?"}$defaultMarker"
+        }
         append(')')
         val ret = fn.returnType
         if (!ret.isUnit()) { append(": "); append(ret.render(typeParams)) }

--- a/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
+++ b/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
@@ -428,4 +428,40 @@ class IndexerTest {
                 "got: ${guidance.map { "${it.detail} -> deprecated=${it.deprecated}" }}",
         )
     }
+
+    @Test
+    @DisplayName("indexJarFile marks defaulted parameters in rendered function detail")
+    fun testDefaultedParametersAreMarkedInDetail() {
+        // The real `launch` overload's `context`/`start` parameters both carry
+        // Kotlin default values (`= EmptyCoroutineContext`, `= CoroutineStart.DEFAULT`);
+        // only `block` is truly required. Without a default-value marker in the
+        // rendered detail text, the Rust side's `params_from_detail` (which infers
+        // "required" purely from the ABSENCE of `=` in each parameter's own text)
+        // has no way to tell these apart from a fully-required 3-arg function --
+        // causing a real call like `scope.launch { ... }` (0 explicit args, only a
+        // trailing lambda) to fail arity/shape filtering against a wrongly-required
+        // `context`/`start`, and get treated as unresolved/ambiguous. This is a
+        // real, measured bug found via the resolution-accuracy benchmark on a real
+        // Kotlin/Android corpus (Moneta) -- see the 2026-08-26 investigation.
+        val jarPath = System.getProperty("coroutines.jar")
+        assertNotNull(jarPath, "coroutines.jar system property must be set by the build")
+
+        val real = indexJarFile(jarPath!!)
+            .filter { it.name == "launch" && it.extensionReceiverType == "CoroutineScope" }
+            .firstOrNull { it.detail.contains("context: CoroutineContext") && !it.deprecated }
+        assertNotNull(real, "real launch(context: CoroutineContext, ...) overload missing")
+
+        assertTrue(
+            real!!.detail.contains("context: CoroutineContext =") &&
+                real.detail.contains("start: CoroutineStart ="),
+            "context/start both declare Kotlin default values and must be marked " +
+                "with '=' in the rendered detail so params_from_detail counts them " +
+                "as optional, got: ${real.detail}",
+        )
+        assertFalse(
+            real.detail.substringAfter("block:").contains("="),
+            "block has no default value and must NOT be marked with '=', " +
+                "got: ${real.detail}",
+        )
+    }
 }

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -40,7 +40,12 @@ use crate::sidecar::SidecarSymbol;
 ///            in addition to classes/methods — a cache built before this shipped has no
 ///            field entries at all, and the JAR's own (mtime, size) fingerprint never
 ///            changes to reveal that, so the version must be bumped to force a rescan.
-const JAR_CACHE_VERSION: u32 = 14;
+/// v14 → v15: sidecar's `renderFunction` now marks each Kotlin default-valued parameter
+///            with a trailing `= ...` in the rendered `detail` text, so `params_from_detail`
+///            can tell a defaulted param apart from a required one (previously every
+///            JAR-derived extension function's default-valued params were counted as
+///            required, wrongly rejecting real calls like `scope.launch { }` on arity).
+const JAR_CACHE_VERSION: u32 = 15;
 
 #[derive(Serialize, Deserialize)]
 struct JarCache {


### PR DESCRIPTION
## Summary
- `KotlinClassIndexer`'s `renderFunction` (java-sidecar) rendered every extension-function parameter as plain `"name: Type"`, with no indication of whether it carries a Kotlin default value — even though the underlying `kotlinx-metadata` parse already exposes this via `KmValueParameter.declaresDefaultValue`.
- On the Rust side, `params_from_detail` infers a parameter's "required" status purely from the absence of `=` in its own rendered text (already correctly handles `= 0`-style markers, per its own existing tests) — so every JAR-derived extension function with a defaulted parameter was silently counted as fully required, regardless of its real arity.
- **Real, measured impact**: `kotlinx.coroutines`' `CoroutineScope.launch(context = EmptyCoroutineContext, start = CoroutineStart.DEFAULT, block)` reported `param_counts=(3,3)` instead of the true `(1,3)` — so an ordinary `scope.launch { ... }` call (0 explicit args + a trailing lambda) failed `CallShape`'s arity check and got demoted to unresolved/ambiguous. **This is not narrow** — any JAR-derived function with a default parameter (extremely common across `kotlinx.coroutines`, Compose, and the Kotlin stdlib) was affected identically.
- Fix: mark each parameter with `= ...` in the rendered detail when `declaresDefaultValue` is true — `params_from_detail` already handles this shape correctly (existing test coverage), so no Rust-side logic change was needed beyond bumping `JAR_CACHE_VERSION` to force a rescan of already-cached JARs built under the old, defaults-blind rendering.

## Real-corpus impact (measured, not estimated)
Re-ran `kmp-lsp resolution-accuracy --root ~/Work/Moneta/android` with this fix isolated from every other resolver-side fix from this session:
- member-ref recall: **76.4% → ~82.0-82.5%**
- FilteredCandidate (ambiguous): **~18,900 → ~10,000-10,500** (~45% reduction, confirmed across 2 runs)
- `launch` specifically: fully disappeared from the ambiguous bucket, now a stable resolved cache hit

By far the largest single improvement found in this session's resolution-accuracy investigation.

## Test plan
- [x] New sidecar test: `testDefaultedParametersAreMarkedInDetail` (RED→GREEN, verified against the real `kotlinx-coroutines-core-jvm:1.11.0` fixture jar already used by the sibling deprecated-overload test)
- [x] Full sidecar test suite: `./gradlew test` — all pass
- [x] Full Rust test suite: `cargo test --bin kmp-lsp` — 1847 passed, 0 failed
- [x] `cargo fmt --check` / pre-commit clippy — clean
- [x] Real-corpus benchmark re-run (see above)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ