### PR TITLE
resolve kotlin.String/CharSequence to their real java.lang platform type

### DIFF
--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -55,6 +55,8 @@ pub(crate) use infer_lines::{
     find_declaration_range_in_lines, infer_type_in_lines, infer_type_in_lines_raw,
 };
 #[cfg(test)]
+pub(crate) use resolve::resolve_kotlin_builtin_type_platform_equivalent;
+#[cfg(test)]
 pub(crate) use resolve::resolve_symbol;
 #[cfg(test)]
 pub(crate) use resolve::resolve_symbol_index_only;

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -380,7 +380,7 @@ fn resolve_chain(
         }
         let rg_locations =
             rg_find_definition(name, root.as_deref(), &source_roots, matcher.as_deref());
-        return match shape {
+        let rg_result = match shape {
             // `rg` is a blind text search with no arity awareness of its own — without this,
             // a same-file, wrong-arity declaration that step 1 already ruled out can come
             // straight back here, since `rg` re-finds it by pattern match alone.
@@ -390,6 +390,16 @@ fn resolve_chain(
                 .collect(),
             None => rg_locations,
         };
+        if !rg_result.is_empty() {
+            return rg_result;
+        }
+        // 5.5 ── Kotlin built-in-type platform equivalent (last resort) ────────
+        // `rg`/`fd` search the *workspace's own* source tree and can never find
+        // `String`/`CharSequence`: those are compiler intrinsics with no
+        // compiled `.class` file in kotlin-stdlib's JAR at all, and no
+        // in-workspace source either -- see
+        // docs/superpowers/specs/2026-08-27-kotlin-builtin-type-platform-mapping-design.md.
+        return resolve_kotlin_builtin_type_platform_equivalent(indexer, name);
     }
 
     // Tail fallback — global definitions index (includes JAR symbols).
@@ -405,22 +415,50 @@ fn resolve_chain(
     //    `com.android.internal.*`-packaged one) when it used the older,
     //    plain unique-match-only rule.
     //  - Full: never reached (returns inside the rg branch above).
+    //
+    // Each non-`ScopedOnly` arm falls through to
+    // `resolve_kotlin_builtin_type_platform_equivalent` when its own lookup
+    // comes up empty -- see the 5.5 comment above the `Full`/rg branch.
+    // `ScopedOnly` is deliberately excluded: "no tail at all" is its own
+    // documented contract (its callers already have their own downstream
+    // fallback), so it must not gain one here.
     match io {
-        ResolveIo::Full | ResolveIo::ScopedOnly => vec![],
-        ResolveIo::NoRg => indexer
-            .lookup_definitions(name)
-            .into_iter()
-            .next()
-            .map(|loc| vec![loc])
-            .unwrap_or_default(),
-        ResolveIo::IndexOnly => {
-            ambiguity_safe_tail_with_denylist(indexer, from_uri, indexer.lookup_definitions(name))
+        ResolveIo::Full => vec![],
+        ResolveIo::ScopedOnly => vec![],
+        ResolveIo::NoRg => {
+            let found = indexer
+                .lookup_definitions(name)
+                .into_iter()
+                .next()
+                .map(|loc| vec![loc])
+                .unwrap_or_default();
+            if !found.is_empty() {
+                return found;
+            }
+            resolve_kotlin_builtin_type_platform_equivalent(indexer, name)
         }
-        ResolveIo::HierarchyAmbiguitySafe => ambiguity_safe_tail_with_denylist(
-            indexer,
-            hierarchy_walk_origin_uri.unwrap_or(from_uri),
-            indexer.lookup_definitions(name),
-        ),
+        ResolveIo::IndexOnly => {
+            let found = ambiguity_safe_tail_with_denylist(
+                indexer,
+                from_uri,
+                indexer.lookup_definitions(name),
+            );
+            if !found.is_empty() {
+                return found;
+            }
+            resolve_kotlin_builtin_type_platform_equivalent(indexer, name)
+        }
+        ResolveIo::HierarchyAmbiguitySafe => {
+            let found = ambiguity_safe_tail_with_denylist(
+                indexer,
+                hierarchy_walk_origin_uri.unwrap_or(from_uri),
+                indexer.lookup_definitions(name),
+            );
+            if !found.is_empty() {
+                return found;
+            }
+            resolve_kotlin_builtin_type_platform_equivalent(indexer, name)
+        }
     }
 }
 
@@ -2142,6 +2180,84 @@ pub(crate) fn is_stdlib(pkg: &str) -> bool {
         | "WebKit" | "StoreKit" | "GameKit" | "ARKit" | "RealityKit"
         | "Swift" | "ObjectiveC" | "Darwin" | "Dispatch" | "os"
     )
+}
+
+/// Kotlin's own "mapped types" — compiler-intrinsic built-in types with NO
+/// compiled `.class` file in kotlin-stdlib's JAR at all. The Kotlin compiler
+/// substitutes their real JVM platform-type equivalent directly into
+/// bytecode, so a class-file-scanning indexer (this project's JAR sidecar)
+/// can never find a class file that doesn't exist. Real corpus evidence: a
+/// typical Android/Kotlin workspace has 13 same-named JAR/workspace
+/// candidates for bare `String`, and NONE of them is the real class — see
+/// `docs/superpowers/specs/2026-08-27-kotlin-builtin-type-platform-mapping-design.md`.
+///
+/// Deliberately narrow (2 entries, the ones directly evidenced by
+/// measurement) — Kotlin has roughly 20 mapped types in total
+/// (`Any`/`Throwable`/`Number`/the boxed primitives/the collection
+/// interfaces/...), but adding the rest speculatively, without real corpus
+/// evidence each one is actually hit, would violate the same
+/// "evidenced-only, not a broad heuristic" discipline
+/// [`DENYLISTED_PACKAGE_PREFIXES`] already established. Extending this list
+/// is a mechanical follow-up once a real gap is measured, not a redesign.
+const KOTLIN_BUILTIN_TYPE_PLATFORM_EQUIVALENTS: &[(&str, &str)] = &[
+    ("String", "java.lang.String"),
+    ("CharSequence", "java.lang.CharSequence"),
+];
+
+/// Last-resort fallback for a Kotlin compiler-intrinsic built-in type name
+/// (see [`KOTLIN_BUILTIN_TYPE_PLATFORM_EQUIVALENTS`]): every normal
+/// resolution step already failed by the time any tail fallback calls this,
+/// since a built-in type is never locally declared, explicitly imported, or
+/// present in the workspace's own source tree — so this can only ever turn
+/// an existing decline into a correct resolve, never introduce a wrong one.
+///
+/// Re-derives the Android SDK sources root via the already-existing
+/// [`crate::workspace_json::detect_android_sdk_source_paths`] (no new
+/// discovery mechanism — reuses Primitive B's own function) and, if the
+/// expected `<root>/java/lang/String.java`-shaped file exists on disk,
+/// indexes it on demand — the same `std::fs::read_to_string` +
+/// `index_content` pattern `resolve_chain`'s own step 0.5 already uses for
+/// "the caller's own file isn't indexed yet", just triggered by a known
+/// built-in name instead. One-time cost per session per type: once indexed,
+/// the file is permanently cached like any other, so this filesystem lookup
+/// only ever runs for the first `String`/`CharSequence` resolution.
+///
+/// Scoped to Android projects for now — a plain JVM/non-Android Kotlin
+/// project has no equivalent auto-detected `java.lang.*` source bundle;
+/// locating a JDK's own bundled sources is a separate discovery problem,
+/// not addressed here (see the design doc's explicit scope boundary).
+pub(crate) fn resolve_kotlin_builtin_type_platform_equivalent(
+    indexer: &Indexer,
+    name: &str,
+) -> Vec<Location> {
+    let Some(&(_, platform_fqn)) = KOTLIN_BUILTIN_TYPE_PLATFORM_EQUIVALENTS
+        .iter()
+        .find(|&&(builtin, _)| builtin == name)
+    else {
+        return vec![];
+    };
+    let Some(workspace_root) = indexer.workspace_root.get() else {
+        return vec![];
+    };
+    let relative_path = platform_fqn.replace('.', "/") + ".java";
+    for sdk_source_root in crate::workspace_json::detect_android_sdk_source_paths(&workspace_root) {
+        let file_path = sdk_source_root.join(&relative_path);
+        let Ok(file_uri) = Url::from_file_path(&file_path) else {
+            continue;
+        };
+        let file_uri_str = file_uri.as_str();
+        if !indexer.files.contains_key(file_uri_str) {
+            let Ok(content) = std::fs::read_to_string(&file_path) else {
+                continue;
+            };
+            indexer.index_content(&file_uri, &content);
+        }
+        let locs = find_name_in_uri(indexer, name, file_uri_str);
+        if !locs.is_empty() {
+            return locs;
+        }
+    }
+    vec![]
 }
 
 // ─── impl Indexer wrappers ────────────────────────────────────────────────────

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -7908,3 +7908,149 @@ fn the_initializer_search_survives_a_pathologically_deep_file() {
     let found = handle.join().expect("must not overflow the stack");
     assert_eq!(found, None, "the name is not declared anywhere in the file");
 }
+
+// ─── Kotlin built-in-type platform-equivalent fallback ───────────────────────
+//
+// `kotlin.String`/`kotlin.CharSequence` are compiler intrinsics with no
+// compiled `.class` file anywhere in kotlin-stdlib's JAR (verified via
+// `unzip -l kotlin-stdlib-*.jar | grep String.class` -> no output — see
+// docs/superpowers/specs/2026-08-27-kotlin-builtin-type-platform-mapping-design.md).
+// `resolve_kotlin_builtin_type_platform_equivalent` is the last-resort
+// fallback that indexes the real platform declaration from the Android SDK
+// sources bundle on demand.
+
+/// Builds a fake Android SDK layout (`local.properties` + `sdk/sources/
+/// android-<api>/<relative_java_path>`) under `root`, matching the exact
+/// shape `detect_android_sdk_source_paths` looks for (see
+/// `sdk_dir_from_local_properties_finds_sdk_dot_dir` in
+/// `workspace_json_tests.rs`, the precedent this fixture follows).
+fn write_fake_android_sdk_source(root: &std::path::Path, relative_java_path: &str, content: &str) {
+    let fake_sdk = root.join("sdk");
+    let file_path = fake_sdk
+        .join("sources")
+        .join("android-34")
+        .join(relative_java_path);
+    std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+    std::fs::write(&file_path, content).unwrap();
+    std::fs::write(
+        root.join("local.properties"),
+        format!("sdk.dir={}\n", fake_sdk.display()),
+    )
+    .unwrap();
+}
+
+#[test]
+fn resolve_kotlin_builtin_type_platform_equivalent_indexes_java_lang_string_on_demand() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_fake_android_sdk_source(
+        root,
+        "java/lang/String.java",
+        "package java.lang;\npublic final class String implements CharSequence {\n}\n",
+    );
+
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+
+    let locs = resolve_kotlin_builtin_type_platform_equivalent(&idx, "String");
+    assert_eq!(
+        locs.len(),
+        1,
+        "expected the on-demand-indexed java.lang.String declaration, got {locs:?}"
+    );
+    assert!(
+        locs[0].uri.path().ends_with("java/lang/String.java"),
+        "expected the real platform source file, got {:?}",
+        locs[0].uri
+    );
+
+    // The on-demand indexing must persist (step 0.5's own contract), not
+    // just parse ad hoc — a later hierarchy walk from `String` needs its
+    // supertypes (`CharSequence` here) available from `indexer.files`.
+    assert!(
+        idx.files.contains_key(locs[0].uri.as_str()),
+        "expected the file to be permanently cached after the first resolution"
+    );
+}
+
+#[test]
+fn resolve_kotlin_builtin_type_platform_equivalent_ignores_unmapped_names() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_fake_android_sdk_source(
+        root,
+        "java/lang/String.java",
+        "package java.lang;\npublic final class String {\n}\n",
+    );
+
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+
+    // "SomeRandomClass" is not one of Kotlin's mapped built-in types, so the
+    // fallback must not fire even though an SDK is present.
+    let locs = resolve_kotlin_builtin_type_platform_equivalent(&idx, "SomeRandomClass");
+    assert!(
+        locs.is_empty(),
+        "expected no fallback for an unmapped name, got {locs:?}"
+    );
+}
+
+#[test]
+fn resolve_kotlin_builtin_type_platform_equivalent_returns_empty_without_an_sdk() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // No local.properties, no fake SDK -- `detect_android_sdk_source_paths`
+    // must come back empty (short of a real SDK on the CI machine's own env
+    // vars, which `no_sdk_returns_empty` in workspace_json_tests.rs already
+    // documents as a possible, harmless false pass).
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+
+    let locs = resolve_kotlin_builtin_type_platform_equivalent(&idx, "String");
+    assert!(
+        locs.is_empty()
+            || std::env::var("ANDROID_HOME").is_ok()
+            || std::env::var("ANDROID_SDK_ROOT").is_ok(),
+        "expected no fallback without any SDK, got {locs:?}"
+    );
+}
+
+/// End-to-end through the real public entry point (`resolve_symbol`, the
+/// `Full` policy that spawns `rg`) -- the flagship scenario the whole design
+/// doc exists for: resolving a bare `String` qualifier root when nothing in
+/// the workspace's own source explicitly names it, matching the real
+/// `toViewText` receiver-resolution gap found on the Moneta corpus.
+#[test]
+fn resolve_symbol_full_policy_falls_back_to_the_builtin_type_platform_equivalent() {
+    if !rg_available() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_fake_android_sdk_source(
+        root,
+        "java/lang/String.java",
+        "package java.lang;\npublic final class String implements CharSequence {\n}\n",
+    );
+
+    let caller_src = "package com.example\nfun use(s: String) { }\n";
+    let caller_path = root.join("Caller.kt");
+    std::fs::write(&caller_path, caller_src).unwrap();
+    let caller_uri = Url::from_file_path(&caller_path).unwrap();
+
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+    idx.index_content(&caller_uri, caller_src);
+
+    let locs = resolve_symbol(&idx, "String", None, &caller_uri);
+    assert_eq!(
+        locs.len(),
+        1,
+        "expected the builtin-type fallback to resolve bare String, got {locs:?}"
+    );
+    assert!(
+        locs[0].uri.path().ends_with("java/lang/String.java"),
+        "expected the real platform source file, got {:?}",
+        locs[0].uri
+    );
+}

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -8054,3 +8054,66 @@ fn resolve_symbol_full_policy_falls_back_to_the_builtin_type_platform_equivalent
         locs[0].uri
     );
 }
+
+/// The same fallback must also surface in dot-completion, not just goto-def/
+/// hover: `extension_fn_completions` resolves the receiver class via
+/// `resolve_symbol_no_rg` and walks its real supertypes to build the
+/// ancestor set an extension's receiver is matched against. Before this fix,
+/// `resolve_symbol_no_rg(idx, "String", ..)` came back empty, so a `String`
+/// receiver's ancestor set was just `{"String"}` -- an extension declared on
+/// `CharSequence` (e.g. the real `toViewText`) could never match and so
+/// never appeared as a suggestion while typing.
+#[test]
+fn resolve_kotlin_builtin_type_platform_equivalent_surfaces_supertype_extensions_in_dot_completion()
+{
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_fake_android_sdk_source(
+        root,
+        "java/lang/String.java",
+        "package java.lang;\npublic final class String implements CharSequence {\n}\n",
+    );
+    // The walk from String to CharSequence must itself resolve CharSequence's
+    // own declaration (via the same builtin-type fallback) to become a real
+    // hop -- without a real java.lang.CharSequence.java on disk too (as the
+    // real Android SDK sources bundle always has), the walk dead-ends at
+    // String and this test would pass for the wrong reason.
+    write_fake_android_sdk_source(
+        root,
+        "java/lang/CharSequence.java",
+        "package java.lang;\npublic interface CharSequence {\n}\n",
+    );
+
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+
+    // Simulate an indexed extension declared on CharSequence, the same shape
+    // `jar_extension_appears_in_dot_completion` uses for a JAR-sourced one.
+    idx.extension_by_receiver
+        .entry("CharSequence".to_owned())
+        .or_default()
+        .push(crate::types::ExtensionEntry {
+            file_uri: "file:///app/ViewText.kt".to_owned(),
+            name: "toViewText".to_owned(),
+            kind: tower_lsp::lsp_types::SymbolKind::FUNCTION,
+            detail: "fun CharSequence?.toViewText(): String".to_owned(),
+            visibility: crate::types::Visibility::Public,
+            package: Some("app".to_owned()),
+            trailing_lambda: false,
+            deprecated: false,
+            container: None,
+        });
+
+    let caller_src = "package app\nfun use(s: String) { s }\n";
+    let caller_path = root.join("Caller.kt");
+    std::fs::write(&caller_path, caller_src).unwrap();
+    let caller_uri = Url::from_file_path(&caller_path).unwrap();
+    idx.index_content(&caller_uri, caller_src);
+
+    let items = complete_dot(&idx, "s", &caller_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"toViewText"),
+        "expected the CharSequence extension to appear for a String receiver, got: {labels:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- `kotlin.String`/`CharSequence` are compiler intrinsics with **no compiled `.class` file anywhere in kotlin-stdlib's JAR** — verified directly (`unzip -l kotlin-stdlib-*.jar | grep String.class` → no output). The compiler substitutes their real JVM platform type (`java.lang.String`, `java.lang.CharSequence`) directly into bytecode.
- This meant a bare `String` receiver — and everything hanging off it, e.g. `fun CharSequence?.toViewText()` — was permanently unresolvable regardless of how correct the supertype-hierarchy walk itself was (PR #289): the correct candidate was never a candidate in the first place.
- Adds a narrow, evidenced-only fallback (`resolve_kotlin_builtin_type_platform_equivalent`): when the resolution chain's tail comes up empty for `String`/`CharSequence` specifically, resolve the real `java.lang.*` declaration by indexing it on demand from the Android SDK sources bundle (reusing the existing `detect_android_sdk_source_paths` + the same on-demand-indexing pattern `resolve_chain`'s own step 0.5 already uses for cold files).
- Wired into every `ResolveIo` policy's tail except `ScopedOnly` (which intentionally has no tail — its callers already have their own downstream fallback).

Full root-cause trace and design rationale: `docs/superpowers/specs/2026-08-27-kotlin-builtin-type-platform-mapping-design.md`.

## Test plan

- [x] New unit tests for `resolve_kotlin_builtin_type_platform_equivalent` (on-demand indexing succeeds, persists into `indexer.files`, ignores unmapped names, no-op without an SDK)
- [x] End-to-end test through the real `resolve_symbol` (`Full`/rg) entry point, resolving a bare `String` receiver with no explicit reference anywhere in the workspace
- [x] Full suite green: `cargo test --bin kmp-lsp` (1865 passed, 0 failed)
- [x] `cargo clippy --tests -- -D warnings` clean
- [ ] Re-measure `resolution-accuracy --root ~/Work/Moneta/android` and confirm `toViewText` itself now resolves (not just the aggregate count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ