### PR TITLE
extend builtin-type platform mapping to Kotlin collection interfaces

### DIFF
--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -789,6 +789,12 @@ fn is_default_import_type(name: &str) -> bool {
         | "MutableIterable" | "MutableCollection" | "MutableList" | "MutableSet"
         | "MutableMap" | "ArrayList" | "HashMap" | "HashSet" | "LinkedHashMap"
         | "LinkedHashSet"
+        // kotlin.* specialized primitive array types (default-imported, same as
+        // `Array` above) -- real, measured false-positive source: `ByteArray`
+        // alone was 45% of the missing-import POC's total flags on the Moneta
+        // corpus before this fix.
+        | "ByteArray" | "CharArray" | "ShortArray" | "IntArray" | "LongArray"
+        | "FloatArray" | "DoubleArray" | "BooleanArray"
         // kotlin.sequences.*
         | "Sequence"
     )
@@ -2191,17 +2197,37 @@ pub(crate) fn is_stdlib(pkg: &str) -> bool {
 /// candidates for bare `String`, and NONE of them is the real class — see
 /// `docs/superpowers/specs/2026-08-27-kotlin-builtin-type-platform-mapping-design.md`.
 ///
-/// Deliberately narrow (2 entries, the ones directly evidenced by
-/// measurement) — Kotlin has roughly 20 mapped types in total
-/// (`Any`/`Throwable`/`Number`/the boxed primitives/the collection
-/// interfaces/...), but adding the rest speculatively, without real corpus
-/// evidence each one is actually hit, would violate the same
-/// "evidenced-only, not a broad heuristic" discipline
-/// [`DENYLISTED_PACKAGE_PREFIXES`] already established. Extending this list
-/// is a mechanical follow-up once a real gap is measured, not a redesign.
+/// Deliberately narrow (`String`/`CharSequence` plus the
+/// `kotlin.collections.*` interfaces, the ones directly evidenced by
+/// measurement so far) — Kotlin has roughly 20 mapped types in total
+/// (`Any`/`Throwable`/`Number`/the boxed primitives/...), but adding the
+/// rest speculatively, without real corpus evidence each one is actually
+/// hit, would violate the same "evidenced-only, not a broad heuristic"
+/// discipline [`DENYLISTED_PACKAGE_PREFIXES`] already established.
+/// Extending this list is a mechanical follow-up once a real gap is
+/// measured, not a redesign.
 const KOTLIN_BUILTIN_TYPE_PLATFORM_EQUIVALENTS: &[(&str, &str)] = &[
     ("String", "java.lang.String"),
     ("CharSequence", "java.lang.CharSequence"),
+    // kotlin.collections.* interfaces -- same "compiler-intrinsic mapped
+    // type, no compiled .class anywhere in kotlin-stdlib's JAR" shape as
+    // String/CharSequence above (verified the same way: `unzip -l
+    // kotlin-stdlib-*.jar | grep List.class` etc. -> no output). Kotlin's
+    // read-only/mutable pairs (`List`/`MutableList`, ...) are a compile-time
+    // view over ONE real platform interface -- both map to the same target,
+    // which is why e.g. `MutableList` and `List` share a value here.
+    ("List", "java.util.List"),
+    ("MutableList", "java.util.List"),
+    ("Set", "java.util.Set"),
+    ("MutableSet", "java.util.Set"),
+    ("Map", "java.util.Map"),
+    ("MutableMap", "java.util.Map"),
+    ("Collection", "java.util.Collection"),
+    ("MutableCollection", "java.util.Collection"),
+    ("Iterable", "java.lang.Iterable"),
+    ("MutableIterable", "java.lang.Iterable"),
+    ("Iterator", "java.util.Iterator"),
+    ("MutableIterator", "java.util.Iterator"),
 ];
 
 /// Last-resort fallback for a Kotlin compiler-intrinsic built-in type name
@@ -2236,6 +2262,14 @@ pub(crate) fn resolve_kotlin_builtin_type_platform_equivalent(
     else {
         return vec![];
     };
+    // The platform type's own simple name, NOT `name` -- some entries
+    // (`MutableList` -> `java.util.List`) map a Kotlin-only spelling onto a
+    // real interface declared under a DIFFERENT simple name; searching the
+    // target file for a symbol literally called "MutableList" would always
+    // come up empty.
+    let Some(platform_simple_name) = platform_fqn.rsplit('.').next() else {
+        return vec![];
+    };
     let Some(workspace_root) = indexer.workspace_root.get() else {
         return vec![];
     };
@@ -2252,7 +2286,7 @@ pub(crate) fn resolve_kotlin_builtin_type_platform_equivalent(
             };
             indexer.index_content(&file_uri, &content);
         }
-        let locs = find_name_in_uri(indexer, name, file_uri_str);
+        let locs = find_name_in_uri(indexer, platform_simple_name, file_uri_str);
         if !locs.is_empty() {
             return locs;
         }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -7506,6 +7506,37 @@ fn resolve_in_scope_strict_true_via_default_import_type() {
     assert!(resolve_in_scope_strict(&idx, "Result", &caller_uri));
 }
 
+/// Real, measured false positive on the Moneta corpus: `ByteArray` (a
+/// specialized primitive array type, in scope everywhere without an import
+/// exactly like `Result` above) accounted for 74 of 164 total flags (45%)
+/// in the `missing-import` POC diagnostic before this fix — `is_default_import_type`
+/// allowlisted `Array` itself plus the boxed collection/primitive types, but
+/// missed all 8 specialized primitive array types Kotlin also default-imports.
+#[test]
+fn resolve_in_scope_strict_true_via_default_import_type_for_primitive_array_types() {
+    let caller_uri = uri("/Caller.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &caller_uri,
+        "package app\nfun use(bytes: ByteArray) = bytes\n",
+    );
+    for name in [
+        "ByteArray",
+        "CharArray",
+        "ShortArray",
+        "IntArray",
+        "LongArray",
+        "FloatArray",
+        "DoubleArray",
+        "BooleanArray",
+    ] {
+        assert!(
+            resolve_in_scope_strict(&idx, name, &caller_uri),
+            "expected {name} to be in scope via Kotlin's default import, was flagged as missing"
+        );
+    }
+}
+
 /// Regression: `resolvable_via_default_import` must check `jar_definitions`
 /// directly (by package), not the narrower `importable_fqns` cache — a
 /// top-level `kotlin.*` FUNCTION (e.g. `error`, `run`, `with`, `repeat`) is not
@@ -8115,5 +8146,117 @@ fn resolve_kotlin_builtin_type_platform_equivalent_surfaces_supertype_extensions
     assert!(
         labels.contains(&"toViewText"),
         "expected the CharSequence extension to appear for a String receiver, got: {labels:?}"
+    );
+}
+
+/// `MutableList` maps to the SAME real platform type as `List`
+/// (`java.util.List` — Kotlin's mutable/immutable distinction is a
+/// compile-time-only view over one real JVM interface literally named
+/// `List`, never `MutableList`). A lookup that searches the target file for
+/// a symbol named `name` (the ORIGINAL Kotlin spelling) rather than the
+/// resolved platform type's own simple name would search `List.java` for a
+/// symbol called `"MutableList"` and always come up empty -- this must
+/// search by the platform type's own simple name instead.
+#[test]
+fn resolve_kotlin_builtin_type_platform_equivalent_maps_mutablelist_to_the_real_list_interface() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_fake_android_sdk_source(
+        root,
+        "java/util/List.java",
+        "package java.util;\npublic interface List<E> extends Collection<E> {\n}\n",
+    );
+
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+
+    let locs = resolve_kotlin_builtin_type_platform_equivalent(&idx, "MutableList");
+    assert_eq!(
+        locs.len(),
+        1,
+        "expected MutableList to resolve to the real java.util.List declaration, got {locs:?}"
+    );
+    assert!(
+        locs[0].uri.path().ends_with("java/util/List.java"),
+        "expected the real platform source file, got {:?}",
+        locs[0].uri
+    );
+}
+
+/// `Map` -> `java.util.Map`, the plain (non-Mutable-aliased) case, matching
+/// the same on-demand-index-and-find shape already proven for `String`.
+#[test]
+fn resolve_kotlin_builtin_type_platform_equivalent_resolves_map_to_the_real_java_util_map() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_fake_android_sdk_source(
+        root,
+        "java/util/Map.java",
+        "package java.util;\npublic interface Map<K, V> {\n}\n",
+    );
+
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+
+    let locs = resolve_kotlin_builtin_type_platform_equivalent(&idx, "Map");
+    assert_eq!(locs.len(), 1, "expected Map to resolve, got {locs:?}");
+    assert!(locs[0].uri.path().ends_with("java/util/Map.java"));
+}
+
+/// End-to-end through the real supertype-hierarchy walk (`extension_fn_completions`,
+/// via `resolve_symbol_no_rg`): an extension declared on `Iterable` must
+/// surface for a `List`-typed receiver, since `java.util.List` really does
+/// extend `Collection` which really does extend `Iterable` -- proving the
+/// collection interfaces resolve to declarations with correct, walkable
+/// supertype chains, not just a bare unlinked file.
+#[test]
+fn resolve_kotlin_builtin_type_platform_equivalent_surfaces_iterable_extensions_for_a_list_receiver(
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_fake_android_sdk_source(
+        root,
+        "java/util/List.java",
+        "package java.util;\npublic interface List<E> extends Collection<E> {\n}\n",
+    );
+    write_fake_android_sdk_source(
+        root,
+        "java/util/Collection.java",
+        "package java.util;\npublic interface Collection<E> extends Iterable<E> {\n}\n",
+    );
+    write_fake_android_sdk_source(
+        root,
+        "java/lang/Iterable.java",
+        "package java.lang;\npublic interface Iterable<T> {\n}\n",
+    );
+
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+    idx.extension_by_receiver
+        .entry("Iterable".to_owned())
+        .or_default()
+        .push(crate::types::ExtensionEntry {
+            file_uri: "file:///app/Extensions.kt".to_owned(),
+            name: "secondOrNull".to_owned(),
+            kind: tower_lsp::lsp_types::SymbolKind::FUNCTION,
+            detail: "fun <T> Iterable<T>.secondOrNull(): T?".to_owned(),
+            visibility: crate::types::Visibility::Public,
+            package: Some("app".to_owned()),
+            trailing_lambda: false,
+            deprecated: false,
+            container: None,
+        });
+
+    let caller_src = "package app\nfun use(items: List<Int>) { items }\n";
+    let caller_path = root.join("Caller.kt");
+    std::fs::write(&caller_path, caller_src).unwrap();
+    let caller_uri = Url::from_file_path(&caller_path).unwrap();
+    idx.index_content(&caller_uri, caller_src);
+
+    let items = complete_dot(&idx, "items", &caller_uri, false, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"secondOrNull"),
+        "expected the Iterable extension to appear for a List receiver, got: {labels:?}"
     );
 }


### PR DESCRIPTION
## Summary

- `kotlin.collections.{List,MutableList,Set,MutableSet,Map,MutableMap,Collection,MutableCollection,Iterable,MutableIterable,Iterator,MutableIterator}` are compiler intrinsics with no compiled `.class` file in kotlin-stdlib's JAR — same shape as `String`/`CharSequence` (PR #291). A `List`-typed receiver could never resolve any member/extension on it (`.map`, `.filter`, `.isNotEmpty`, `.toSet`, ...) since the receiver type itself was never a candidate.
- Extends `KOTLIN_BUILTIN_TYPE_PLATFORM_EQUIVALENTS` with all 12 interfaces, mapped to their real `java.util.*`/`java.lang.Iterable` equivalents.
- **Real bug fixed along the way**: the on-demand lookup searched the resolved file for a symbol named after the *original* Kotlin spelling rather than the platform type's own simple name — so `MutableList` (→ `java.util.List`, a file that only contains a symbol literally named `List`) would never have resolved. Caught by a RED test before it shipped.
- Also adds the 8 specialized primitive array types (`ByteArray`, `IntArray`, `CharArray`, `LongArray`, `ShortArray`, `FloatArray`, `DoubleArray`, `BooleanArray`) to `is_default_import_type`, fixing a real missing-import false-positive cluster: `ByteArray` alone was 74 of Moneta's 164 missing-import flags (45%).

Follow-up from `docs/superpowers/specs/2026-08-27-kotlin-builtin-type-platform-mapping-design.md` — planned via Fable analysis of combined Moneta + Now in Android resolution-accuracy data after PR #291 merged.

## Measured impact

Real corpora, before → after (this branch vs. main `371f99b`):

**Moneta** (13,231 files):
- member recall: 85.2% → 85.4% (+789 resolved)
- bare recall: 63.3% → 63.8% (+3425 resolved)
- FilteredCandidate: 5665 → 5545
- missing-imports: **164 → 83 (-49%)**

**Now in Android** (338 files):
- member recall: 78.5% → 78.9%
- bare recall: 57.4% → 58.3%

**Known remaining gap, explicitly out of scope here**: `Map.entries`/`.keys` (→ Java's `entrySet()`/`keySet()`, different method names) still don't resolve — confirmed unchanged in both corpora's benchmarks (206 Moneta, 11 nowinandroid, both exactly flat). That's a separate Kotlin↔Java member-name remapping problem, not a receiver-type-resolution one, and not addressed in this slice.

## Test plan

- [x] New unit tests: `MutableList`→`List` name-mismatch regression, `Map` positive case, end-to-end `Iterable` extension surfacing for a `List` receiver via `complete_dot`, primitive-array-type `resolve_in_scope_strict` coverage
- [x] Full suite green: 1870 passed, 0 failed
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] Real-corpus benchmarks re-run before/after on both Moneta and Now in Android (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ