### PR TITLE
fix(missing-import): a stdlib star import must suppress the flag too

### DIFF
--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -900,6 +900,24 @@ pub(crate) fn resolve_in_scope_strict(indexer: &Indexer, name: &str, from_uri: &
     if !resolve_same_package(indexer, name, from_uri).is_empty() {
         return true;
     }
+    // A star import of a stdlib-shaped package (`java.*`/`kotlin.*`/`android.*`/
+    // `androidx.*`) has no locally-indexed source for `find_in_star_imports`
+    // below to search, so it's excluded from that search entirely — but for
+    // THIS check (does some import plausibly cover `name`, at all), that
+    // exclusion is wrong: the file compiles, so `import java.util.*` really
+    // does bring `Date` into scope even though we can't confirm membership
+    // one way or the other. Real, measured false positive on Moneta:
+    // `Date`/`Calendar`/`Collections` were flagged as missing imports in
+    // files that explicitly had `import java.util.*`.
+    if let Some(file_data) = indexer.files.get(from_uri.as_str()) {
+        if file_data
+            .imports
+            .iter()
+            .any(|i| i.is_star && is_stdlib(&i.full_path))
+        {
+            return true;
+        }
+    }
     let star_pkgs: Vec<String> = match indexer.files.get(from_uri.as_str()) {
         Some(f) => f
             .imports

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -7537,6 +7537,31 @@ fn resolve_in_scope_strict_true_via_default_import_type_for_primitive_array_type
     }
 }
 
+/// Real, measured false positive on the Moneta corpus: a file with an
+/// explicit `import java.util.*` still had `Date`/`Calendar`/`Collections`
+/// flagged as missing imports. Root cause: the star-import-coverage check
+/// filtered OUT any star import whose package `is_stdlib()` (`java.*`,
+/// `kotlin.*`, `android.*`, `androidx.*`) before even considering it,
+/// because that filter's ORIGINAL purpose was "don't waste an `rg`/source-tree
+/// search on a package with no local source to search" — a reasonable
+/// optimization for the SEARCH itself, but wrong for this EXISTENCE check:
+/// the code compiles, so `import java.util.*` genuinely does bring `Date`
+/// into scope even though we have no local source to verify it against.
+#[test]
+fn resolve_in_scope_strict_true_via_stdlib_star_import() {
+    let caller_uri = uri("/Caller.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &caller_uri,
+        "package app\nimport java.util.*\nfun use() { Date() }\n",
+    );
+    assert!(
+        resolve_in_scope_strict(&idx, "Date", &caller_uri),
+        "import java.util.* must cover Date, even though java.util has no \
+         locally-indexed source to confirm membership against"
+    );
+}
+
 /// Regression: `resolvable_via_default_import` must check `jar_definitions`
 /// directly (by package), not the narrower `importable_fqns` cache — a
 /// top-level `kotlin.*` FUNCTION (e.g. `error`, `run`, `with`, `repeat`) is not


### PR DESCRIPTION
## Summary

`resolve_in_scope_strict` (the missing-import diagnostic's own reachability check) excluded stdlib-prefixed star imports (`java.*`, `kotlin.*`, `android.*`, `androidx.*`) from the "does some import cover this name" check entirely — correct for `find_in_star_imports`' own *search* (there's no local source to search for those packages), but wrong for this *existence* question: the file compiles, so `import java.util.*` really does bring `Date` into scope even though we can't verify membership one way or the other.

Found via Fable analysis of resolution-accuracy + import-diagnostic data (a runner-up in the same batch that produced PR #293).

**Real, measured false positive on Moneta**: `Date`/`Calendar`/`Collections`/`File`/`IOException`/`Locale`/... were flagged as missing imports in files that had an explicit `import java.util.*` (or `java.io.*`, `android.*`, etc.) covering them.

## Measured impact (Moneta, 13,231 files)

- missing-imports: 83 → 46 flags (**-45%**)
- unused-imports: 60 → 60 (unaffected, as expected — this fix is scoped entirely to `resolve_in_scope_strict`, which only the missing-import diagnostic calls)

## Test plan

- [x] New regression test `resolve_in_scope_strict_true_via_stdlib_star_import`, verified genuine RED→GREEN
- [x] Full suite green: 1873 passed, 0 failed
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] Real-corpus benchmark re-run before/after on Moneta (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ