### PR TITLE
chore(deps): switch tree-sitter-swift-bundled back to a real crates.io version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,8 +1609,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-swift-bundled"
-version = "0.1.0"
-source = "git+https://github.com/Hessesian/tree-sitter-swift?rev=00ddccfa09fc556f7e1120d3d3a2fd62ec86bd65#00ddccfa09fc556f7e1120d3d3a2fd62ec86bd65"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71f8a1d8fae8824c9f73871e36b2a49ff0516ed9ef561eff1a522b2eef7bd487"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,14 @@ tree-sitter-java = "0.23"
 # aliased under the same crate name so every `tree_sitter_kotlin::` path in this
 # codebase keeps working unchanged.
 tree-sitter-kotlin = { package = "brokk-tree-sitter-kotlin", version = "0.4.0" }
-# The published crate hard-pins tree-sitter = "0.22", which conflicts with
-# the core bump above (Cargo's `links` uniqueness rule) — this is our own
-# sibling repo (https://github.com/Hessesian/tree-sitter-swift), bumped to
-# 0.26 there and referenced by rev rather than vendoring its source here.
-tree-sitter-swift-bundled = { git = "https://github.com/Hessesian/tree-sitter-swift", rev = "00ddccfa09fc556f7e1120d3d3a2fd62ec86bd65" }
+# Our own sibling repo (https://github.com/Hessesian/tree-sitter-swift),
+# bumped to tree-sitter 0.26 there (the published 0.1.0 hard-pinned 0.22,
+# which conflicted with the core bump above via Cargo's `links` uniqueness
+# rule) and published as 0.2.0. A git+rev reference here would resolve fine
+# locally but silently breaks `cargo publish` for kmp-lsp itself — crates.io
+# refuses to publish any crate whose dependency graph includes an
+# un-versioned git dependency — so this must stay a normal version dependency.
+tree-sitter-swift-bundled = "0.2.0"
 
 # Concurrent index storage (no Mutex needed)
 dashmap = "5"


### PR DESCRIPTION
## Summary

The tree-sitter 0.26 migration (#268) pointed `tree-sitter-swift-bundled` at a `git`+`rev` reference into our own sibling repo (`Hessesian/tree-sitter-swift`), because the last published `0.1.0` hard-pinned `tree-sitter = "0.22"`, which conflicted with the core bump via Cargo's `links` uniqueness rule. That silently broke kmp-lsp's own `cargo publish` — crates.io refuses to publish any crate whose dependency graph includes an un-versioned git dependency. This is exactly what failed in v0.26.0's `publish` job.

`tree-sitter-swift-bundled 0.2.0` (tree-sitter 0.26-compatible) is now published on crates.io (`Hessesian/tree-sitter-swift#1`) — switch back to a normal version dependency.

## Test plan

- [x] `cargo build --bin kmp-lsp` resolves the real crates.io version
- [x] Full suite green: 1873 passed, 0 failed
- [x] `cargo publish --dry-run` succeeds end-to-end for kmp-lsp itself (packages, verifies, compiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ