### PR TITLE
fix(resolve): map primitive-scalar Kotlin types to their java.lang boxes

### DIFF
--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -2249,12 +2249,12 @@ pub(crate) fn is_stdlib(pkg: &str) -> bool {
 /// candidates for bare `String`, and NONE of them is the real class — see
 /// `docs/superpowers/specs/2026-08-27-kotlin-builtin-type-platform-mapping-design.md`.
 ///
-/// Deliberately narrow (`String`/`CharSequence` plus the
-/// `kotlin.collections.*` interfaces, the ones directly evidenced by
-/// measurement so far) — Kotlin has roughly 20 mapped types in total
-/// (`Any`/`Throwable`/`Number`/the boxed primitives/...), but adding the
-/// rest speculatively, without real corpus evidence each one is actually
-/// hit, would violate the same "evidenced-only, not a broad heuristic"
+/// Deliberately narrow (`String`/`CharSequence`, the `kotlin.collections.*`
+/// interfaces, and the 8 primitive scalar types, the ones directly
+/// evidenced by measurement so far) — Kotlin has roughly 20 mapped types in
+/// total (`Any`/`Throwable`/`Number`/`Comparable`/...), but adding the rest
+/// speculatively, without real corpus evidence each one is actually hit,
+/// would violate the same "evidenced-only, not a broad heuristic"
 /// discipline [`DENYLISTED_PACKAGE_PREFIXES`] already established.
 /// Extending this list is a mechanical follow-up once a real gap is
 /// measured, not a redesign.
@@ -2280,6 +2280,20 @@ const KOTLIN_BUILTIN_TYPE_PLATFORM_EQUIVALENTS: &[(&str, &str)] = &[
     ("MutableIterable", "java.lang.Iterable"),
     ("Iterator", "java.util.Iterator"),
     ("MutableIterator", "java.util.Iterator"),
+    // Kotlin's 8 primitive scalar types -- same compiler-intrinsic shape:
+    // verified none of `Int`/`Long`/`Double`/`Float`/`Boolean`/`Byte`/`Short`/`Char`
+    // has a compiled `.class` file in kotlin-stdlib's JAR either. `Char` is
+    // the one name mismatch (-> `Character`, not `Char`) -- handled the same
+    // way `MutableList` -> `java.util.List` already is, by looking up the
+    // platform type's own simple name rather than the original Kotlin one.
+    ("Int", "java.lang.Integer"),
+    ("Long", "java.lang.Long"),
+    ("Double", "java.lang.Double"),
+    ("Float", "java.lang.Float"),
+    ("Boolean", "java.lang.Boolean"),
+    ("Byte", "java.lang.Byte"),
+    ("Short", "java.lang.Short"),
+    ("Char", "java.lang.Character"),
 ];
 
 /// Last-resort fallback for a Kotlin compiler-intrinsic built-in type name

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -8440,3 +8440,59 @@ fn complete_dot_finds_named_companion_members_on_a_jar_backed_type() {
         "expected the REAL Forest.d, not the DecoyForest.d decoy"
     );
 }
+
+// ─── primitive-scalar compiler-intrinsic mapped types ────────────────────────
+//
+// Kotlin's 8 primitive scalar types (`Int`/`Long`/`Double`/`Float`/`Boolean`/
+// `Byte`/`Short`/`Char`) are compiler intrinsics with no compiled `.class`
+// file in kotlin-stdlib's JAR at all — the exact same shape as
+// `String`/`CharSequence`/the collection interfaces already handled. Real,
+// measured gap: `Int.MAX_VALUE` (a real call site in Moneta,
+// `core/common/src/main/java/cz/moneta/smartbanka/common/extensions/ListExtensions.kt`)
+// resolved to zero candidates.
+
+/// Plain case: the Kotlin name matches the Java platform type's own simple
+/// name (`Long` -> `java.lang.Long`).
+#[test]
+fn resolve_kotlin_builtin_type_platform_equivalent_resolves_long_to_java_lang_long() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_fake_android_sdk_source(
+        root,
+        "java/lang/Long.java",
+        "package java.lang;\npublic final class Long {\n    public static final long MAX_VALUE = 0x7fffffffffffffffL;\n}\n",
+    );
+
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+
+    let locs = resolve_kotlin_builtin_type_platform_equivalent(&idx, "Long");
+    assert_eq!(locs.len(), 1, "expected Long to resolve, got {locs:?}");
+    assert!(locs[0].uri.path().ends_with("java/lang/Long.java"));
+}
+
+/// The one name-mismatch case among the 8: `Char` maps to `java.lang.Character`,
+/// not `java.lang.Char` -- mirroring the exact `MutableList` -> `java.util.List`
+/// mismatch already handled by looking up the platform type's own simple name
+/// rather than the original Kotlin spelling.
+#[test]
+fn resolve_kotlin_builtin_type_platform_equivalent_resolves_char_to_java_lang_character() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_fake_android_sdk_source(
+        root,
+        "java/lang/Character.java",
+        "package java.lang;\npublic final class Character {\n}\n",
+    );
+
+    let idx = Indexer::new();
+    idx.workspace_root.set(root.to_path_buf());
+
+    let locs = resolve_kotlin_builtin_type_platform_equivalent(&idx, "Char");
+    assert_eq!(
+        locs.len(),
+        1,
+        "expected Char to resolve to java.lang.Character, got {locs:?}"
+    );
+    assert!(locs[0].uri.path().ends_with("java/lang/Character.java"));
+}


### PR DESCRIPTION
## Summary
- `Int`/`Long`/`Double`/`Float`/`Boolean`/`Byte`/`Short`/`Char` are compiler intrinsics with no compiled `.class` in kotlin-stdlib's JAR, so companion-member lookups (`Int.MAX_VALUE`, `Char.isDigit(c)`, etc.) resolved to nothing.
- Extends `KOTLIN_BUILTIN_TYPE_PLATFORM_EQUIVALENTS` (the same table used for `String`/`List`/`Map`/etc. since #291/#292) to cover the 8 primitive-scalar types, with `Char` → `java.lang.Character` as the one name-mismatch case.

## Test plan
- [x] 2 new unit tests (plain case + Char rename case), confirmed RED before fix / GREEN after
- [x] Full suite: 1875 passed / 0 failed / 3 ignored
- [x] `cargo fmt` + `cargo clippy --tests -- -D warnings` clean
- [x] Measured against real Moneta corpus (13,242 files): member-ref recall 85.8%, no primitive-type names in the actionable Gap list