### PR TITLE
fix(resolve): synthesize entries/values/valueOf for enum classes

### DIFF
--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -28,7 +28,10 @@ use crate::types::{FileData, FileIndexResult, Visibility};
 ///      `extension_receiver`, `extension_receiver_type`, `doc`) moved behind a
 ///      boxed `cold: Option<Box<SymbolColdFields>>` — a positional bincode
 ///      layout change, so older caches must be rejected and rescanned.
-pub(crate) const CACHE_VERSION: u32 = 30;
+/// v31: `parse_kotlin` now synthesizes `entries`/`values`/`valueOf` symbols
+///      for every enum class — a cached pre-v31 file's symbol list lacks
+///      them, so older caches must be rejected and rescanned.
+pub(crate) const CACHE_VERSION: u32 = 31;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -196,6 +196,9 @@ pub(crate) fn parse_kotlin(content: &str) -> FileData {
         // ── synthesize compiler-generated copy() for every data class ────────
         synthesize_data_class_copy(root, bytes, &mut data.symbols);
 
+        // ── synthesize compiler-generated entries/values/valueOf for every enum ──
+        synthesize_enum_members(&mut data.symbols);
+
         finalize_parse(data, root, bytes);
     })
 }
@@ -468,6 +471,78 @@ fn synthesize_data_class_copy(root: Node, bytes: &[u8], symbols: &mut Vec<Symbol
             cold: None,
             trailing_lambda: false,
             deprecated: cls.deprecated,
+        });
+    }
+}
+
+/// Synthesize the three compiler-generated static members every `enum class`
+/// gets: `entries` (a `EnumEntries<T>` property, Kotlin 1.9+), `values()`
+/// (`Array<T>`), and `valueOf(name: String)` (`T`). None of these ever
+/// appears as a literal declared symbol in the source text — the compiler
+/// generates them — so without this, `Flavor.entries`/
+/// `TransactionAction.valueOf(it.name)` resolve to zero candidates no matter
+/// how correct qualified-member lookup otherwise is. Same synthesis shape as
+/// [`synthesize_data_class_copy`] just above; instance members inherited
+/// from `kotlin.Enum` (`.name`, `.ordinal`) are a separate, already-handled
+/// concern and not touched here.
+fn synthesize_enum_members(symbols: &mut Vec<SymbolEntry>) {
+    let enum_classes: Vec<SymbolEntry> = symbols
+        .iter()
+        .filter(|s| s.kind == SymbolKind::ENUM)
+        .cloned()
+        .collect();
+
+    for cls in enum_classes {
+        // `range` deliberately points at the class name's own (small) span,
+        // not `cls.range` (the full class body): `find_name_scoped_to_container`
+        // treats a member whose `range` equals its container's `range` as the
+        // container symbol matching itself and excludes it. Using `cls.range`
+        // here — as `synthesize_data_class_copy` above does — would make these
+        // three synthesized members invisible to that lookup. It's harmless
+        // there only because `copy()` is instance-called and resolves through
+        // a different path; `Type.entries`/`values()`/`valueOf()` are
+        // type-qualified and go through exactly this containment check.
+        symbols.push(SymbolEntry {
+            name: "entries".to_owned(),
+            kind: SymbolKind::PROPERTY,
+            visibility: cls.visibility,
+            range: cls.selection_range,
+            selection_range: cls.selection_range,
+            detail: format!("val entries: EnumEntries<{}>", cls.name),
+            params: String::new(),
+            param_counts: (0, 0),
+            container: Some(cls.name.clone()),
+            cold: None,
+            trailing_lambda: false,
+            deprecated: false,
+        });
+        symbols.push(SymbolEntry {
+            name: "values".to_owned(),
+            kind: SymbolKind::FUNCTION,
+            visibility: cls.visibility,
+            range: cls.selection_range,
+            selection_range: cls.selection_range,
+            detail: format!("fun values(): Array<{}>", cls.name),
+            params: String::new(),
+            param_counts: (0, 0),
+            container: Some(cls.name.clone()),
+            cold: None,
+            trailing_lambda: false,
+            deprecated: false,
+        });
+        symbols.push(SymbolEntry {
+            name: "valueOf".to_owned(),
+            kind: SymbolKind::FUNCTION,
+            visibility: cls.visibility,
+            range: cls.selection_range,
+            selection_range: cls.selection_range,
+            detail: format!("fun valueOf(value: String): {}", cls.name),
+            params: "value: String".to_owned(),
+            param_counts: (1, 1),
+            container: Some(cls.name),
+            cold: None,
+            trailing_lambda: false,
+            deprecated: false,
         });
     }
 }

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -1962,6 +1962,50 @@ fn data_class_copy_function_type_param_not_split_on_arrow() {
 }
 
 #[test]
+fn enum_class_synthesizes_entries_values_valueof() {
+    // Kotlin 1.9+ synthesizes `entries`/`values()`/`valueOf(name)` onto every
+    // enum class at compile time -- they never appear as literal declared
+    // symbols in the source text, so nothing before this indexed them at all.
+    // Real, measured gap: `Flavor.entries`/`TransactionAction.valueOf(name)`
+    // in the Moneta corpus resolved to zero candidates.
+    let content = "enum class Flavor { PROD, DEV }";
+    let data = crate::parser::parse_kotlin(content);
+
+    let entries = data
+        .symbols
+        .iter()
+        .find(|s| s.name == "entries" && s.container.as_deref() == Some("Flavor"))
+        .expect("entries should be synthesized for enum class");
+    assert_eq!(entries.kind, SymbolKind::PROPERTY);
+
+    let value_of = data
+        .symbols
+        .iter()
+        .find(|s| s.name == "valueOf" && s.container.as_deref() == Some("Flavor"))
+        .expect("valueOf(name) should be synthesized for enum class");
+    assert_eq!(value_of.kind, SymbolKind::FUNCTION);
+    assert_eq!(
+        value_of.param_counts,
+        (1, 1),
+        "valueOf(name: String) has one required param, got {:?}",
+        value_of.param_counts
+    );
+
+    let values = data
+        .symbols
+        .iter()
+        .find(|s| s.name == "values" && s.container.as_deref() == Some("Flavor"))
+        .expect("values() should be synthesized for enum class");
+    assert_eq!(values.kind, SymbolKind::FUNCTION);
+    assert_eq!(
+        values.param_counts,
+        (0, 0),
+        "values() takes no params, got {:?}",
+        values.param_counts
+    );
+}
+
+#[test]
 fn extension_property_with_public_modifier_receiver() {
     let src = "public val ViewModel.viewModelScope: CoroutineScope get() = TODO()";
     let data = super::parse_kotlin(src);

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -667,6 +667,47 @@ fn resolve_qualified_class_name_prefers_private_companion_member() {
     );
 }
 
+/// Regression: the enum-member-synthesis fix originally gave `entries`/
+/// `values`/`valueOf` the same `range` as their enclosing enum class, which
+/// made `find_name_scoped_to_container`'s self-containment guard
+/// (`symbol.range != container_symbol.range`) silently exclude them —
+/// `Flavor.entries` resolved to nothing even though the symbol existed in
+/// the table. Must resolve through the actual type-qualified lookup path,
+/// not just be present in the symbol table (a symbol-table-only check
+/// missed this bug the first time).
+#[test]
+fn enum_type_qualified_entries_values_valueof_resolve() {
+    // No literal "entries"/"values"/"valueOf" text anywhere but the enum
+    // declaration itself — `find_name_scoped_to_container`'s degenerate-
+    // container fallback does a raw post-declaration text scan, which could
+    // paper over a range-containment bug by matching a call-site occurrence
+    // instead of the synthesized symbol actually being found.
+    let uri = uri("/Flavor.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &uri,
+        concat!(
+            "package app\n",
+            "enum class Flavor {\n",
+            "  PROD, DEV\n",
+            "}\n",
+        ),
+    );
+
+    assert!(
+        !resolve_symbol(&idx, "entries", Some("Flavor"), &uri).is_empty(),
+        "Flavor.entries did not resolve"
+    );
+    assert!(
+        !resolve_symbol(&idx, "values", Some("Flavor"), &uri).is_empty(),
+        "Flavor.values did not resolve"
+    );
+    assert!(
+        !resolve_symbol(&idx, "valueOf", Some("Flavor"), &uri).is_empty(),
+        "Flavor.valueOf did not resolve"
+    );
+}
+
 #[test]
 fn resolve_qualified_class_name_prefers_named_companion_member() {
     // Same as above but with an explicitly named companion (`companion object


### PR DESCRIPTION
## Summary
- Kotlin 1.9+ synthesizes `entries`/`values()`/`valueOf(name)` onto every `enum class` at compile time — they never appear as literal declared symbols in the source, so goto-def/hover on `Flavor.entries` or `TransactionAction.valueOf(it.name)` resolved to zero candidates.
- `synthesize_enum_members` (`parser.rs`, modeled on the existing `synthesize_data_class_copy`) synthesizes these three members onto every enum class's symbol table at parse time.
- Bumps `CACHE_VERSION` (30 → 31): this fix adds new symbols to `parse_kotlin`'s output, so a pre-fix cached file's symbol list is stale and must be rejected/rescanned. Caught this the hard way — the first two corpus measurements of this fix showed zero improvement because the on-disk workspace cache was silently serving pre-fix data for already-indexed files, even though the resolution logic itself was already correct.

## Test plan
- [x] New unit test (`enum_class_synthesizes_entries_values_valueof`) confirming the three symbols are synthesized with correct kind/param_counts
- [x] New resolver regression test (`enum_type_qualified_entries_values_valueof_resolve`) exercising the actual type-qualified lookup path — not just symbol-table presence, since a symbol-table-only check missed the first version of this fix's range bug
- [x] Full suite: 1876 passed / 0 failed / 3 ignored
- [x] `cargo fmt` + `cargo clippy --tests -- -D warnings` clean
- [x] Measured against real Moneta corpus (13,242 files, cold reindex after the cache-version bump): member-ref recall 85.8% → 86.3%, `entries` dropped out of the top-20 actionable Gap names entirely (previously 206 occurrences)