### PR TITLE
fix(jar-index): index a JAR-compiled enum class's own constants

### DIFF
--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
@@ -358,6 +358,17 @@ private fun entriesFromClass(klass: KmClass, dep: DeprecationInfo, pkg: String):
             pkg = pkg, topLevel = false,
         )
     }
+    // `klass.enumEntries` is metadata-only -- a `KmClass`'s functions/properties
+    // lists never include its own enum constants (`BufferOverflow.DROP_OLDEST`),
+    // just their simple names. `"enum_member"` mirrors the Rust source-parsing
+    // side's `SymbolKind::ENUM_MEMBER` for a real `enum_entry` CST node, so a
+    // JAR-compiled enum constant and a source-declared one behave identically.
+    for (entryName in klass.enumEntries) {
+        entries += SymbolEntry(
+            entryName, "enum_member", containerName, "$simpleName.$entryName",
+            pkg = pkg, topLevel = false,
+        )
+    }
     return entries
 }
 

--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/model/SymbolEntry.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/model/SymbolEntry.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class SymbolEntry(
     val name: String,
-    /** "class", "interface", "object", "fun", "val", "var", "typealias" */
+    /** "class", "interface", "object", "fun", "val", "var", "typealias", "enum_member" */
     val kind: String,
     /** Enclosing class/object name; empty for top-level symbols. */
     val container: String,

--- a/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
+++ b/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
@@ -506,4 +506,38 @@ class IndexerTest {
                 "got: ${logMethods.map { it.name }}",
         )
     }
+
+    @Test
+    @DisplayName("indexJarFile indexes a compiled enum class's own constants")
+    fun testCompiledEnumClassConstantsAreIndexed() {
+        // `entriesFromClass` iterates `klass.functions`/`klass.properties` but
+        // never `klass.enumEntries` -- so a JAR-compiled enum class's own
+        // constants (e.g. `BufferOverflow.DROP_OLDEST`) were never indexed at
+        // all, even though the enum class itself (and any real functions/
+        // properties it declares) were. Real, measured gap: any qualified
+        // reference to a JAR-compiled enum constant resolves to zero
+        // candidates in a real consuming project.
+        val jarPath = System.getProperty("coroutines.jar")
+        assertNotNull(jarPath, "coroutines.jar system property must be set by the build")
+
+        val entries = indexJarFile(jarPath!!)
+
+        val bufferOverflow = entries.singleOrNull { it.name == "BufferOverflow" && it.kind == "class" }
+        assertNotNull(bufferOverflow, "expected the BufferOverflow enum class itself to be indexed")
+
+        val constantNames = setOf("SUSPEND", "DROP_OLDEST", "DROP_LATEST")
+        val constants = entries.filter { it.name in constantNames && it.container == "BufferOverflow" }
+        assertEquals(
+            constantNames,
+            constants.map { it.name }.toSet(),
+            "expected all three BufferOverflow enum constants under its own container, " +
+                "got: ${entries.filter { it.container == "BufferOverflow" }.map { "${it.name}:${it.kind}" }}",
+        )
+        assertTrue(
+            constants.all { it.kind == "enum_member" },
+            "enum constants must carry the 'enum_member' kind so the Rust side maps them " +
+                "to SymbolKind::ENUM_MEMBER (matching source-parsed enum constants), " +
+                "got: ${constants.map { "${it.name}:${it.kind}" }}",
+        )
+    }
 }

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -1173,6 +1173,7 @@ fn kind_str_to_lsp(kind: &str) -> tower_lsp::lsp_types::SymbolKind {
         "val" => tower_lsp::lsp_types::SymbolKind::PROPERTY,
         "var" => tower_lsp::lsp_types::SymbolKind::VARIABLE,
         "typealias" => tower_lsp::lsp_types::SymbolKind::CLASS,
+        "enum_member" => tower_lsp::lsp_types::SymbolKind::ENUM_MEMBER,
         _ => tower_lsp::lsp_types::SymbolKind::NULL,
     }
 }

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -55,7 +55,11 @@ use crate::sidecar::SidecarSymbol;
 ///            match the enclosing class's bare simple name (was a fully-qualified
 ///            `"Outer.Forest"`, which could never match an `Outer.member` lookup
 ///            keyed by `Outer`'s own bare name) — force re-scan.
-const JAR_CACHE_VERSION: u32 = 16;
+/// v17: sidecar now emits an `"enum_member"` entry for every one of a JAR-
+///      compiled enum class's own constants (`BufferOverflow.DROP_OLDEST`) —
+///      a cached pre-v17 JAR's entries lack them, so older caches must be
+///      rejected and rescanned.
+const JAR_CACHE_VERSION: u32 = 17;
 
 #[derive(Serialize, Deserialize)]
 struct JarCache {

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -1611,6 +1611,62 @@ fn jar_nested_class_fqn_in_qualified_index() {
 }
 
 #[test]
+fn jar_enum_constant_resolves_with_enum_member_kind() {
+    // The sidecar now emits an "enum_member" SymbolEntry for each of a
+    // JAR-compiled enum class's own constants (see KotlinClassIndexer.kt's
+    // `entriesFromClass`, which iterates `klass.enumEntries`). Confirms the
+    // Rust side both resolves `BufferOverflow.DROP_OLDEST` as a qualified
+    // member (same container-name matching already proven for JAR functions/
+    // properties) and maps its kind to `SymbolKind::ENUM_MEMBER`, not the
+    // `NULL` sentinel an unrecognized kind string would fall back to.
+    let indexer = idx();
+    let jar_path = "/home/test/.gradle/caches/kotlinx-coroutines-core-jvm-1.11.0.jar";
+
+    let symbols = vec![
+        make_sidecar_symbol(
+            "BufferOverflow",
+            "class",
+            "class kotlinx.coroutines.channels.BufferOverflow",
+            "",
+        ),
+        make_sidecar_symbol(
+            "DROP_OLDEST",
+            "enum_member",
+            "BufferOverflow.DROP_OLDEST",
+            "BufferOverflow",
+        ),
+    ];
+    populate_from_symbols(&indexer, jar_path.as_ref(), &symbols);
+
+    let user_uri = Url::parse("file:///src/main/Main.kt").unwrap();
+    indexer.index_content(
+        &user_uri,
+        "package com.example.main\n\nimport kotlinx.coroutines.channels.BufferOverflow\n\nfun example() = BufferOverflow.DROP_OLDEST",
+    );
+
+    let locs =
+        crate::resolver::resolve_symbol(&indexer, "DROP_OLDEST", Some("BufferOverflow"), &user_uri);
+    assert!(
+        !locs.is_empty(),
+        "BufferOverflow.DROP_OLDEST should resolve via container-name matching"
+    );
+
+    let fd = indexer
+        .file_data_for(&format!("jar:file://{jar_path}"))
+        .expect("jar file data should be populated");
+    let drop_oldest = fd
+        .symbols
+        .iter()
+        .find(|s| s.name == "DROP_OLDEST")
+        .expect("DROP_OLDEST symbol should be present");
+    assert_eq!(
+        drop_oldest.kind,
+        tower_lsp::lsp_types::SymbolKind::ENUM_MEMBER,
+        "enum_member sidecar kind must map to SymbolKind::ENUM_MEMBER, not fall back to NULL"
+    );
+}
+
+#[test]
 fn jar_extension_has_package_for_same_package_resolution() {
     let indexer = idx();
     let jar_path = "/home/test/.gradle/caches/coroutines-core-1.7.3.jar";


### PR DESCRIPTION
## Summary
- `entriesFromClass` iterated a `KmClass`'s `functions`/`properties` but never its `enumEntries`, so a JAR-compiled enum class's own constants (e.g. `BufferOverflow.DROP_OLDEST`, `Orientation.Horizontal`) were never indexed at all — any qualified or imported-bare reference to one resolved to zero candidates.
- Adds a new `"enum_member"` sidecar kind for these, mapped to `SymbolKind::ENUM_MEMBER` on the Rust side (matching source-parsed enum constants, PR #299's synthesized ones included).
- Bumps `JAR_CACHE_VERSION` (16 → 17): this fix adds new entries to what gets cached per JAR class, so a pre-fix cached JAR's entries are stale — same lesson as PR #299's `CACHE_VERSION` bump.

This is the third of three "cheap fix" resolution-accuracy candidates scouted earlier this session, after #298 (primitive-scalar companions) and #299 (enum `entries`/`values`/`valueOf`).

## Test plan
- [x] New sidecar test (`testCompiledEnumClassConstantsAreIndexed`, against the real `kotlinx-coroutines-core-jvm` fixture jar's `BufferOverflow` enum) confirmed RED before the fix / GREEN after
- [x] New Rust resolver test (`jar_enum_constant_resolves_with_enum_member_kind`) confirmed RED before the `kind_str_to_lsp` mapping / GREEN after
- [x] Full sidecar suite and full Rust suite (1878 passed / 0 failed / 3 ignored) both green
- [x] `cargo fmt` + `cargo clippy --tests -- -D warnings` clean
- [x] Measured against real Moneta corpus (13,242 files): member-ref recall 86.3% → 86.5%, bare-ref recall 63.7% → 65.0% (JAR enum constants are commonly referenced as bare imported names)