### PR TITLE
fix(jar-index): index a JAR-compiled class's real named nested types

### DIFF
--- a/java-sidecar/build.gradle.kts
+++ b/java-sidecar/build.gradle.kts
@@ -44,6 +44,16 @@ dependencies {
     timberFixture("com.jakewharton.timber:timber:5.0.1")
 }
 
+// Real-world fixture JAR for the plain-nested-class regression test: Moshi's
+// core module is pure Java (no Kotlin metadata), and its entire builder API
+// lives in `Moshi$Builder` — a plain static nested class, not a companion
+// (Java has no such concept). Also covers a differently-named nested class
+// in a different class (`JsonAdapter$Factory`).
+val moshiFixture by configurations.creating { isTransitive = false }
+dependencies {
+    moshiFixture("com.squareup.moshi:moshi:1.15.2")
+}
+
 application {
     mainClass.set("io.github.hessesian.jarindexer.MainKt")
 }
@@ -62,6 +72,9 @@ tasks.test {
         timberFixture.files
             .firstOrNull { it.name.startsWith("timber") }
             ?.let { systemProperty("timber.jar", it.absolutePath) }
+        moshiFixture.files
+            .firstOrNull { it.name.startsWith("moshi") }
+            ?.let { systemProperty("moshi.jar", it.absolutePath) }
     }
 }
 

--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
@@ -10,6 +10,25 @@ import org.objectweb.asm.FieldVisitor
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 
+// ── Nested-class naming: real declarations vs. compiler-synthesized helpers ──
+
+/**
+ * True when `simpleName` (the segment after a class's *last* `$`, e.g. `"Builder"`
+ * in `Moshi$Builder`) is the compiler's naming pattern for a synthetic nested
+ * class rather than a real, user-nameable declaration.
+ *
+ * Both javac and kotlinc number anonymous classes, local classes, and lambdas
+ * with a digit immediately after the `$` (`Outer$1`, `Outer$1Local`,
+ * `Outer$foo$1`, ...) — never true for a real named nested class/interface/
+ * object, so this alone is enough to reject them. `WhenMappings`/`DefaultImpls`
+ * (Kotlin's own synthesized helpers) pass this check by name, but are already
+ * excluded upstream: they compile to `KotlinClassMetadata.SyntheticClass`, not
+ * `.Class`, so `indexClassBytes`'s `when (metadata)` dispatch drops them via its
+ * `else -> emptyList()` branch before a nested class ever reaches this check.
+ */
+private fun looksSynthetic(simpleName: String): Boolean =
+    simpleName.isEmpty() || simpleName.first().isDigit()
+
 // ── ASM: extract @kotlin.Metadata annotation bytes ───────────────────────────
 
 private class StringArrayCollector(private val target: MutableList<String>) : AnnotationVisitor(Opcodes.ASM9) {
@@ -425,14 +444,21 @@ private class JavaClassVisitor(private val entries: MutableList<SymbolEntry>, pr
     private var className = ""
     private var isPublicClass = false
 
+    private var ownContainer = ""
+
     override fun visit(version: Int, access: Int, name: String, signature: String?, superName: String?, interfaces: Array<out String>?) {
-        className = name.substringAfterLast('/')
-        // Excludes `$`-named (nested/inner) classes here, once, so every
-        // member-visiting callback below (`visitMethod`, `visitField`) that
-        // gates on `isPublicClass` automatically skips members of a class
-        // that was never itself emitted as a class definition — Kotlin
-        // callers reference `Outer.Inner`, never the JVM's `Outer$Inner`.
-        isPublicClass = (access and Opcodes.ACC_PUBLIC) != 0 && !className.contains('$')
+        // JVM binary names nest with a literal `$` (`Outer$Builder`, unlike the
+        // Kotlin-metadata side's own dot convention -- see `entriesFromClass`).
+        // A real named nested class (`Outer$Builder`, referenced from Kotlin as
+        // `Outer.Builder`) is worth indexing, same as a real top-level class --
+        // what must stay excluded is a compiler-synthesized one: javac numbers
+        // anonymous and local classes (`Outer$1`, `Outer$1Local`), never true
+        // for a class with a real declared name.
+        val segments = name.substringAfterLast('/').split('$')
+        className = segments.last()
+        ownContainer = if (segments.size > 1) segments[segments.size - 2] else ""
+        val looksSyntheticNested = segments.size > 1 && looksSynthetic(className)
+        isPublicClass = (access and Opcodes.ACC_PUBLIC) != 0 && !looksSyntheticNested
         if (isPublicClass) {
             // Direct super types (super class + interfaces) as simple names; `Object`
             // is implicit and dropped as noise.
@@ -440,7 +466,10 @@ private class JavaClassVisitor(private val entries: MutableList<SymbolEntry>, pr
                 superName?.takeIf { it != "java/lang/Object" }?.let { add(it.substringAfterLast('/')) }
                 interfaces?.forEach { add(it.substringAfterLast('/')) }
             }
-            entries += SymbolEntry(className, "class", "", "class $className", pkg = pkg, topLevel = true, supers = supers)
+            entries += SymbolEntry(
+                className, "class", ownContainer, "class $className",
+                pkg = pkg, topLevel = segments.size == 1, supers = supers,
+            )
         }
     }
 
@@ -490,19 +519,20 @@ fun indexClassBytes(bytes: ByteArray): List<SymbolEntry> {
             val metadata = runCatching { KotlinClassMetadata.readLenient(metaVisitor.toMetadata()) }.getOrNull()
                 ?: return emptyList()
             val isFacade = metadata is KotlinClassMetadata.FileFacade || metadata is KotlinClassMetadata.MultiFileClassPart
-            // A companion object (named OR the default unnamed one) is the one
-            // nested-class shape whose members are worth indexing -- everything
-            // else `$`-named is an anonymous/synthetic compiler helper (lambdas,
-            // `WhenMappings`, anonymous objects, ...). Checked via the REAL
-            // Kotlin-metadata signal (`ClassKind.COMPANION_OBJECT`), not a
-            // `$Companion`-suffix name heuristic: the suffix only ever matches
-            // the default, UNNAMED companion (`Foo$Companion`) and silently
-            // drops every NAMED companion (`companion object Forest : Tree()`,
-            // compiled as `Foo$Forest`) -- a real, measured gap (Timber's
-            // entire public API -- `d`/`e`/`i`/`w`/`tag`/`plant`/... -- lives in
-            // exactly such a named companion and was previously unindexed).
-            val isCompanion = (metadata as? KotlinClassMetadata.Class)?.kmClass?.kind == ClassKind.COMPANION_OBJECT
-            if (!isFacade && !isCompanion && name.contains('$')) return emptyList()
+            // Any REAL named nested declaration (class/interface/object/enum/
+            // companion) is worth indexing, not just companions -- Kotlin
+            // callers reference `Outer.Builder(...)`/`Outer.Nested.member` just
+            // as often as a companion member. What must stay excluded is a
+            // compiler-SYNTHESIZED `$`-named class: lambdas, `WhenMappings`,
+            // `DefaultImpls` all compile to `KotlinClassMetadata.SyntheticClass`
+            // (filtered below, by the `when (metadata)` dispatch's `else`
+            // branch), and anonymous/local classes are numbered (`Outer$1`,
+            // `Outer$foo$1Local`) -- `looksSynthetic` on the class's own last
+            // `$`-segment catches those even though they DO carry `.Class`
+            // metadata (an anonymous `object : Foo {}` expression does).
+            if (name.contains('$') && !isFacade && looksSynthetic(name.substringAfterLast('$'))) {
+                return emptyList()
+            }
             val dep = DeprecationInfo(visitor.deprecatedMethods, visitor.deprecatedFields)
             val pkg = visitor.packageName
             when (metadata) {

--- a/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
+++ b/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
@@ -151,18 +151,21 @@ class IndexerTest {
     }
 
     @Test
-    @DisplayName("indexClassBytes does not orphan fields on a nested (\$-named) class")
-    fun testJavaFieldExtractionSkipsNestedClass() {
-        // The class-visiting entry point already skips emitting a class definition
-        // for `$`-named classes (see testInnerClass). Field extraction must apply
-        // the same exclusion — otherwise fields get indexed under a container
-        // qualifier ("Outer$Inner") that was never indexed as a class and that no
-        // Kotlin caller would ever reference (Kotlin spells it "Outer.Inner").
+    @DisplayName("indexClassBytes does not orphan fields on a synthetic (compiler-numbered) nested class")
+    fun testJavaFieldExtractionSkipsSyntheticNestedClass() {
+        // The class-visiting entry point excludes compiler-SYNTHESIZED `$`-named
+        // classes (anonymous/local, numbered `Outer$1` — see
+        // testJavaAnonymousNestedClassIsExcluded) but now indexes a REAL named
+        // nested class (see testJavaNestedClassIsIndexed). Field extraction must
+        // apply the same synthetic-only exclusion — otherwise fields on an
+        // anonymous class get indexed under a container qualifier ("Outer$1")
+        // that was never indexed as a class and that no Kotlin caller could ever
+        // reference.
         val cw = org.objectweb.asm.ClassWriter(0)
         cw.visit(
             org.objectweb.asm.Opcodes.V1_8,
             org.objectweb.asm.Opcodes.ACC_PUBLIC,
-            "com/example/Outer\$Inner",
+            "com/example/Outer\$1",
             null,
             "java/lang/Object",
             null
@@ -180,7 +183,7 @@ class IndexerTest {
 
         assertTrue(
             result.isEmpty(),
-            "fields on a \$-named class must be skipped, matching class-skipping behavior; got: ${result.map { "${it.name}:${it.kind}:${it.container}" }}"
+            "fields on an anonymous/synthetic \$-named class must be skipped, matching class-skipping behavior; got: ${result.map { "${it.name}:${it.kind}:${it.container}" }}"
         )
     }
 
@@ -322,22 +325,29 @@ class IndexerTest {
     }
 
     @Test
-    @DisplayName("indexClassBytes handles class with \$ in name (inner class)")
-    fun testInnerClass(@TempDir tmpDir: File) {
+    @DisplayName("indexClassBytes indexes a real named nested (\$-named, pure-Java) class")
+    fun testJavaNestedClassIsIndexed(@TempDir tmpDir: File) {
+        // A real named nested class (`Outer$Inner`, referenced from Kotlin as
+        // `Outer.Inner`) is a legitimate, user-nameable declaration — same as
+        // a real top-level class — and must be indexed under its own bare
+        // name with its enclosing class as its container.
         val innerBytes = minimalClassBytes("com/example/Outer\$Inner")
         val result = indexClassBytes(innerBytes)
-        // Inner classes with $ should be skipped unless they end with $Companion
-        assertTrue(result.isEmpty(), "should skip inner class with \$ in name")
+        val cls = result.singleOrNull { it.name == "Inner" && it.kind == "class" }
+        assertTrue(cls != null, "should index the real named nested class; got: ${result.map { it.name }}")
+        assertEquals("Outer", cls!!.container, "nested class's container must be its enclosing class")
+        assertFalse(cls.topLevel, "a nested class is not top-level")
     }
 
     @Test
-    @DisplayName("indexClassBytes accepts Companion classes")
-    fun testCompanionClass(@TempDir tmpDir: File) {
-        val companionBytes = minimalClassBytes("com/example/Foo\$Companion")
-        val result = indexClassBytes(companionBytes)
-        // No Kotlin metadata → Java fallback path; ACC_PUBLIC class but name has $
-        // JavaClassVisitor skips names containing '$'
-        assertTrue(result.isEmpty(), "JavaClassVisitor skips \$ names")
+    @DisplayName("indexClassBytes skips an anonymous/local (compiler-numbered) nested class")
+    fun testJavaAnonymousNestedClassIsExcluded(@TempDir tmpDir: File) {
+        // javac numbers anonymous and local classes (`Outer$1`, `Outer$1Local`)
+        // — never true for a class with a real declared name — so this shape
+        // must stay excluded even though it's otherwise ACC_PUBLIC.
+        val anonymousBytes = minimalClassBytes("com/example/Outer\$1")
+        val result = indexClassBytes(anonymousBytes)
+        assertTrue(result.isEmpty(), "should skip an anonymous (numbered) nested class; got: ${result.map { it.name }}")
     }
 
     @Test
@@ -462,6 +472,65 @@ class IndexerTest {
             real.detail.substringAfter("block:").contains("="),
             "block has no default value and must NOT be marked with '=', " +
                 "got: ${real.detail}",
+        )
+    }
+
+    @Test
+    @DisplayName("indexJarFile indexes a JAR-compiled, pure-Java, non-companion nested class (Moshi.Builder)")
+    fun testJarCompiledPlainNestedClassIsIndexed() {
+        // Moshi's core module is pure Java (no Kotlin metadata at all) — its
+        // entire builder API lives in `Moshi$Builder`, a plain static nested
+        // class, not a companion (Java has no such concept). The nested-class
+        // gate used to exclude EVERY `$`-named class outright in the Java
+        // fallback path, so `Moshi.Builder(...)` — a very common real-world
+        // constructor call — resolved to zero candidates.
+        val jarPath = System.getProperty("moshi.jar")
+        assertNotNull(jarPath, "moshi.jar system property must be set by the build")
+
+        val entries = indexJarFile(jarPath!!)
+
+        val builder = entries.singleOrNull { it.name == "Builder" && it.kind == "class" && it.container == "Moshi" }
+        assertNotNull(builder, "expected Moshi\$Builder to be indexed under container Moshi; got: " +
+            entries.filter { it.name == "Builder" }.map { "${it.name}:${it.container}" })
+
+        val buildMethod = entries.filter { it.name == "build" && it.container == "Builder" }
+        assertTrue(buildMethod.isNotEmpty(), "expected Builder.build() to be indexed under container Builder")
+
+        // A public, differently-named nested class in a different top-level
+        // class must also work — proves the container-parsing isn't hardcoded
+        // to a single class.
+        val factory = entries.singleOrNull { it.name == "Factory" && it.kind == "class" && it.container == "JsonAdapter" }
+        assertNotNull(factory, "expected JsonAdapter\$Factory to be indexed under container JsonAdapter")
+    }
+
+    @Test
+    @DisplayName("indexJarFile excludes compiler-synthesized nested classes even with the broadened gate")
+    fun testJarSyntheticNestedClassesAreExcluded() {
+        // The nested-class gate now admits real named declarations (see
+        // testJarCompiledPlainNestedClassIsIndexed / testNamedCompanionObjectMembersAreIndexed),
+        // so this regression-tests that the compiler's own synthetic helpers
+        // (`WhenMappings`, `DefaultImpls`, lambdas, anonymous objects) stay
+        // excluded — none of them are declarations a Kotlin caller could ever
+        // reference by name.
+        val jarPath = System.getProperty("coroutines.jar")
+        assertNotNull(jarPath, "coroutines.jar system property must be set by the build")
+
+        val entries = indexJarFile(jarPath!!)
+
+        assertTrue(
+            entries.none { it.container == "CoroutineStart" && it.name == "WhenMappings" },
+            "WhenMappings must never be indexed as a nested class",
+        )
+        assertTrue(
+            entries.none { it.name == "DefaultImpls" },
+            "DefaultImpls must never be indexed as a nested class",
+        )
+        assertTrue(
+            entries.none { it.name.contains('$') },
+            "no indexed symbol name should ever contain a raw '\$' " +
+                "(covers anonymous lambda/object-expression classes like AwaitKt\$joinAll\$1 " +
+                "and CoroutineExceptionHandlerKt\$CoroutineExceptionHandler\$1); got: " +
+                entries.filter { it.name.contains('$') }.map { "${it.name}:${it.container}" },
         )
     }
 

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -59,7 +59,7 @@ use crate::sidecar::SidecarSymbol;
 ///      compiled enum class's own constants (`BufferOverflow.DROP_OLDEST`) —
 ///      a cached pre-v17 JAR's entries lack them, so older caches must be
 ///      rejected and rescanned.
-const JAR_CACHE_VERSION: u32 = 17;
+const JAR_CACHE_VERSION: u32 = 18;
 
 #[derive(Serialize, Deserialize)]
 struct JarCache {


### PR DESCRIPTION
## Summary

- The nested-class gate excluded every `$`-named JAR class except companion objects, on **both** the Kotlin-metadata path and the pure-Java fallback path — so `Moshi.Builder(...)` (a real, common constructor call through an outer-class qualifier) resolved to zero candidates. Most Java libraries used from Kotlin (Moshi's core module included) have no Kotlin metadata at all, so the pure-Java path mattered just as much as the Kotlin one.
- Both paths now admit any real named nested declaration (class/interface/object/enum/companion), while still excluding compiler-synthesized `$`-named classes: `WhenMappings`/`DefaultImpls` are already dropped via their `SyntheticClass` metadata type, and anonymous/local classes are rejected by a digit-first check on the class's own last `$`-segment (`Outer$1`, `Outer$foo$1Local`) — verified against real anonymous-object-expression and lambda classes from kotlinx-coroutines, not just synthetic test fixtures.
- The pure-Java path also gained proper `$`-based container/nesting parsing (it previously always emitted `container = ""`, even in cases where a class WAS indexed).
- No Rust-side change was needed — `find_name_scoped_to_container`'s existing JAR-degenerate-range fallback already finds a newly-indexed nested class's members correctly.
- Bumps `JAR_CACHE_VERSION` 17→18 (changes what the sidecar emits for already-cached JARs).

## Measurement

Same-day controlled comparison against unmodified `main` on the identical Moneta corpus state (13,231 files):

- The previously-top-20 `Builder` member-ref gap (106 occurrences) drops out of the top 20 entirely.
- Combined member+bare CstResolved count is flat: 660,977 → 660,913 (0.0066% difference, within run-to-run noise).
- The member-ref recall percentage alone *looks* lower (86.0% → 84.5%) purely as a reclassification artifact: `R.string`/`R.drawable`-shaped chains — whose own nested-class receiver type now resolves — move from the uncounted "bare ref" bucket into the counted "member ref" bucket. Roughly half of those newly-counted occurrences now resolve; the rest surface a separate, pre-existing `R`-class gap that was previously invisible to this benchmark (already known/tracked separately, not caused by this change).

## Test plan

- [x] `./gradlew test` (java-sidecar) — 24/24 pass, including two new real-corpus regression tests against live `moshi:1.15.2` and `kotlinx-coroutines-core-jvm:1.11.0` fixture JARs
- [x] `cargo test` — 1878+ pass, 0 failed
- [x] `cargo fmt --check`, `cargo clippy --tests -- -D warnings` — clean
- [x] Deployed the fixed sidecar jar locally and confirmed `Moshi.Builder` resolves end-to-end against the real Moneta corpus (debug-instrumented, reverted before commit)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01CXHAR25HwqxCjg33D38NTV