### PR TITLE
fix(resolve): give Full IO the same global-defs tail IndexOnly already has

### DIFF
--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -476,6 +476,66 @@ fn jar_qualified_member_resolves_for_inferred_but_unimported_receiver_type() {
 }
 
 #[test]
+fn jar_qualified_member_ambiguous_root_narrowed_by_sibling_import_package() {
+    // Real, measured Moneta collision: `kotlinx.coroutines.Deferred` and an
+    // unrelated `com.google.firebase.components.Deferred` share a bare name.
+    // A file that calls `.await()` on an inferred `Deferred` almost never
+    // spells out `import kotlinx.coroutines.Deferred` (it's never written as
+    // a literal type), but DOES import a sibling from the same package
+    // (`kotlinx.coroutines.async`, the function that produced the inferred
+    // value) -- real, available evidence the denylist/module-scoped
+    // tie-breaks can't use (no denylist entry applies, and this workspace
+    // has no `workspace.json` module-dependency data).
+    let indexer = idx();
+    populate_from_symbols(
+        &indexer,
+        "/home/test/.gradle/caches/coroutines-core-1.7.3.jar".as_ref(),
+        &[
+            make_sidecar_symbol(
+                "Deferred",
+                "interface",
+                "interface kotlinx.coroutines.Deferred",
+                "",
+            ),
+            make_sidecar_symbol("await", "fun", "suspend fun await(): T", "Deferred"),
+        ],
+    );
+    populate_from_symbols(
+        &indexer,
+        "/home/test/.gradle/caches/firebase-components-19.0.0.aar".as_ref(),
+        &[make_sidecar_symbol(
+            "Deferred",
+            "class",
+            "class com.google.firebase.components.Deferred",
+            "",
+        )],
+    );
+
+    let user_uri = Url::parse("file:///src/main/Main.kt").unwrap();
+    // No `import ...Deferred` at all (used only via inference) -- but DOES
+    // import a sibling symbol from the real package.
+    indexer.index_content(
+        &user_uri,
+        "package com.example\nimport kotlinx.coroutines.async\nfun test() {}",
+    );
+
+    let locs = indexer.find_definition_qualified("await", Some("Deferred"), &user_uri);
+    assert_eq!(
+        locs.len(),
+        1,
+        "await should resolve uniquely via the sibling-import package tie-break, \
+         not decline as ambiguous; got: {:?}",
+        locs
+    );
+    assert!(
+        locs[0].uri.as_str().contains("coroutines-core"),
+        "must resolve to the kotlinx.coroutines Deferred, not the unrelated \
+         firebase-components one; got: {:?}",
+        locs[0]
+    );
+}
+
+#[test]
 fn empty_sidecar_symbols_no_crash() {
     let indexer = idx();
     let jar_path = "/home/test/.gradle/caches/empty-1.0.jar";

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -438,6 +438,44 @@ fn jar_qualified_name_in_qualified_index() {
 }
 
 #[test]
+fn jar_qualified_member_resolves_for_inferred_but_unimported_receiver_type() {
+    // A variable's type can be correctly INFERRED (e.g. via a JAR function's
+    // return type, `scope.async { ... }` returning `Deferred<T>`) without
+    // ever being explicitly imported in the referencing file -- Kotlin
+    // doesn't require an import for a type used only through inference.
+    // `find_definition_qualified` is called with that inferred type name as
+    // the qualifier (see `cst_symbol.rs`'s `receiver_type`), so qualified
+    // member lookup must not depend on the file's own import list to resolve
+    // the qualifier root -- real, measured gap: `Deferred<T>.await()` (and
+    // any JAR type used only via inference) resolved to zero candidates.
+    let indexer = idx();
+    populate_from_symbols(
+        &indexer,
+        "/home/test/.gradle/caches/coroutines-core-1.7.3.jar".as_ref(),
+        &[
+            make_sidecar_symbol(
+                "Deferred",
+                "interface",
+                "interface kotlinx.coroutines.Deferred",
+                "",
+            ),
+            make_sidecar_symbol("await", "fun", "suspend fun await(): T", "Deferred"),
+        ],
+    );
+
+    let user_uri = Url::parse("file:///src/main/Main.kt").unwrap();
+    // Deliberately no `import kotlinx.coroutines.Deferred` -- the file only
+    // ever uses `Deferred` via inference.
+    indexer.index_content(&user_uri, "package com.example\nfun test() {}");
+
+    let locs = indexer.find_definition_qualified("await", Some("Deferred"), &user_uri);
+    assert!(
+        !locs.is_empty(),
+        "await should resolve on an inferred-but-unimported JAR receiver type; got 0 locations"
+    );
+}
+
+#[test]
 fn empty_sidecar_symbols_no_crash() {
     let indexer = idx();
     let jar_path = "/home/test/.gradle/caches/empty-1.0.jar";

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -513,20 +513,27 @@ fn resolve_chain(
 const DENYLISTED_PACKAGE_PREFIXES: &[&str] = &["com.android.internal."];
 
 /// Tail fallback shared by [`ResolveIo::HierarchyAmbiguitySafe`] (the
-/// hierarchy walk's own per-hop resolution) and [`ResolveIo::IndexOnly`]
+/// hierarchy walk's own per-hop resolution), [`ResolveIo::IndexOnly`]
 /// (general bare-name resolution — diagnostics, `resolve_qualified`'s
-/// qualifier-root lookup, etc.): a unique candidate wins outright; an
-/// ambiguous set gets two narrow tie-breaks in sequence — first
+/// qualifier-root lookup, etc.), and `Full`'s own equivalent tail (see
+/// `resolve_chain`'s step 5.4): a unique candidate wins outright; an
+/// ambiguous set gets three narrow tie-breaks in sequence — first
 /// [`DENYLISTED_PACKAGE_PREFIXES`] (unconditional, project-wide), then
 /// [`module_scoped_tie_break`] (real per-module Gradle dependency data, when
-/// available) — before still declining unless one of them leaves exactly
-/// one candidate. See the real-workspace-json-schema design doc's §5 for why
-/// this ordering (denylist first, module-scoping second) is correct: the
-/// denylist is unconditional and needs no loaded data, while module-scoping
-/// only ever narrows what the denylist couldn't. `origin_uri` is the real
-/// file to resolve an owning module from for the second tie-break — the
-/// hierarchy walk's own starting file for `HierarchyAmbiguitySafe`, or
-/// simply the caller's own `from_uri` for `IndexOnly`.
+/// `workspace.json` provides it), then [`import_package_tie_break`] (the
+/// calling file's own already-parsed import list, always available — no
+/// external data needed, unlike module-scoping) — before still declining
+/// unless one of them leaves exactly one candidate. See the
+/// real-workspace-json-schema design doc's §5 for why denylist-first is
+/// correct: it's unconditional and needs no loaded data. Import-package
+/// narrowing runs last because it's the weakest signal of the three (a file
+/// merely importing a sibling from the right package, not the ambiguous
+/// name itself) — module-scoped narrowing, when its data is available, is
+/// strictly more precise (it's the *real* Gradle dependency graph, not an
+/// inference from unrelated imports). `origin_uri` is the real file to
+/// resolve an owning module/import-list from — the hierarchy walk's own
+/// starting file for `HierarchyAmbiguitySafe`, or simply the caller's own
+/// `from_uri` for `IndexOnly`/`Full`.
 fn ambiguity_safe_tail_with_denylist(
     indexer: &Indexer,
     origin_uri: &Url,
@@ -548,7 +555,11 @@ fn ambiguity_safe_tail_with_denylist(
     if filtered.len() < 2 {
         return vec![];
     }
-    module_scoped_tie_break(indexer, origin_uri, filtered)
+    let module_scoped = module_scoped_tie_break(indexer, origin_uri, filtered.clone());
+    if !module_scoped.is_empty() {
+        return module_scoped;
+    }
+    import_package_tie_break(indexer, origin_uri, filtered)
 }
 
 /// Second tie-break for [`ambiguity_safe_tail_with_denylist`]: when the
@@ -572,6 +583,52 @@ fn module_scoped_tie_break(
         .into_iter()
         .filter(|location| {
             candidate_gradle_meta(location).is_some_and(|meta| dependencies.contains(&meta))
+        })
+        .collect();
+    if narrowed.len() == 1 {
+        narrowed
+    } else {
+        vec![]
+    }
+}
+
+/// Third tie-break for [`ambiguity_safe_tail_with_denylist`]: when the
+/// denylist and module-scoped narrowing still leave more than one candidate,
+/// narrow using `origin_uri`'s own explicit (non-star) imports — not of the
+/// ambiguous name itself (`resolve_via_imports` already tried that, earlier
+/// in the chain, and failed, or this tail would never have been reached) but
+/// of any OTHER symbol from the same package. A file that writes `import
+/// kotlinx.coroutines.async` but never spells out `Deferred` (used only
+/// through inference, e.g. `scope.async { }.await()`) still tells us
+/// `kotlinx.coroutines` is a real, in-use package for this file — evidence
+/// an unrelated same-named decoy from a package this file never otherwise
+/// references (real, measured case: `com.google.firebase.components.Deferred`)
+/// doesn't have. Weaker than [`module_scoped_tie_break`] (an inference from
+/// unrelated imports, not the real dependency graph), so tried after it, but
+/// needs no `workspace.json` data at all — narrows real cases that
+/// module-scoping can't when a workspace has no module-dependency data
+/// loaded (e.g. a `workspace.json` with only `sourcePaths`, no `libraries`).
+fn import_package_tie_break(
+    indexer: &Indexer,
+    origin_uri: &Url,
+    locations: Vec<Location>,
+) -> Vec<Location> {
+    let Some(file_data) = indexer.files.get(origin_uri.as_str()) else {
+        return vec![];
+    };
+    let imported_packages: std::collections::HashSet<String> = file_data
+        .imports
+        .iter()
+        .filter(|i| !i.is_star)
+        .map(|i| import_package_prefix(&i.full_path))
+        .collect();
+    if imported_packages.is_empty() {
+        return vec![];
+    }
+    let narrowed: Vec<Location> = locations
+        .into_iter()
+        .filter(|location| {
+            location_package(indexer, location).is_some_and(|pkg| imported_packages.contains(&pkg))
         })
         .collect();
     if narrowed.len() == 1 {
@@ -638,7 +695,22 @@ fn candidate_gradle_meta(location: &Location) -> Option<crate::cli::extract_sour
 /// denylisted — the tie-break must only ever remove a candidate it can
 /// positively prove is denylisted.
 fn is_denylisted_package_prefix(indexer: &Indexer, location: &Location) -> bool {
-    let Some(package) = jar_symbol_package(indexer, location)
+    let Some(package) = location_package(indexer, location) else {
+        return false;
+    };
+    DENYLISTED_PACKAGE_PREFIXES
+        .iter()
+        .any(|prefix| package.starts_with(prefix))
+}
+
+/// `location`'s own real package — same three-map fallback chain
+/// [`is_denylisted_package_prefix`]'s doc comment explains (per-symbol JAR
+/// package first, then a regular source file's single package, then a
+/// compiled-only JAR entry's first-symbol-derived package). Shared by every
+/// tie-break in [`ambiguity_safe_tail_with_denylist`] that needs to compare
+/// a candidate's package against something else.
+fn location_package(indexer: &Indexer, location: &Location) -> Option<String> {
+    jar_symbol_package(indexer, location)
         .or_else(|| {
             indexer
                 .files
@@ -651,12 +723,6 @@ fn is_denylisted_package_prefix(indexer: &Indexer, location: &Location) -> bool 
                 .get(location.uri.as_str())
                 .and_then(|f| f.package.clone())
         })
-    else {
-        return false;
-    };
-    DENYLISTED_PACKAGE_PREFIXES
-        .iter()
-        .any(|prefix| package.starts_with(prefix))
 }
 
 /// Returns the first Location found by scanning star-import packages.

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -393,6 +393,32 @@ fn resolve_chain(
         if !rg_result.is_empty() {
             return rg_result;
         }
+        // 5.4 ── global definitions index (includes JAR symbols) ───────────────
+        // `rg`/`fd` only search the *workspace's own* source tree, so a type
+        // used purely through inference and never explicitly imported (Kotlin
+        // doesn't require an import for that) — e.g. `scope.async { }.await()`,
+        // where `Deferred` is inferred from `async`'s JAR-indexed return type
+        // but no file spells out `import kotlinx.coroutines.Deferred` — was
+        // unreachable here: real, measured gap. Same ambiguity-safe tie-break
+        // `IndexOnly`/`HierarchyAmbiguitySafe` already use below, extended to
+        // `Full` too — a unique JAR/workspace candidate wins outright; an
+        // ambiguous set still declines rather than guessing. Shape-filtered
+        // first, same as `rg_result` just above: an arity-incompatible
+        // same-name workspace declaration (e.g. a differently-shaped local
+        // overload) must not win here just because it's the sole candidate
+        // this index lookup happens to return.
+        let jar_tail_candidates = indexer.lookup_definitions(name);
+        let jar_tail_candidates = match shape {
+            Some(shape) => jar_tail_candidates
+                .into_iter()
+                .filter(|location| rg_location_satisfies_call_shape(indexer, location, name, shape))
+                .collect(),
+            None => jar_tail_candidates,
+        };
+        let jar_tail = ambiguity_safe_tail_with_denylist(indexer, from_uri, jar_tail_candidates);
+        if !jar_tail.is_empty() {
+            return jar_tail;
+        }
         // 5.5 ── Kotlin built-in-type platform equivalent (last resort) ────────
         // `rg`/`fd` search the *workspace's own* source tree and can never find
         // `String`/`CharSequence`: those are compiler intrinsics with no
@@ -414,7 +440,9 @@ fn resolve_chain(
     //    on the Moneta corpus (13 candidates for bare `String`, including a
     //    `com.android.internal.*`-packaged one) when it used the older,
     //    plain unique-match-only rule.
-    //  - Full: never reached (returns inside the rg branch above).
+    //  - Full: never reached — it has its own equivalent tail (5.4 above,
+    //    same `ambiguity_safe_tail_with_denylist` call) inside the rg branch,
+    //    since Full always returns from within that `if full_io` block.
     //
     // Each non-`ScopedOnly` arm falls through to
     // `resolve_kotlin_builtin_type_platform_equivalent` when its own lookup


### PR DESCRIPTION
## Summary

**Commit 1** — `resolve_chain`'s Full-IO branch (live goto-definition/hover) unconditionally returned from inside its rg-fallback block, so it could never reach the global-definitions-index tail fallback (`ambiguity_safe_tail_with_denylist` + `lookup_definitions`, includes JAR symbols) that `IndexOnly`/`HierarchyAmbiguitySafe` already use. Real gap: a JAR type used only through inference and never explicitly imported (Kotlin doesn't require an import for that) — e.g. `scope.async { }.await()` — resolved to zero candidates under live goto-definition/hover.

**Commit 2** — adds a third, narrower tie-break to `ambiguity_safe_tail_with_denylist` itself (shared by `IndexOnly`/`HierarchyAmbiguitySafe`/commit 1's new Full tail): when an ambiguous bare-name lookup can't be narrowed by the denylist or module-scoped Gradle data, check whether the calling file imports another symbol from the *same package* as one of the candidates. Concrete real case: `kotlinx.coroutines.Deferred` collides with an unrelated `com.google.firebase.components.Deferred` in any project depending on both — a file that writes `import kotlinx.coroutines.async` but never spells out `Deferred` itself now correctly prefers the coroutines one.

## Real corpus measurement

Full before/after on the same Moneta corpus state (13,247 files):

| | Before | After | Delta |
|---|---|---|---|
| member-ref recall | 84.5% | 86.0% | +1.5pp |
| bare-ref recall | 65.3% | 71.2% | **+5.9pp** |
| Gap total (member+bare) | 297,335 | 244,776 | **−52,559** |
| combined resolved count | 660,913 | 711,461 | **+50,548** |

`await` — the gap that prompted this investigation (1087+ occurrences in the original measurement) — drops completely out of the top-20 gap list. The swing is far above this benchmark's known ~500-600 run-to-run noise floor, and its breadth (way beyond just `Deferred`) confirms this tie-break helps many same-named ambiguous lookups across the real 740-jar dependency graph, not just the one collision that motivated it.

## Test plan

- [x] Two new regression tests, both RED-verified before their fix (temporarily disabled the relevant code path, confirmed the exact expected failure, re-enabled)
- [x] `cargo test` — 1880 pass, 0 failed
- [x] `cargo fmt --check`, `cargo clippy --tests -- -D warnings` — clean
- [x] Full before/after resolution-accuracy measurement on real Moneta corpus (above)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01CXHAR25HwqxCjg33D38NTV