### PR TITLE
fix(resolve): return every overload when a qualified member name collides

### DIFF
--- a/src/resolver/find.rs
+++ b/src/resolver/find.rs
@@ -138,6 +138,73 @@ pub(crate) fn find_name_scoped_to_container(
     .next()
 }
 
+/// Like [`find_name_scoped_to_container`], but returns EVERY same-named
+/// symbol declared directly inside `container`'s own body, not just the
+/// first match — for a caller that needs to hand an overloaded name's full
+/// candidate set to arity-based shape filtering, instead of collapsing to
+/// one arbitrary overload before that filtering ever runs.
+///
+/// Real, measured bug this fixes: a Java class's overloaded method (e.g.
+/// `FormatUtil.formatAmount`, 6 overloads) always resolved to the SAME one
+/// candidate via `find_name_scoped_to_container`'s `.find()` (Java method
+/// symbols land in reverse source order in `file_data.symbols`, so `.find()`
+/// always picked the highest-arity, last-declared overload) — which then
+/// failed arity-based shape filtering for nearly every real call site, since
+/// callers overwhelmingly use the OTHER overloads.
+///
+/// Only widens the primary range-containment path — the degenerate-range
+/// (JAR stub) fallback still returns at most one candidate, same as before;
+/// broadening overload support there needs sidecar-side changes (the JAR
+/// indexer would need to preserve each overload as a distinct symbol
+/// candidate), a separate, larger effort not needed for the real-world
+/// pure-Java-source case this was measured against.
+pub(crate) fn find_all_names_scoped_to_container(
+    idx: &Indexer,
+    name: &str,
+    container: &Location,
+) -> Vec<Location> {
+    let Some(file_data) = ensure_file_data(idx, &container.uri) else {
+        return vec![];
+    };
+
+    let Some(container_symbol) = file_data
+        .symbols
+        .iter()
+        .find(|symbol| symbol.selection_range == container.range)
+    else {
+        return find_name_in_uri_after_line(
+            idx,
+            name,
+            container.uri.as_str(),
+            container.range.start.line,
+        );
+    };
+
+    let contained: Vec<Location> = file_data
+        .symbols
+        .iter()
+        .filter(|symbol| {
+            symbol.name == name
+                && symbol.range != container_symbol.range
+                && range_encloses(container_symbol.range, symbol.range)
+        })
+        .map(|found| Location {
+            uri: container.uri.clone(),
+            range: found.selection_range,
+        })
+        .collect();
+    if !contained.is_empty() {
+        return contained;
+    }
+
+    find_name_in_uri_after_line(
+        idx,
+        name,
+        container.uri.as_str(),
+        container.range.start.line,
+    )
+}
+
 /// Like `find_declaration_range_in_lines` but only searches from `start_line`.
 pub(crate) fn find_declaration_range_after_line(
     lines: &[String],

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -32,7 +32,10 @@ use crate::types::{CallerContext, FileData};
 use crate::StrExt;
 
 use super::fd::{fd_find_and_parse, import_package_prefix};
-use super::find::{find_local_declaration, find_name_in_uri, find_name_scoped_to_container};
+use super::find::{
+    find_all_names_scoped_to_container, find_local_declaration, find_name_in_uri,
+    find_name_scoped_to_container,
+};
 use super::hierarchy::{
     walk_hierarchy, walk_hierarchy_breadth_first, MAX_SYNC_JAR_PROMOTIONS_PER_HIERARCHY_WALK,
 };
@@ -1407,8 +1410,15 @@ fn resolve_qualified(
                 continue;
             }
 
-            if let Some(loc) = find_name_scoped_to_container(indexer, name, &anchor) {
-                return vec![loc];
+            // Every same-named candidate, not just the first match — `name`
+            // may be an overloaded Java/Kotlin function, and collapsing to
+            // one arbitrary overload here (before the caller's own
+            // arity-based shape filtering ever runs) would make nearly
+            // every real call site to a DIFFERENT overload resolve to
+            // nothing (see `find_all_names_scoped_to_container`'s doc).
+            let member_locs = find_all_names_scoped_to_container(indexer, name, &anchor);
+            if !member_locs.is_empty() {
+                return member_locs;
             }
 
             // `anchor`'s own body doesn't declare `name` — it may live on a

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -5816,6 +5816,42 @@ fn find_definition_qualified_prefers_own_member_over_scope_function_fallback() {
     );
 }
 
+/// Real, measured bug (Moneta's `FormatUtil.java`, 6 real `formatAmount`
+/// overloads): a Java class's overloaded method always resolved to exactly
+/// ONE arbitrary candidate via `find_name_scoped_to_container`'s `.find()`
+/// (Java method symbols land in reverse source order in `file_data.symbols`,
+/// so `.find()` always picked the highest-arity, last-declared overload) —
+/// which then failed arity-based shape filtering (`shape_filter_locations`)
+/// for nearly every real call site, since callers overwhelmingly use the
+/// OTHER overloads. Qualified member lookup must hand the caller ALL
+/// same-named candidates so shape filtering — not first-match order — picks
+/// the right one.
+#[test]
+fn find_definition_qualified_returns_all_overload_candidates() {
+    let idx = Indexer::new();
+    let use_uri = Url::parse("file:///app/FormatUtil.java").unwrap();
+    idx.index_content(
+        &use_uri,
+        concat!(
+            "package app;\n",
+            "public class FormatUtil {\n",
+            "    public static String formatAmount(java.math.BigDecimal a) { return null; }\n",
+            "    public static String formatAmount(java.math.BigDecimal a, int b) { return null; }\n",
+            "    public static String formatAmount(java.math.BigDecimal a, int b, boolean c) { return null; }\n",
+            "}\n",
+        ),
+    );
+
+    let locs = idx.find_definition_qualified("formatAmount", Some("FormatUtil"), &use_uri);
+    assert_eq!(
+        locs.len(),
+        3,
+        "must return all 3 overload candidates, not collapse to the single \
+         highest-arity/last-declared one; got {:?}",
+        locs
+    );
+}
+
 /// Primitive D (member-extension visibility): `fun Modifier.weight(...)`
 /// declared as a MEMBER of `interface ColumnScope` — the real Compose
 /// `ColumnScope`/`Modifier.weight` shape — must resolve via goto-definition


### PR DESCRIPTION
## Summary

- `find_name_scoped_to_container`'s primary range-containment path used `.find()`, so `resolve_qualified`'s final member-lookup step always collapsed an overloaded name to exactly ONE candidate before the caller's own arity-based shape filtering (`shape_filter_locations`) ever got a chance to run.
- Real, measured bug: a Java class's overloaded method (`FormatUtil.formatAmount`, 6 real overloads in Moneta) always resolved to the highest-arity, last-declared overload — Java method symbols land in reverse source order in `file_data.symbols` — which then failed arity filtering for nearly every real call site, since callers overwhelmingly use the OTHER overloads.
- **Structural, not name-specific**: any overloaded Java (or Kotlin) method reached through a qualified lookup hits this, not just these three names.
- Adds `find_all_names_scoped_to_container`, a sibling of `find_name_scoped_to_container` that returns EVERY same-named symbol in the container's primary path instead of just the first match, wired into `resolve_qualified`'s final member-lookup step. Only the primary (range-containment) path is widened — the degenerate-range (JAR stub) fallback still returns at most one candidate; broadening overload support there needs sidecar-side changes, a separate effort. The other three call sites of `find_name_scoped_to_container` (walking nested TYPE segments) are untouched — a class/type name isn't overloadable, so `.find()`'s first-match semantics were never the bug there.

## Real corpus measurement

Full before/after on the same Moneta corpus state (13,247 files):

| | Before | After | Delta |
|---|---|---|---|
| member-ref recall | 86.0% | 87.1% | +1.1pp |
| FilteredCandidate total | 8,454 | 7,581 | −873 |
| Gap total (member) | 14,543 | 13,489 | −1,054 |
| combined resolved count | 711,461 | 712,903 | +1,442 |

`formatAmount`/`formatAccount`/`formatPercentage` disappear completely from both the Gap and FilteredCandidate top-20 tables (were 131 Gap + 58 Filtered, 129 Gap, and 41 Filtered occurrences respectively). Smaller aggregate swing than the previous ambiguity-tie-break fix, but a clean, coherent win across all three buckets (Gap down, Filtered down, Resolved up) with no offsetting regression — and it's a structural fix, so it should also help any other overloaded-method collision not yet surfaced by this specific corpus sample.

## Test plan

- [x] New regression test `find_definition_qualified_returns_all_overload_candidates`, RED-verified (temporarily reverted the call site, confirmed the exact "collapsed to 1 of 3, the last-declared one" failure, restored)
- [x] `cargo test` — 1881 pass, 0 failed
- [x] `cargo fmt --check`, `cargo clippy --tests -- -D warnings` — clean
- [x] Full before/after resolution-accuracy measurement on real Moneta corpus (above)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01CXHAR25HwqxCjg33D38NTV