### PR TITLE
feat(jar): discover and index each Android module's own R.jar

### DIFF
--- a/src/cli/resolution_accuracy_poc.rs
+++ b/src/cli/resolution_accuracy_poc.rs
@@ -70,7 +70,16 @@ pub(crate) async fn run_resolution_accuracy(root: &Path) {
     // without warming the compiled-JAR index, every library type looks
     // unresolvable and member recall would be an artifact of missing setup,
     // not resolver quality. Same requirement `missing_import_poc` documents.
-    let gradle_paths = crate::indexer::jar::scan_gradle_jars(None);
+    // Also folds in each Android module's own AAPT-generated `R.jar` — never
+    // a Gradle dependency, so `scan_gradle_jars` alone can never find it —
+    // so `R.string.foo`-style references get a fair, real measurement here
+    // too, same as the live LSP's own pipeline (`compiled_jar_paths_with_android_sdk`).
+    let mut gradle_paths = crate::indexer::jar::scan_gradle_jars(None);
+    for jar in crate::workspace_json::detect_android_r_class_jars(root) {
+        if !gradle_paths.contains(&jar) {
+            gradle_paths.push(jar);
+        }
+    }
     if !gradle_paths.is_empty() {
         let mut sidecar = index.jar_sidecar.lock().unwrap_or_else(|e| e.into_inner());
         let jar_symbol_count = crate::indexer::jar::index_jars(&index, &gradle_paths, &mut sidecar);

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -664,25 +664,35 @@ fn abandon_stale_jar_scan(
     let _ = jar_done_tx.send(());
 }
 
-/// Appends the Android SDK's compiled `android.jar` to `gradle_paths`, gated
-/// on the same `workspace_uses_gradle_cache` verdict the Gradle-cache scan
-/// itself uses. `android.jar` never lives in the Gradle module cache, but its
-/// Tier-1 manifest cost is real (measured: 3.18s cold / 550ms warm for a
-/// single real `android.jar`) — a workspace with no JVM sources (the same
-/// condition `workspace_uses_gradle_cache` already gates the Gradle-cache
-/// pipeline on, see its own call site's comment) must not pay it, matching
-/// the precedent this gate exists to enforce. Extracted as its own function
-/// (rather than inlined in `spawn_jar_indexing`) so the gating behavior is
-/// directly unit-testable without the sidecar/tokio machinery that makes
-/// `spawn_jar_indexing` itself untestable in this crate's unit-test harness.
+/// Appends the Android SDK's compiled `android.jar`, plus each Gradle
+/// module's own AAPT-generated `R.jar` (see
+/// [`crate::workspace_json::detect_android_r_class_jars`] — `R.string.foo`
+/// otherwise resolves to zero candidates no matter how correct import
+/// handling is, since `R.jar` was never even discovered), to `gradle_paths`,
+/// gated on the same `workspace_uses_gradle_cache` verdict the Gradle-cache
+/// scan itself uses. Neither ever lives in the Gradle module cache, but the
+/// SDK jar's Tier-1 manifest cost is real (measured: 3.18s cold / 550ms warm
+/// for a single real `android.jar`) — a workspace with no JVM sources (the
+/// same condition `workspace_uses_gradle_cache` already gates the
+/// Gradle-cache pipeline on, see its own call site's comment) must not pay
+/// it, matching the precedent this gate exists to enforce. Extracted as its
+/// own function (rather than inlined in `spawn_jar_indexing`) so the gating
+/// behavior is directly unit-testable without the sidecar/tokio machinery
+/// that makes `spawn_jar_indexing` itself untestable in this crate's
+/// unit-test harness.
 pub(crate) fn compiled_jar_paths_with_android_sdk(
     workspace_root: Option<PathBuf>,
     workspace_uses_gradle_cache: bool,
     mut gradle_paths: Vec<PathBuf>,
 ) -> Vec<PathBuf> {
     if workspace_uses_gradle_cache {
-        if let Some(root) = workspace_root {
-            for jar in crate::workspace_json::detect_android_sdk_jar_path(&root) {
+        if let Some(root) = &workspace_root {
+            for jar in crate::workspace_json::detect_android_sdk_jar_path(root) {
+                if !gradle_paths.contains(&jar) {
+                    gradle_paths.push(jar);
+                }
+            }
+            for jar in crate::workspace_json::detect_android_r_class_jars(root) {
                 if !gradle_paths.contains(&jar) {
                     gradle_paths.push(jar);
                 }

--- a/src/workspace/scan_handler_tests.rs
+++ b/src/workspace/scan_handler_tests.rs
@@ -321,3 +321,32 @@ fn android_jar_gate_preserves_existing_gradle_paths() {
         "gating android.jar off must not disturb the Gradle-cache paths already collected"
     );
 }
+
+#[test]
+fn module_r_class_jar_is_included_when_workspace_uses_gradle_cache() {
+    // `R.string.foo` resolves to zero candidates no matter how correct
+    // import handling is if `R.jar` is never even discovered — this proves
+    // the wiring, not just `detect_android_r_class_jars` in isolation.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("settings.gradle.kts"),
+        "include(\":core:common\")\n",
+    )
+    .unwrap();
+    let r_jar_dir = dir
+        .path()
+        .join("core/common/build/intermediates/compile_r_class_jar/debug/generateDebugRFile");
+    std::fs::create_dir_all(&r_jar_dir).unwrap();
+    std::fs::write(r_jar_dir.join("R.jar"), b"fake r.jar").unwrap();
+
+    let paths = super::compiled_jar_paths_with_android_sdk(
+        Some(dir.path().to_path_buf()),
+        true,
+        Vec::new(),
+    );
+
+    assert!(
+        paths.iter().any(|p| p.ends_with("R.jar")),
+        "core/common's R.jar must be included; got {paths:?}"
+    );
+}

--- a/src/workspace_json.rs
+++ b/src/workspace_json.rs
@@ -734,6 +734,99 @@ pub(crate) fn detect_android_sdk_jar_path(workspace_root: &Path) -> Vec<PathBuf>
     }
 }
 
+/// Real AGP task-output directories that produce a module's own `R.jar` —
+/// `compile_r_class_jar` for library modules, `compile_and_runtime_r_class_jar`
+/// for application/test modules. Neither has one fixed variant subdirectory
+/// name across a real project: a custom product-flavor setup produces names
+/// like `tst1Debug`/`ppeDebug`/`prodDebug` instead of plain `debug`/`release`
+/// (real, observed on a production multi-flavor app) — [`find_r_class_jar_for_module`]
+/// globs every variant under both task dirs rather than assuming one name.
+const R_CLASS_JAR_TASK_DIRS: &[&str] = &["compile_r_class_jar", "compile_and_runtime_r_class_jar"];
+
+/// Locates each Gradle module's own AAPT-generated `R.jar` (the module's
+/// resource-symbol class — `R`, plus its real nested classes `R$string`,
+/// `R$drawable`, `R$id`, … since PR #301 indexes those correctly) under its
+/// `build/` output, so `R.string.foo`-style references resolve like any
+/// other JAR type.
+///
+/// `R.jar` is never a Gradle dependency — it never lands in the shared
+/// Gradle cache [`scan_gradle_jars`] scans — and AGP regenerates it per
+/// module, per build variant, under an unpredictable variant-named
+/// subdirectory (see [`R_CLASS_JAR_TASK_DIRS`]'s doc). Picks at most ONE
+/// variant's `R.jar` per module (preferring one whose variant name contains
+/// "debug", else whichever is found first): a real, measured, and
+/// acceptable trade-off — resource NAMES don't change with build variant
+/// for the same module (an id's underlying numeric VALUE does, but that has
+/// no bearing on name resolution, all this benchmark/goto-definition needs).
+///
+/// Reuses [`settings_subprojects`] for module identity — the same
+/// `include(":module")` parsing [`detect_build_layout_source_paths`] already
+/// uses — so a module directory that plain doesn't have a built `R.jar` yet
+/// (never built, or a pure-Kotlin module with no `res/`) is silently
+/// skipped, never an error.
+pub(crate) fn detect_android_r_class_jars(workspace_root: &Path) -> Vec<PathBuf> {
+    let subprojects = settings_subprojects(workspace_root);
+    let module_dirs: Vec<PathBuf> = if subprojects.is_empty() {
+        vec![workspace_root.to_owned()]
+    } else {
+        subprojects.iter().map(|s| workspace_root.join(s)).collect()
+    };
+
+    let jars: Vec<PathBuf> = module_dirs
+        .iter()
+        .filter_map(|module_dir| find_r_class_jar_for_module(module_dir))
+        .collect();
+
+    if !jars.is_empty() {
+        log::info!(
+            "android-r-class: auto-detected {} module R.jar(s)",
+            jars.len()
+        );
+    }
+    jars
+}
+
+/// One module's own `R.jar`, if its project has been built — see
+/// [`detect_android_r_class_jars`]'s doc for the selection rule (prefer a
+/// "debug"-named variant, else the first one found).
+fn find_r_class_jar_for_module(module_dir: &Path) -> Option<PathBuf> {
+    let mut fallback: Option<PathBuf> = None;
+    for task_dir_name in R_CLASS_JAR_TASK_DIRS {
+        let task_dir = module_dir.join("build/intermediates").join(task_dir_name);
+        let Ok(variant_entries) = std::fs::read_dir(&task_dir) else {
+            continue;
+        };
+        for variant_entry in variant_entries.filter_map(|e| e.ok()) {
+            if !variant_entry
+                .file_type()
+                .map(|t| t.is_dir())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let Ok(task_output_entries) = std::fs::read_dir(variant_entry.path()) else {
+                continue;
+            };
+            for task_output_entry in task_output_entries.filter_map(|e| e.ok()) {
+                let jar = task_output_entry.path().join("R.jar");
+                if !jar.is_file() {
+                    continue;
+                }
+                let is_debug_shaped = variant_entry
+                    .file_name()
+                    .to_string_lossy()
+                    .to_lowercase()
+                    .contains("debug");
+                if is_debug_shaped {
+                    return Some(jar);
+                }
+                fallback.get_or_insert(jar);
+            }
+        }
+    }
+    fallback
+}
+
 /// Resolve the local Android SDK root directory, checking (in order)
 /// `local.properties`' `sdk.dir`, then `$ANDROID_HOME`, then
 /// `$ANDROID_SDK_ROOT`. Shared by `detect_android_sdk_source_paths` and

--- a/src/workspace_json_tests.rs
+++ b/src/workspace_json_tests.rs
@@ -746,3 +746,132 @@ fn load_module_dependencies_scopes_each_module_to_its_own_content_roots() {
         "app-only dependency leaked into core's scope: {artifacts:?}"
     );
 }
+
+// ─── Android R.jar detection tests ───────────────────────────────────────────
+
+/// Real, observed AGP output shape: `<module>/build/intermediates/
+/// compile_r_class_jar/<variant>/generate<Variant>RFile/R.jar`.
+fn write_r_jar(module_dir: &std::path::Path, task_dir: &str, variant: &str, task_output: &str) {
+    let dir = module_dir
+        .join("build/intermediates")
+        .join(task_dir)
+        .join(variant)
+        .join(task_output);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("R.jar"), b"fake r.jar").unwrap();
+}
+
+#[test]
+fn r_class_jars_found_across_multiple_modules() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("settings.gradle.kts"),
+        "include(\":core:common\")\ninclude(\":feature:accident\")\n",
+    )
+    .unwrap();
+    write_r_jar(
+        &dir.path().join("core/common"),
+        "compile_r_class_jar",
+        "debug",
+        "generateDebugRFile",
+    );
+    write_r_jar(
+        &dir.path().join("feature/accident"),
+        "compile_r_class_jar",
+        "debug",
+        "generateDebugRFile",
+    );
+
+    let jars = detect_android_r_class_jars(dir.path());
+    assert_eq!(jars.len(), 2, "expected one R.jar per module; got {jars:?}");
+    assert!(jars
+        .iter()
+        .any(|j| j.starts_with(dir.path().join("core/common"))));
+    assert!(jars
+        .iter()
+        .any(|j| j.starts_with(dir.path().join("feature/accident"))));
+}
+
+#[test]
+fn r_class_jar_prefers_debug_shaped_variant_over_custom_flavor() {
+    // Real, observed shape: a custom product-flavor setup produces variant
+    // names like `tst1Debug`/`ppeDebug`/`prodDebug` — none literally named
+    // "debug", but "prodDebug" (say) still CONTAINS "debug" and should win
+    // over a variant that doesn't (e.g. a pure "release"-only entry, or an
+    // unrelated non-debug flavor combination).
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("settings.gradle.kts"),
+        "include(\":app\")\n",
+    )
+    .unwrap();
+    let module_dir = dir.path().join("app");
+    write_r_jar(
+        &module_dir,
+        "compile_and_runtime_r_class_jar",
+        "release",
+        "processReleaseResources",
+    );
+    write_r_jar(
+        &module_dir,
+        "compile_and_runtime_r_class_jar",
+        "prodDebug",
+        "processProdDebugResources",
+    );
+
+    let jars = detect_android_r_class_jars(dir.path());
+    assert_eq!(jars.len(), 1);
+    assert!(
+        jars[0].to_string_lossy().contains("prodDebug"),
+        "must prefer the debug-shaped variant over release; got {:?}",
+        jars[0]
+    );
+}
+
+#[test]
+fn r_class_jar_falls_back_to_compile_and_runtime_task_dir() {
+    // App/test modules use a differently-named AGP task output dir than
+    // library modules (`compile_and_runtime_r_class_jar`, not
+    // `compile_r_class_jar`) — both must be checked.
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("settings.gradle.kts"),
+        "include(\":mobile\")\n",
+    )
+    .unwrap();
+    write_r_jar(
+        &dir.path().join("mobile"),
+        "compile_and_runtime_r_class_jar",
+        "tst1Debug",
+        "processTst1DebugResources",
+    );
+
+    let jars = detect_android_r_class_jars(dir.path());
+    assert_eq!(jars.len(), 1);
+}
+
+#[test]
+fn r_class_jar_skips_module_never_built() {
+    // A module with no `build/` output at all (never built, or pure-Kotlin
+    // with no `res/`) must be silently skipped, never an error.
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("settings.gradle.kts"),
+        "include(\":core:common\")\ninclude(\":core:pure-kotlin\")\n",
+    )
+    .unwrap();
+    write_r_jar(
+        &dir.path().join("core/common"),
+        "compile_r_class_jar",
+        "debug",
+        "generateDebugRFile",
+    );
+    // core/pure-kotlin has no build/ dir at all.
+
+    let jars = detect_android_r_class_jars(dir.path());
+    assert_eq!(
+        jars.len(),
+        1,
+        "only the built module's R.jar should be found; got {jars:?}"
+    );
+}

--- a/src/workspace_json_tests.rs
+++ b/src/workspace_json_tests.rs
@@ -829,7 +829,7 @@ fn r_class_jar_prefers_debug_shaped_variant_over_custom_flavor() {
 }
 
 #[test]
-fn r_class_jar_falls_back_to_compile_and_runtime_task_dir() {
+fn r_class_jar_found_under_app_module_task_dir() {
     // App/test modules use a differently-named AGP task output dir than
     // library modules (`compile_and_runtime_r_class_jar`, not
     // `compile_r_class_jar`) — both must be checked.


### PR DESCRIPTION
## Summary

- `R.string`/`R.drawable`/`R.id`/`R.layout` references resolved to zero candidates no matter how correct import handling was — a fundamentally different problem than the resolver fixes earlier this cycle. `R.jar` is AAPT-generated per module, per build variant, into that module's own `build/` output; it's never a Gradle dependency, so `scan_gradle_jars` (which only scans the shared Gradle dependency cache) can never find it. Source-file discovery also excludes `build/` entirely, by design.
- Adds `detect_android_r_class_jars` (`src/workspace_json.rs`): for each Gradle module (reusing `settings_subprojects`, the same `include(":module")` parsing `detect_build_layout_source_paths` already uses), globs `build/intermediates/{compile_r_class_jar,compile_and_runtime_r_class_jar}/` for the module's own `R.jar`. Neither AGP task-output shape has one fixed variant subdirectory name across a real project — a custom product-flavor setup produces names like `tst1Debug`/`ppeDebug`/`prodDebug` instead of plain `debug`/`release` (real, observed on Moneta, a 136-module app) — so this picks one variant per module (preferring a "debug"-shaped name, else the first found): resource NAMES don't change with build variant for the same module, only their numeric ID values do, irrelevant to symbol resolution.
- Wired into both real consumers: the live LSP's own `compiled_jar_paths_with_android_sdk` (gated on the identical `workspace_uses_gradle_cache` condition `android.jar`'s own detection already uses) and the resolution-accuracy benchmark. **No sidecar changes needed** — `R.class` is pure Java, so it goes through the same `JavaClassVisitor` path PR #301 already fixed.
- `BuildConfig.class` deliberately out of scope — a genuinely different, messier directory shape with far lower real-world occurrence count. Separate follow-up if ever pursued.

## Real corpus measurement

Full before/after on the same Moneta corpus state (13,247 files, 77 of 136 modules had a built R.jar to discover):

| | Before | After | Delta |
|---|---|---|---|
| member-ref recall | 87.1% | 88.7% | +1.6pp |
| bare-ref recall | 71.2% | 71.5% | +0.3pp |
| Gap total (member+bare) | 244,207 | 239,669 | −4,538 |
| FilteredCandidate | 7,581 | 7,108 | −473 |
| combined resolved count | 712,903 | 717,959 | +5,056 |

`string`/`id`/`layout` disappear completely from the member-ref Gap top-20; `drawable` drops from 1,120 to 623 occurrences (the remainder now traces to a different file/cause, not `R.drawable` itself).

## Test plan

- [x] 4 new tests for `detect_android_r_class_jars`/`find_r_class_jar_for_module` (multi-module discovery, debug-variant preference over a custom flavor, `compile_and_runtime_r_class_jar` fallback, silently skips an unbuilt module), RED-verified by temporarily neutering the implementation
- [x] 1 new integration test confirming `compiled_jar_paths_with_android_sdk` actually includes the discovered R.jar
- [x] `cargo test` — 1886 pass, 0 failed
- [x] `cargo fmt --check`, `cargo clippy --tests -- -D warnings` — clean
- [x] Full before/after resolution-accuracy measurement on real Moneta corpus (above)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01CXHAR25HwqxCjg33D38NTV