### PR TITLE
fix(r-class-jar): deterministic variant selection when multiple debug-shaped variants exist

### DIFF
--- a/src/workspace_json.rs
+++ b/src/workspace_json.rs
@@ -789,6 +789,18 @@ pub(crate) fn detect_android_r_class_jars(workspace_root: &Path) -> Vec<PathBuf>
 /// One module's own `R.jar`, if its project has been built — see
 /// [`detect_android_r_class_jars`]'s doc for the selection rule (prefer a
 /// "debug"-named variant, else the first one found).
+///
+/// "First found" means first in a *stable, sorted* order, not raw
+/// `std::fs::read_dir` iteration order — the standard library explicitly
+/// leaves that order unspecified, and it has been observed on this codebase's
+/// own dev machine to NOT match creation order (varies by filesystem, and can
+/// even be the reverse of insertion order). When a module has more than one
+/// variant whose name contains "debug" at once (a real product-flavor
+/// possibility, e.g. `stagingDebug` and `prodDebug` both present), or more
+/// than one non-debug fallback variant, candidate directory entries are
+/// sorted by name before picking so the same on-disk tree always yields the
+/// same `R.jar`, regardless of filesystem/platform/run-to-run enumeration
+/// order.
 fn find_r_class_jar_for_module(module_dir: &Path) -> Option<PathBuf> {
     let mut fallback: Option<PathBuf> = None;
     for task_dir_name in R_CLASS_JAR_TASK_DIRS {
@@ -796,7 +808,9 @@ fn find_r_class_jar_for_module(module_dir: &Path) -> Option<PathBuf> {
         let Ok(variant_entries) = std::fs::read_dir(&task_dir) else {
             continue;
         };
-        for variant_entry in variant_entries.filter_map(|e| e.ok()) {
+        let mut variant_entries: Vec<_> = variant_entries.filter_map(|e| e.ok()).collect();
+        variant_entries.sort_by_key(|e| e.file_name());
+        for variant_entry in variant_entries {
             if !variant_entry
                 .file_type()
                 .map(|t| t.is_dir())
@@ -807,7 +821,10 @@ fn find_r_class_jar_for_module(module_dir: &Path) -> Option<PathBuf> {
             let Ok(task_output_entries) = std::fs::read_dir(variant_entry.path()) else {
                 continue;
             };
-            for task_output_entry in task_output_entries.filter_map(|e| e.ok()) {
+            let mut task_output_entries: Vec<_> =
+                task_output_entries.filter_map(|e| e.ok()).collect();
+            task_output_entries.sort_by_key(|e| e.file_name());
+            for task_output_entry in task_output_entries {
                 let jar = task_output_entry.path().join("R.jar");
                 if !jar.is_file() {
                     continue;

--- a/src/workspace_json_tests.rs
+++ b/src/workspace_json_tests.rs
@@ -875,3 +875,85 @@ fn r_class_jar_skips_module_never_built() {
         "only the built module's R.jar should be found; got {jars:?}"
     );
 }
+
+/// Real, documented possibility: a product-flavor setup can have MORE THAN
+/// ONE variant whose name contains "debug" present simultaneously under
+/// `build/intermediates/` (e.g. both `stagingDebug` and `prodDebug` built in
+/// the same tree). `find_r_class_jar_for_module`'s own doc only promises
+/// "prefers a debug-shaped variant, else the first found" — it does NOT say
+/// which debug-shaped variant wins when there's more than one. The pick must
+/// still be the SAME every time regardless of the filesystem's `read_dir`
+/// iteration order (which the std docs explicitly leave unspecified) — not a
+/// coin flip across machines or runs.
+///
+/// This asserts the specific deterministic rule the fix establishes: sort
+/// candidate variants by directory name and take the alphabetically-first
+/// match, so `prodDebug` (p < s) always wins over `stagingDebug` no matter
+/// which order the directory entries happen to come back in.
+#[test]
+fn r_class_jar_deterministic_among_multiple_debug_shaped_variants() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("settings.gradle.kts"),
+        "include(\":app\")\n",
+    )
+    .unwrap();
+    let module_dir = dir.path().join("app");
+    write_r_jar(
+        &module_dir,
+        "compile_and_runtime_r_class_jar",
+        "prodDebug",
+        "processProdDebugResources",
+    );
+    write_r_jar(
+        &module_dir,
+        "compile_and_runtime_r_class_jar",
+        "stagingDebug",
+        "processStagingDebugResources",
+    );
+
+    let jars = detect_android_r_class_jars(dir.path());
+    assert_eq!(jars.len(), 1);
+    assert!(
+        jars[0].to_string_lossy().contains("prodDebug"),
+        "selection among tied debug-shaped variants must be deterministic \
+         (alphabetically-first variant name); got {:?}",
+        jars[0]
+    );
+}
+
+/// Same non-determinism risk applies to the non-debug fallback path: with no
+/// debug-shaped variant at all, more than one plain/custom-flavor variant
+/// can be present simultaneously, and the pick must still be stable.
+#[test]
+fn r_class_jar_deterministic_among_multiple_fallback_variants() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("settings.gradle.kts"),
+        "include(\":app\")\n",
+    )
+    .unwrap();
+    let module_dir = dir.path().join("app");
+    write_r_jar(
+        &module_dir,
+        "compile_and_runtime_r_class_jar",
+        "prod",
+        "processProdResources",
+    );
+    write_r_jar(
+        &module_dir,
+        "compile_and_runtime_r_class_jar",
+        "staging",
+        "processStagingResources",
+    );
+
+    let jars = detect_android_r_class_jars(dir.path());
+    assert_eq!(jars.len(), 1);
+    assert!(
+        jars[0].to_string_lossy().contains("prod")
+            && !jars[0].to_string_lossy().contains("staging"),
+        "selection among tied fallback variants must be deterministic \
+         (alphabetically-first variant name); got {:?}",
+        jars[0]
+    );
+}


### PR DESCRIPTION
## Summary
- `find_r_class_jar_for_module` (added in #305) picks one AAPT-generated `R.jar` variant per Android module by preferring a "debug"-shaped variant name, else the first found. When more than one variant name contains "debug" at once (a real, documented possibility with product flavors, e.g. `stagingDebug` and `prodDebug` both present under `build/intermediates/`), the previous code returned whichever one raw `std::fs::read_dir` happened to yield first — an order the stdlib explicitly leaves unspecified, and empirically NOT tied to insertion/creation order on this machine's filesystem.
- Fix: sort the candidate variant directories (and their task-output subdirectories) by name before selecting, so the same on-disk module tree always yields the same `R.jar` regardless of filesystem/platform/run-to-run enumeration order. Same fix applies to the non-debug fallback path when multiple non-debug variants exist.

## Test plan
- [x] Added `r_class_jar_deterministic_among_multiple_debug_shaped_variants` and `r_class_jar_deterministic_among_multiple_fallback_variants` to `src/workspace_json_tests.rs`, each creating two real tied-variant directories (`prodDebug`/`stagingDebug`, `prod`/`staging`) with plausible AGP task-output shapes.
- [x] Confirmed genuine RED against the pre-fix code on this machine: `/tmp` here is tmpfs, whose `read_dir` order is reverse-insertion, not creation order or name order (verified independently with `ls -U` on throwaway dirs). Writing `prodDebug` first / `stagingDebug` second causes tmpfs to hand back `stagingDebug` first, so the old "return on first debug-shaped match" code picked the wrong (non-deterministic) variant — both new tests failed reproducibly pre-fix.
- [x] Post-fix: both tests pass reliably across 10 repeated runs.
- [x] `cargo test` (full suite): 1888 passed, 0 failed, 3 ignored.
- [x] `cargo fmt` clean, `cargo clippy --tests -- -D warnings` clean.
- [x] `cargo build --bin kmp-lsp` + `resolution-accuracy` sanity pass against `~/Work/Moneta/android/core/commonui` (a real module with a built `R.jar`): `R.drawable`/`R.string` still resolve correctly to `compile_r_class_jar/debug/generateDebugRFile/R.jar`, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXHAR25HwqxCjg33D38NTV