### PR TITLE
fix(hover): decline rather than guess on an ambiguous qualified reference

### DIFF
--- a/src/features/hover.rs
+++ b/src/features/hover.rs
@@ -5,7 +5,9 @@
 //! `build_subst_map`) depends on `IndexRead`, and `WorkspaceRead: IndexRead`.
 //! Migrating these to the new traits is tracked as part of F5 cleanup.
 
-use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Position, Url};
+use tower_lsp::lsp_types::{
+    Hover, HoverContents, Location, MarkupContent, MarkupKind, Position, Url,
+};
 
 use crate::backend::cursor::CursorContext;
 use crate::backend::format::{format_contextual_hover, format_symbol_hover};
@@ -82,21 +84,16 @@ fn contextual_receiver_hover<W: WorkspaceRead>(
 ) -> Option<Hover> {
     let receiver_type = ctx.contextual.as_ref()?;
     ctx.qualifier.as_ref()?;
-    let mut locations = resolve_with_receiver_fallback(workspace, &ctx.word, receiver_type, uri);
+    let locations = resolve_with_receiver_fallback(workspace, &ctx.word, receiver_type, uri);
     // Same self-shadow reasoning as goto-definition's identical branch (see
-    // `CursorContext::contextual`'s doc). Filtering to empty returns `None`
-    // rather than the wrong candidate — `compute_hover` then falls through to
-    // `regular_symbol_hover`'s string-qualifier path, which never consults
-    // the extension-in-scope registry that causes the wrong match.
-    if let Some(indexer) = workspace.as_indexer() {
-        if let Some(shape) =
-            crate::features::definition::call_shape_at_callee(indexer, uri, position)
-        {
-            locations =
-                crate::indexer::shape_filter_locations(indexer, shape, locations).resolved();
-        }
-    }
-    let location = locations.into_iter().next()?;
+    // `CursorContext::contextual`'s doc): arity-filter by a derivable call
+    // shape first. And — same "don't guess" reasoning as
+    // `qualified_member_hover_markdown` — decline (`None`) rather than an
+    // arbitrary pick when more than one candidate still remains, shape
+    // filtering or no. Either way, `compute_hover` then falls through to
+    // `regular_symbol_hover`'s string-qualifier path.
+    let shape_ctx = call_shape_ctx(workspace, uri, position);
+    let location = pick_unambiguous_location(shape_ctx, locations)?;
     let info = enrich_at_location(
         workspace,
         &location,
@@ -105,6 +102,46 @@ fn contextual_receiver_hover<W: WorkspaceRead>(
         &ResolveOptions::hover(),
     )?;
     Some(make_markdown_hover(format_symbol_hover(&info, uri.path())))
+}
+
+/// The call shape of the call whose callee sits under `position`, paired with
+/// the `Indexer` needed to apply it — `None` when there's no indexer (test
+/// stubs) or the cursor isn't precisely on a call's callee (see
+/// `call_shape_at_callee`).
+fn call_shape_ctx<'a, W: WorkspaceRead>(
+    workspace: &'a W,
+    uri: &Url,
+    position: Position,
+) -> Option<(&'a crate::indexer::Indexer, crate::indexer::CallShape)> {
+    let indexer = workspace.as_indexer()?;
+    let shape = crate::features::definition::call_shape_at_callee(indexer, uri, position)?;
+    Some((indexer, shape))
+}
+
+/// Reduce `locations` — candidates for a possibly-overloaded qualified
+/// reference — to a single unambiguous one, or decline (`None`) instead of
+/// guessing.
+///
+/// When `shape_ctx` is `Some` (the cursor sits on an actual call's callee),
+/// candidates are first arity-filtered via `shape_filter_locations` — the
+/// same filtering `resolve_identity_with_io` applies for goto-definition.
+/// Whether or not a shape was available, more than one candidate surviving
+/// means the reference is genuinely ambiguous (a bare reference to an
+/// overloaded name, or two overloads sharing an arity) — showing no hover is
+/// more honest than picking an arbitrary overload's docs. See PR #304, which
+/// stopped `resolve_qualified`'s member-lookup step from collapsing overloads
+/// to one arbitrary candidate before this point ever got a look at them.
+fn pick_unambiguous_location(
+    shape_ctx: Option<(&crate::indexer::Indexer, crate::indexer::CallShape)>,
+    mut locations: Vec<Location>,
+) -> Option<Location> {
+    if let Some((indexer, shape)) = shape_ctx {
+        locations = crate::indexer::shape_filter_locations(indexer, shape, locations).resolved();
+    }
+    if locations.len() > 1 {
+        return None;
+    }
+    locations.into_iter().next()
 }
 
 fn regular_symbol_hover<W: WorkspaceRead>(
@@ -118,18 +155,49 @@ fn regular_symbol_hover<W: WorkspaceRead>(
             return hover;
         }
     }
-    let markdown = resolve_hover_markdown(
-        workspace,
-        &ctx.word,
-        ctx.qualifier.as_deref(),
-        uri,
-        position.line,
-    )
-    .or_else(|| crate::stdlib::hover(&ctx.word));
+    let markdown = qualified_member_hover_markdown(workspace, ctx, uri, position)
+        .or_else(|| crate::stdlib::hover(&ctx.word));
     if let Some(markdown) = markdown {
         return Some(make_markdown_hover(markdown));
     }
     fallback_local_binding_hover(workspace, ctx, uri, position.line)
+}
+
+/// Resolve `ctx.word` (optionally behind `ctx.qualifier`) to hover markdown.
+///
+/// An unqualified reference is unaffected by PR #304's overload fan-out
+/// (`resolve_qualified`, where that fan-out happens, is only ever reached
+/// with a qualifier) and delegates straight to `resolve_hover_markdown`.
+///
+/// A qualified reference (`Type.member`, e.g. a Java class's overloaded
+/// static method) resolves ambiguity-aware instead of going through
+/// `resolve_hover_markdown` — that path's `locate_symbol` picks
+/// `.into_iter().next()` with no shape-awareness at all, so it silently shows
+/// one arbitrary overload's docs post-#304. `contextual_receiver_hover`
+/// already covers the sibling case where `ctx.contextual` narrows a receiver
+/// type (smart-cast, lambda params, `it`/`this`); this covers the plain
+/// string-qualifier lookup that function never reaches (`ctx.contextual` is
+/// `None` for a `Type.member` reference on a class name, not a variable).
+fn qualified_member_hover_markdown<W: WorkspaceRead>(
+    workspace: &W,
+    ctx: &CursorContext,
+    uri: &Url,
+    position: Position,
+) -> Option<String> {
+    let Some(qualifier) = ctx.qualifier.as_deref() else {
+        return resolve_hover_markdown(workspace, &ctx.word, None, uri, position.line);
+    };
+    let locations = workspace.find_definition_qualified(&ctx.word, Some(qualifier), uri);
+    let shape_ctx = call_shape_ctx(workspace, uri, position);
+    let location = pick_unambiguous_location(shape_ctx, locations)?;
+    let info = enrich_at_location(
+        workspace,
+        &location,
+        &ctx.word,
+        hover_substitution_context(uri, position.line),
+        &ResolveOptions::hover(),
+    )?;
+    Some(format_symbol_hover(&info, uri.path()))
 }
 
 /// `Some(hover)` when the cursor sits on a call's callee and the call's own

--- a/src/features/hover_tests.rs
+++ b/src/features/hover_tests.rs
@@ -316,3 +316,90 @@ class Reducer {
          sibling field found by proximity to Event's own declaration, got: {text:?}"
     );
 }
+
+/// Real corpus case that motivated PR #304 (Moneta's `FormatUtil.java`),
+/// reached through hover's own resolution pipeline instead of goto-def's.
+/// `resolve_qualified` now hands every same-named overload to its caller
+/// (`find_all_names_scoped_to_container`, see PR #304), in `file_data.symbols`
+/// order — reverse source order for Java, so the 3-arg (last-declared)
+/// overload sorts first. Before this fix, `locate_symbol`
+/// (`src/indexer/resolution.rs`) picked `.into_iter().next()` with no
+/// shape-awareness at all, so hovering the CALL to the 2-arg overload always
+/// showed the 3-arg overload's own signature instead.
+#[test]
+fn hover_on_qualified_call_shows_the_called_overload_not_an_arbitrary_one() {
+    let idx = Indexer::new();
+    let java_uri = Url::parse("file:///app/FormatUtil.java").unwrap();
+    idx.index_content(
+        &java_uri,
+        concat!(
+            "package app;\n",
+            "public class FormatUtil {\n",
+            "    public static String formatAmount(java.math.BigDecimal a) { return null; }\n",
+            "    public static String formatAmount(java.math.BigDecimal a, int b) { return null; }\n",
+            "    public static String formatAmount(java.math.BigDecimal a, int b, boolean c) { return null; }\n",
+            "}\n",
+        ),
+    );
+
+    let uri = Url::parse("file:///app/Caller.kt").unwrap();
+    let src = "package app\n\
+               class Caller {\n\
+                   fun run(amount: java.math.BigDecimal) {\n\
+                       FormatUtil.formatAmount(amount, 2)\n\
+                   }\n\
+               }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+    let col = src.lines().nth(3).unwrap().find("formatAmount").unwrap() as u32;
+    let position = Position::new(3, col);
+    let ctx = CursorContext::build(&idx, &uri, position).unwrap();
+
+    let hover = compute_hover(&idx, &ctx, &uri, position).expect("expected a hover result");
+    let text = hover_text(&hover);
+    assert!(
+        text.contains("int b") && !text.contains("boolean c"),
+        "hovering the 2-arg call must show the 2-arg overload's own \
+         signature, not the 3-arg (or 1-arg) overload's, got: {text:?}"
+    );
+}
+
+/// The sibling gap left open by PR #304: a qualified reference with NO
+/// derivable call shape (here, a bare property-style reference — no call
+/// parens at all) that still resolves to more than one overload candidate
+/// must decline rather than silently showing an arbitrary overload's docs.
+#[test]
+fn hover_on_ambiguous_qualified_reference_without_call_declines_rather_than_guessing() {
+    let idx = Indexer::new();
+    let java_uri = Url::parse("file:///app/FormatUtil.java").unwrap();
+    idx.index_content(
+        &java_uri,
+        concat!(
+            "package app;\n",
+            "public class FormatUtil {\n",
+            "    public static String formatAmount(java.math.BigDecimal a) { return null; }\n",
+            "    public static String formatAmount(java.math.BigDecimal a, int b) { return null; }\n",
+            "    public static String formatAmount(java.math.BigDecimal a, int b, boolean c) { return null; }\n",
+            "}\n",
+        ),
+    );
+
+    let uri = Url::parse("file:///app/Caller.kt").unwrap();
+    let src = "package app\n\
+               class Caller {\n\
+                   val ref = FormatUtil.formatAmount\n\
+               }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+    let col = src.lines().nth(2).unwrap().find("formatAmount").unwrap() as u32;
+    let position = Position::new(2, col);
+    let ctx = CursorContext::build(&idx, &uri, position).unwrap();
+
+    let hover = compute_hover(&idx, &ctx, &uri, position);
+    assert!(
+        hover.is_none(),
+        "an ambiguous qualified reference with no derivable call shape must \
+         decline rather than showing an arbitrary overload's docs, got: {:?}",
+        hover.map(|h| hover_text(&h))
+    );
+}


### PR DESCRIPTION
## Summary

PR #304 made `resolve_qualified`'s member-lookup step return every same-named overload when a qualified member name collides, instead of collapsing to one arbitrary candidate — fixing goto-definition (`Vec<Location>`, client picks) and rename (which refuses when `definitions.len() != 1`). Hover's own resolution pipeline was never updated to be ambiguity-aware, so it kept silently showing one arbitrary overload's docs — in `file_data.symbols` order, i.e. the highest-arity/last-declared Java overload — regardless of which overload was actually referenced.

Two gaps, both closed here:

- `src/indexer/resolution.rs`'s `locate_symbol` (reached via `resolve_symbol_info` → `resolve_hover_markdown`) had **no** shape-awareness at all: plain `.into_iter().next()`.
- `contextual_receiver_hover` (`src/features/hover.rs`) had **partial** shape-awareness: it only arity-filtered when the cursor sat on an actual call's callee, then still picked `.into_iter().next()` unconditionally — so a no-call reference (e.g. hovering a property/field access) that resolved to multiple candidates was picked arbitrarily too.

## Design

- New `qualified_member_hover_markdown` replaces the `resolve_hover_markdown` call in `regular_symbol_hover`'s qualified-reference branch (`Type.member`, e.g. a Java class's overloaded static method). It resolves candidates via `find_definition_qualified`, then:
  - when the cursor sits on a call's callee (a derivable `CallShape`), arity-filters via `shape_filter_locations` — the same filtering goto-definition's `resolve_identity_with_io` already applies;
  - **either way**, declines (`None`) instead of guessing when more than one candidate remains — showing no hover is more honest than confidently showing the wrong overload's signature.
- `contextual_receiver_hover` now shares that same `pick_unambiguous_location` helper, closing its own no-call-shape gap.
- The unqualified-reference path (`resolve_hover_markdown` called with no qualifier) is untouched — `resolve_qualified`'s overload fan-out only ever happens when a qualifier is present, so bare-name hover was never affected by #304's change in the first place.

## RED test evidence

Reverting the `hover.rs` change and rerunning the two new tests reproduces the bug exactly, against a Java class with 3 `formatAmount` overloads (1/2/3-arg, mirroring PR #304's own `FormatUtil.java` corpus case):

```
thread '...hover_on_ambiguous_qualified_reference_without_call_declines_rather_than_guessing' panicked:
an ambiguous qualified reference with no derivable call shape must decline rather than showing an
arbitrary overload's docs, got: Some("```kotlin\npublic static String formatAmount(java.math.BigDecimal a, int b, boolean c) { return null; }\n```\n\n*in `app.FormatUtil`*")

thread '...hover_on_qualified_call_shows_the_called_overload_not_an_arbitrary_one' panicked:
hovering the 2-arg call must show the 2-arg overload's own signature, not the 3-arg (or 1-arg)
overload's, got: "```kotlin\npublic static String formatAmount(java.math.BigDecimal a, int b, boolean c) { return null; }\n```\n\n*in `app.FormatUtil`*"
```

Both a 2-arg *call site* and a no-call *bare reference* showed the 3-arg overload's signature — exactly the highest-arity/last-declared bug PR #304 describes, just reached through hover's own `.next()` instead of `find_name_scoped_to_container`'s `.find()`.

## Test plan

- [x] New tests `hover_on_qualified_call_shows_the_called_overload_not_an_arbitrary_one` and `hover_on_ambiguous_qualified_reference_without_call_declines_rather_than_guessing`, RED-verified (see above)
- [x] `cargo test` — 1888 passed, 0 failed, 3 ignored
- [x] `cargo fmt --check`, `cargo clippy --tests -- -D warnings` — clean
- [x] Manual CLI check skipped: the `kmp-lsp hover` CLI subcommand exercises a different, declaration-only lookup (`enrich_at_line`), not `compute_hover` — the exact function `src/backend/handlers.rs` calls for real LSP `textDocument/hover` requests and the one this fix and its tests target directly, so the automated tests are the representative verification here.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01CXHAR25HwqxCjg33D38NTV