### PR TITLE
fix(resolve): thread module-scoped narrowing into import-package tie-break

### DIFF
--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -533,7 +533,19 @@ const DENYLISTED_PACKAGE_PREFIXES: &[&str] = &["com.android.internal."];
 /// merely importing a sibling from the right package, not the ambiguous
 /// name itself) — module-scoped narrowing, when its data is available, is
 /// strictly more precise (it's the *real* Gradle dependency graph, not an
-/// inference from unrelated imports). `origin_uri` is the real file to
+/// inference from unrelated imports).
+///
+/// Crucially, module-scoped narrowing's authority carries forward even when
+/// it doesn't land on a unique winner by itself: when real dependency data
+/// proves some candidates are real dependencies of the calling module and
+/// rules others out, `import_package_tie_break` is only ever handed that
+/// *proven-possible* subset, never the original, unnarrowed set — a
+/// candidate module-scoping has already disproven (its JAR isn't a
+/// dependency of the module at all) must never be resurrected by a weaker,
+/// merely-inferred signal like a coincidental sibling-import-package match.
+/// The original, unnarrowed set is only ever handed to `import_package_tie_break`
+/// when module-scoping had no dependency data to narrow with in the first
+/// place (see [`ModuleScopedOutcome`]). `origin_uri` is the real file to
 /// resolve an owning module/import-list from — the hierarchy walk's own
 /// starting file for `HierarchyAmbiguitySafe`, or simply the caller's own
 /// `from_uri` for `IndexOnly`/`Full`.
@@ -558,11 +570,43 @@ fn ambiguity_safe_tail_with_denylist(
     if filtered.len() < 2 {
         return vec![];
     }
-    let module_scoped = module_scoped_tie_break(indexer, origin_uri, filtered.clone());
-    if !module_scoped.is_empty() {
-        return module_scoped;
+    match module_scoped_tie_break(indexer, origin_uri, filtered.clone()) {
+        ModuleScopedOutcome::Narrowed(narrowed) if narrowed.len() == 1 => narrowed,
+        ModuleScopedOutcome::Narrowed(narrowed) => {
+            import_package_tie_break(indexer, origin_uri, narrowed)
+        }
+        ModuleScopedOutcome::NoData | ModuleScopedOutcome::NoDependenciesSurvived => {
+            import_package_tie_break(indexer, origin_uri, filtered)
+        }
     }
-    import_package_tie_break(indexer, origin_uri, filtered)
+}
+
+/// Outcome of [`module_scoped_tie_break`] consulting real per-module Gradle
+/// dependency data for an ambiguous candidate set — three real, distinct
+/// cases the caller must not collapse into a single "declined" bucket (see
+/// [`ambiguity_safe_tail_with_denylist`]'s doc comment for why the
+/// distinction matters).
+enum ModuleScopedOutcome {
+    /// No `workspace.json` module-dependency data is available at all for
+    /// `origin_uri`'s owning module (`owning_module_dependencies` returned
+    /// `None`) — module-scoping has nothing to say, so the next tie-break
+    /// must fall back to the original, unnarrowed candidate set.
+    NoData,
+    /// Dependency data WAS available, but none of the candidates are real
+    /// dependencies of the calling module. Treated the same as `NoData`
+    /// rather than as a proof that every candidate is wrong: a workspace's
+    /// dependency data can be incomplete (see `owning_module_dependencies`'s
+    /// own doc comment), so eliminating every candidate is more likely a
+    /// data gap than a genuine "none of these are possible" result — the
+    /// next tie-break falls back to the original, unnarrowed set too.
+    NoDependenciesSurvived,
+    /// Dependency data narrowed the candidates to a real, positive,
+    /// non-empty subset — every remaining candidate is a proven dependency
+    /// of the calling module. Length 1 is a unique winner the caller returns
+    /// immediately; length > 1 is still ambiguous, but the next tie-break
+    /// must only ever choose among THESE candidates, never a candidate this
+    /// narrowing already ruled out.
+    Narrowed(Vec<Location>),
 }
 
 /// Second tie-break for [`ambiguity_safe_tail_with_denylist`]: when the
@@ -570,17 +614,16 @@ fn ambiguity_safe_tail_with_denylist(
 /// hierarchy walk's real starting file's own module's real Gradle dependency
 /// set (see `workspace_json::load_module_dependencies`) — a candidate
 /// survives only if its own JAR's `(group, artifact, version)` is a
-/// dependency of the module `hierarchy_walk_origin_uri` belongs to. Declines
-/// (returns empty), exactly as before this narrowing existed, whenever no
-/// per-module data is available for that module or the narrowing still
-/// leaves more than one candidate.
+/// dependency of the module `hierarchy_walk_origin_uri` belongs to. See
+/// [`ModuleScopedOutcome`] for the three distinct outcomes this can produce
+/// and how the caller must treat each one.
 fn module_scoped_tie_break(
     indexer: &Indexer,
     hierarchy_walk_origin_uri: &Url,
     locations: Vec<Location>,
-) -> Vec<Location> {
+) -> ModuleScopedOutcome {
     let Some(dependencies) = owning_module_dependencies(indexer, hierarchy_walk_origin_uri) else {
-        return vec![];
+        return ModuleScopedOutcome::NoData;
     };
     let narrowed: Vec<Location> = locations
         .into_iter()
@@ -588,10 +631,10 @@ fn module_scoped_tie_break(
             candidate_gradle_meta(location).is_some_and(|meta| dependencies.contains(&meta))
         })
         .collect();
-    if narrowed.len() == 1 {
-        narrowed
+    if narrowed.is_empty() {
+        ModuleScopedOutcome::NoDependenciesSurvived
     } else {
-        vec![]
+        ModuleScopedOutcome::Narrowed(narrowed)
     }
 }
 

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -363,6 +363,199 @@ fn resolve_symbol_index_only_tail_applies_the_denylist_tie_break() {
     );
 }
 
+/// `module_scoped_tie_break` (the second tie-break in
+/// `ambiguity_safe_tail_with_denylist`) only ever returned a non-empty
+/// result when its own real-Gradle-dependency-data narrowing landed on
+/// exactly one candidate — when it narrowed a 3-way ambiguity down to a real
+/// 2-candidate subset ({A, C}, both proven dependencies of the calling
+/// module, with B proven NOT to be one), that positive narrowing was
+/// discarded entirely and the THIRD tie-break (`import_package_tie_break`)
+/// was re-run against the ORIGINAL, unnarrowed 3-candidate set. That let
+/// `import_package_tie_break` pick B — a candidate `module_scoped_tie_break`
+/// had already proven structurally impossible (its JAR isn't even a
+/// dependency of the calling module) — purely because the calling file
+/// happens to import an unrelated sibling symbol from B's own package. A
+/// structurally impossible answer must never be chosen over either
+/// declining or narrowing further among the module-scoped survivors.
+#[test]
+fn module_scoped_narrowing_survives_into_import_package_tie_break() {
+    let idx = Indexer::new();
+    let a_uri = gradle_cache_jar_uri("com.example.a", "a-lib", "1.0.0");
+    let b_uri = gradle_cache_jar_uri("com.example.b", "b-lib", "1.0.0");
+    let c_uri = gradle_cache_jar_uri("com.example.c", "c-lib", "1.0.0");
+    idx.jar_definitions.insert(
+        "Foo".to_owned(),
+        vec![
+            tower_lsp::lsp_types::Location {
+                uri: a_uri.clone(),
+                range: Default::default(),
+            },
+            tower_lsp::lsp_types::Location {
+                uri: b_uri.clone(),
+                range: Default::default(),
+            },
+            tower_lsp::lsp_types::Location {
+                uri: c_uri.clone(),
+                range: Default::default(),
+            },
+        ],
+    );
+    idx.jar_files.insert(
+        a_uri.to_string(),
+        std::sync::Arc::new(crate::types::FileData {
+            package: Some("com.example.alib".to_owned()),
+            ..Default::default()
+        }),
+    );
+    idx.jar_files.insert(
+        b_uri.to_string(),
+        std::sync::Arc::new(crate::types::FileData {
+            package: Some("com.example.blib".to_owned()),
+            ..Default::default()
+        }),
+    );
+    idx.jar_files.insert(
+        c_uri.to_string(),
+        std::sync::Arc::new(crate::types::FileData {
+            package: Some("com.example.clib".to_owned()),
+            ..Default::default()
+        }),
+    );
+
+    // Real Gradle dependency data for the calling file's own module: {A, C}
+    // are real dependencies, B is NOT.
+    let mut dependencies_by_content_root: std::collections::HashMap<
+        std::path::PathBuf,
+        std::collections::HashSet<crate::cli::extract_sources::GradleMeta>,
+    > = std::collections::HashMap::new();
+    dependencies_by_content_root.insert(
+        std::path::PathBuf::from("/test"),
+        std::collections::HashSet::from([
+            crate::cli::extract_sources::GradleMeta {
+                group: "com.example.a".to_owned(),
+                artifact: "a-lib".to_owned(),
+                version: "1.0.0".to_owned(),
+            },
+            crate::cli::extract_sources::GradleMeta {
+                group: "com.example.c".to_owned(),
+                artifact: "c-lib".to_owned(),
+                version: "1.0.0".to_owned(),
+            },
+        ]),
+    );
+    *idx.module_dependencies.write().unwrap() = dependencies_by_content_root;
+
+    // The calling file imports an unrelated sibling symbol from B's own
+    // package — the only signal `import_package_tie_break` has to go on —
+    // but never depends on B itself per the real Gradle data above.
+    let host_uri = uri("/Host.kt");
+    idx.index_content(
+        &host_uri,
+        "package com.pkg\nimport com.example.blib.SomethingElse\n",
+    );
+
+    let locs = resolve_symbol_index_only(&idx, "Foo", None, &host_uri);
+    assert!(
+        !locs.iter().any(|l| l.uri == b_uri),
+        "must never resolve to B: module-scoped narrowing already proved \
+         B is not a real dependency of the calling module, so \
+         import_package_tie_break must not be allowed to pick it back up \
+         from the original, unnarrowed candidate set, got {locs:?}"
+    );
+}
+
+/// Companion to the test above: when module-scoped narrowing leaves a real
+/// positive subset ({A, C}) and `import_package_tie_break`, run against THAT
+/// narrowed subset (not the original 3-candidate set), can itself narrow
+/// further to a unique winner, the fixed tail must actually find it — not
+/// just avoid the wrong answer, but reach the right one.
+#[test]
+fn module_scoped_narrowing_lets_import_package_tie_break_reach_a_correct_unique_answer() {
+    let idx = Indexer::new();
+    let a_uri = gradle_cache_jar_uri("com.example.a", "a-lib", "1.0.0");
+    let b_uri = gradle_cache_jar_uri("com.example.b", "b-lib", "1.0.0");
+    let c_uri = gradle_cache_jar_uri("com.example.c", "c-lib", "1.0.0");
+    idx.jar_definitions.insert(
+        "Foo".to_owned(),
+        vec![
+            tower_lsp::lsp_types::Location {
+                uri: a_uri.clone(),
+                range: Default::default(),
+            },
+            tower_lsp::lsp_types::Location {
+                uri: b_uri.clone(),
+                range: Default::default(),
+            },
+            tower_lsp::lsp_types::Location {
+                uri: c_uri.clone(),
+                range: Default::default(),
+            },
+        ],
+    );
+    idx.jar_files.insert(
+        a_uri.to_string(),
+        std::sync::Arc::new(crate::types::FileData {
+            package: Some("com.example.alib".to_owned()),
+            ..Default::default()
+        }),
+    );
+    idx.jar_files.insert(
+        b_uri.to_string(),
+        std::sync::Arc::new(crate::types::FileData {
+            package: Some("com.example.blib".to_owned()),
+            ..Default::default()
+        }),
+    );
+    idx.jar_files.insert(
+        c_uri.to_string(),
+        std::sync::Arc::new(crate::types::FileData {
+            package: Some("com.example.clib".to_owned()),
+            ..Default::default()
+        }),
+    );
+
+    let mut dependencies_by_content_root: std::collections::HashMap<
+        std::path::PathBuf,
+        std::collections::HashSet<crate::cli::extract_sources::GradleMeta>,
+    > = std::collections::HashMap::new();
+    dependencies_by_content_root.insert(
+        std::path::PathBuf::from("/test"),
+        std::collections::HashSet::from([
+            crate::cli::extract_sources::GradleMeta {
+                group: "com.example.a".to_owned(),
+                artifact: "a-lib".to_owned(),
+                version: "1.0.0".to_owned(),
+            },
+            crate::cli::extract_sources::GradleMeta {
+                group: "com.example.c".to_owned(),
+                artifact: "c-lib".to_owned(),
+                version: "1.0.0".to_owned(),
+            },
+        ]),
+    );
+    *idx.module_dependencies.write().unwrap() = dependencies_by_content_root;
+
+    // Imports a sibling symbol from C's own package only (not A's, not B's)
+    // -- among the module-scoped survivors {A, C}, only C matches.
+    let host_uri = uri("/Host.kt");
+    idx.index_content(
+        &host_uri,
+        "package com.pkg\nimport com.example.clib.SomethingElse\n",
+    );
+
+    let locs = resolve_symbol_index_only(&idx, "Foo", None, &host_uri);
+    assert_eq!(
+        locs,
+        vec![tower_lsp::lsp_types::Location {
+            uri: c_uri,
+            range: Default::default(),
+        }],
+        "expected import_package_tie_break, run against the module-scoped \
+         narrowed subset {{A, C}}, to reach the unique correct answer C, \
+         got {locs:?}"
+    );
+}
+
 /// Same guarantee as `resolve_symbol_index_only_never_spawns_rg_or_fd`, but
 /// for a qualified lookup (`resolve_qualified`'s uppercase branch) — Copilot
 /// review on PR #274: `resolve_qualified` resolved its qualifier root via the


### PR DESCRIPTION
## Root cause

`ambiguity_safe_tail_with_denylist`'s second tie-break, `module_scoped_tie_break`, narrows an ambiguous candidate set using the calling file's own module's real Gradle dependency data (from `workspace.json`) — but it only ever *returned* that narrowing when it landed on exactly one candidate. When real dependency data proved e.g. 1 of 3 same-named JAR candidates (`B`) is NOT a dependency of the calling module, but still left 2 (`A`, `C`) ambiguous, the narrowing was discarded entirely (`vec![]`), and the caller fell through to the THIRD tie-break, `import_package_tie_break`, called with the **original, unnarrowed** 3-candidate set.

That let `import_package_tie_break` pick `B` back up — a candidate already proven structurally impossible (its JAR isn't even a real dependency of the calling module) — purely because the calling file happens to import an unrelated sibling symbol from `B`'s own package. A structurally impossible answer being chosen over declining, or over narrowing further among the module-scoped survivors.

## Fix

`module_scoped_tie_break` now returns a `ModuleScopedOutcome` enum with three distinct cases instead of collapsing everything into "empty or not":

- `NoData` — no `workspace.json` module-dependency data available at all for the calling module → fall back to the original, unnarrowed set (unchanged behavior).
- `NoDependenciesSurvived` — dependency data was available but narrowed to zero. Treated the same as `NoData` (falls back to the original set) rather than as proof every candidate is wrong: `workspace.json` dependency data can be incomplete, so eliminating every candidate is more likely a data gap than a genuine "none of these are possible" result.
- `Narrowed(subset)` — a real, positive, non-empty subset survived. Length 1 wins immediately (unchanged behavior). Length > 1 is now threaded into `import_package_tie_break` **as its input candidate set**, so the weaker signal (import-package inference) can only ever choose among candidates the stronger signal (real Gradle dependency graph) already proved possible — never a candidate it already ruled out.

The denylist-first → module-scoping-second → import-package-third authority ordering the existing code already established is preserved; only what gets *handed forward* when module-scoping narrows-but-doesn't-uniquify changes.

## Test evidence

Two new tests in `src/resolver/tests.rs` reproduce the exact 3-candidate scenario (same bare name `Foo` across JARs `A`/`B`/`C`, real `workspace.json` module-dependency data proving `{A, C}` are dependencies of the calling module and `B` is not, calling file importing an unrelated sibling symbol from `B`'s package):

- `module_scoped_narrowing_survives_into_import_package_tie_break` — **confirmed RED on unmodified `main`**: wrongly resolved to `B`:
  ```
  thread '...' panicked: must never resolve to B: ... got [Location { uri: Url { ... path: ".../com.example.b/b-lib/1.0.0/.../b-lib-1.0.0.jar" ... } }]
  ```
  Passes after the fix (empty/declined result, since `A` vs `C` can't be distinguished by import-package alone in this scenario).
- `module_scoped_narrowing_lets_import_package_tie_break_reach_a_correct_unique_answer` — companion test where the narrowed subset `{A, C}` *can* be further disambiguated by import-package (imports a sibling from `C`'s package only); asserts the fix reaches the correct unique answer `C`, not just "doesn't pick the wrong one."

Full `cargo test` (1888 lib tests + integration suites): **all pass, 0 failures**.
`cargo fmt` and `cargo clippy --tests -- -D warnings`: clean.

## Corpus measurement

Scoped before/after `resolution-accuracy` run on `~/Work/Moneta/android/core/common_screen`:

- before: member refs 6143 (78.8% recall), bare refs 59845 (45.2% recall), FilteredCandidate 479
- after: member refs 6110 (79.3% recall), bare refs 59878 (45.3% recall), FilteredCandidate 457

These deltas are **run-to-run measurement noise, not a real signal**: rerunning the identical *fixed* binary twice produced a similar-magnitude spread (member refs 6110 vs 6130, FilteredCandidate 457 vs 464). Moneta's own `workspace.json` was confirmed (via direct inspection) to contain only a `sourcePaths` key — no `libraries`/`dependencies` data — so `Indexer::module_dependencies` stays empty for this whole corpus and `module_scoped_tie_break` hits the `NoData` branch on every call, meaning **this fix's new code path is never exercised on Moneta at all**. Its value here is architectural/correctness, proven by the new unit tests, not measurable on this specific corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXHAR25HwqxCjg33D38NTV