### PR TITLE
fix(resolve): prefer Kotlin's own default-import packages when ambiguous

### DIFF
--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -520,35 +520,39 @@ const DENYLISTED_PACKAGE_PREFIXES: &[&str] = &["com.android.internal."];
 /// (general bare-name resolution — diagnostics, `resolve_qualified`'s
 /// qualifier-root lookup, etc.), and `Full`'s own equivalent tail (see
 /// `resolve_chain`'s step 5.4): a unique candidate wins outright; an
-/// ambiguous set gets three narrow tie-breaks in sequence — first
+/// ambiguous set gets four narrow tie-breaks in sequence — first
 /// [`DENYLISTED_PACKAGE_PREFIXES`] (unconditional, project-wide), then
 /// [`module_scoped_tie_break`] (real per-module Gradle dependency data, when
-/// `workspace.json` provides it), then [`import_package_tie_break`] (the
-/// calling file's own already-parsed import list, always available — no
-/// external data needed, unlike module-scoping) — before still declining
-/// unless one of them leaves exactly one candidate. See the
-/// real-workspace-json-schema design doc's §5 for why denylist-first is
-/// correct: it's unconditional and needs no loaded data. Import-package
-/// narrowing runs last because it's the weakest signal of the three (a file
-/// merely importing a sibling from the right package, not the ambiguous
-/// name itself) — module-scoped narrowing, when its data is available, is
-/// strictly more precise (it's the *real* Gradle dependency graph, not an
-/// inference from unrelated imports).
+/// `workspace.json` provides it), then [`default_kotlin_import_tie_break`]
+/// (Kotlin's own hardcoded default-import package set — a language fact, not
+/// project data), then [`import_package_tie_break`] (the calling file's own
+/// already-parsed import list, always available — no external data needed) —
+/// before still declining unless one of them leaves exactly one candidate.
+/// See the real-workspace-json-schema design doc's §5 for why denylist-first
+/// is correct: it's unconditional and needs no loaded data. The remaining
+/// three run in *decreasing* certainty: module-scoped narrowing is the real
+/// Gradle dependency graph (most precise, but only as available as
+/// `workspace.json`'s own data); Kotlin's default imports are a fixed
+/// language-level fact, always available, but only relevant when a candidate
+/// actually lives in one of those packages; import-package narrowing is the
+/// weakest — a file merely importing a *sibling* from the right package, not
+/// the ambiguous name itself, so it runs last.
 ///
-/// Crucially, module-scoped narrowing's authority carries forward even when
-/// it doesn't land on a unique winner by itself: when real dependency data
-/// proves some candidates are real dependencies of the calling module and
-/// rules others out, `import_package_tie_break` is only ever handed that
-/// *proven-possible* subset, never the original, unnarrowed set — a
-/// candidate module-scoping has already disproven (its JAR isn't a
-/// dependency of the module at all) must never be resurrected by a weaker,
-/// merely-inferred signal like a coincidental sibling-import-package match.
-/// The original, unnarrowed set is only ever handed to `import_package_tie_break`
-/// when module-scoping had no dependency data to narrow with in the first
-/// place (see [`ModuleScopedOutcome`]). `origin_uri` is the real file to
-/// resolve an owning module/import-list from — the hierarchy walk's own
-/// starting file for `HierarchyAmbiguitySafe`, or simply the caller's own
-/// `from_uri` for `IndexOnly`/`Full`.
+/// Crucially, each tie-break's authority carries forward even when it
+/// doesn't land on a unique winner by itself: when module-scoped narrowing
+/// (or default-import narrowing) proves some candidates more plausible than
+/// others without reaching uniqueness, the NEXT tie-break is only ever
+/// handed that narrowed subset, never the original, unnarrowed set — a
+/// candidate an earlier, stronger tie-break has already disproven (or simply
+/// left out) must never be resurrected by a later, weaker signal. The
+/// original, unnarrowed set only ever reaches a later tie-break when the
+/// earlier one had nothing to say at all (no data, for module-scoping; no
+/// candidate in a default-import package, for Kotlin's default imports —
+/// see [`ModuleScopedOutcome`] and [`default_kotlin_import_tie_break`]'s own
+/// doc). `origin_uri` is the real file to resolve an owning module/import
+/// list from — the hierarchy walk's own starting file for
+/// `HierarchyAmbiguitySafe`, or simply the caller's own `from_uri` for
+/// `IndexOnly`/`Full`.
 fn ambiguity_safe_tail_with_denylist(
     indexer: &Indexer,
     origin_uri: &Url,
@@ -570,14 +574,70 @@ fn ambiguity_safe_tail_with_denylist(
     if filtered.len() < 2 {
         return vec![];
     }
-    match module_scoped_tie_break(indexer, origin_uri, filtered.clone()) {
-        ModuleScopedOutcome::Narrowed(narrowed) if narrowed.len() == 1 => narrowed,
-        ModuleScopedOutcome::Narrowed(narrowed) => {
-            import_package_tie_break(indexer, origin_uri, narrowed)
-        }
-        ModuleScopedOutcome::NoData | ModuleScopedOutcome::NoDependenciesSurvived => {
-            import_package_tie_break(indexer, origin_uri, filtered)
-        }
+    let after_module_scope = match module_scoped_tie_break(indexer, origin_uri, filtered.clone()) {
+        ModuleScopedOutcome::Narrowed(narrowed) if narrowed.len() == 1 => return narrowed,
+        ModuleScopedOutcome::Narrowed(narrowed) => narrowed,
+        ModuleScopedOutcome::NoData | ModuleScopedOutcome::NoDependenciesSurvived => filtered,
+    };
+    let after_default_import = default_kotlin_import_tie_break(indexer, after_module_scope);
+    if after_default_import.len() == 1 {
+        return after_default_import;
+    }
+    import_package_tie_break(indexer, origin_uri, after_default_import)
+}
+
+/// Kotlin's own default-import package set: every one of these is available
+/// on every Kotlin/JVM file with no explicit `import` ever needed, by
+/// definition of the language (Kotlin reference, "Default imports"). A
+/// hardcoded LANGUAGE fact, not project data that could be stale or
+/// incomplete — safe to trust unconditionally, the same spirit as
+/// [`DENYLISTED_PACKAGE_PREFIXES`], just a preference instead of an
+/// exclusion.
+const KOTLIN_DEFAULT_IMPORT_PACKAGES: &[&str] = &[
+    "kotlin",
+    "kotlin.annotation",
+    "kotlin.collections",
+    "kotlin.comparisons",
+    "kotlin.io",
+    "kotlin.ranges",
+    "kotlin.sequences",
+    "kotlin.text",
+    "kotlin.jvm",
+    "java.lang",
+];
+
+/// Tie-break run between [`module_scoped_tie_break`] and
+/// [`import_package_tie_break`]: when one or more candidates live in a
+/// package Kotlin implicitly imports for every file (see
+/// [`KOTLIN_DEFAULT_IMPORT_PACKAGES`]), prefer those over any candidate that
+/// would need a real import — or a real receiver-typed member match, which
+/// the caller already tried and failed, or this tail would never run — to be
+/// reachable at all. Real, measured case: `apply`/`run` (Kotlin's own scope
+/// functions, `kotlin.apply`/`kotlin.run`) collide with hundreds of
+/// unrelated same-named JVM/Android members (`java.util.function.
+/// Function.apply`, `Runnable.run`, countless builder `.apply()` methods)
+/// across a real dependency graph — none of THOSE are ever reachable
+/// without an explicit import, so a default-imported candidate is always at
+/// least as plausible, and in this fallback's context (a bare-name retry
+/// after receiver-scoped lookup already failed) is virtually always the
+/// actually-intended target.
+///
+/// Only narrows, never fully declines: when no candidate is in a
+/// default-import package, this is a no-op and the original set passes
+/// through unchanged to the next tie-break.
+fn default_kotlin_import_tie_break(indexer: &Indexer, locations: Vec<Location>) -> Vec<Location> {
+    let narrowed: Vec<Location> = locations
+        .iter()
+        .filter(|location| {
+            location_package(indexer, location)
+                .is_some_and(|pkg| KOTLIN_DEFAULT_IMPORT_PACKAGES.contains(&pkg.as_str()))
+        })
+        .cloned()
+        .collect();
+    if narrowed.is_empty() {
+        locations
+    } else {
+        narrowed
     }
 }
 

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -6015,7 +6015,7 @@ fn find_definition_qualified_falls_back_to_bare_lookup_for_scope_functions() {
 /// (Moneta's own real corpus state — confirmed no `libraries`/`dependencies`
 /// section), and no explicit import of anything relevant at all.
 #[test]
-fn find_definition_qualified_prefers_kotlin_default_import_when_ambiguous_and_unimported() {
+fn find_definition_qualified_prefers_kotlin_default_import_over_unimported_decoy() {
     use crate::types::FileData;
     use std::sync::Arc;
 

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -556,6 +556,99 @@ fn module_scoped_narrowing_lets_import_package_tie_break_reach_a_correct_unique_
     );
 }
 
+/// Companion to the two tests above, for the NEW tie-break inserted between
+/// them: when module-scoped narrowing already excludes a candidate that
+/// happens to live in a Kotlin default-import package (an edge case — real
+/// dependency data proves it's not actually a dependency of this module,
+/// even though its package would otherwise make it the "obviously right"
+/// pick), `default_kotlin_import_tie_break` must not resurrect it from the
+/// original, unnarrowed set — same discipline as `import_package_tie_break`
+/// already has to respect.
+#[test]
+fn module_scoped_narrowing_survives_into_default_kotlin_import_tie_break() {
+    let idx = Indexer::new();
+    let a_uri = gradle_cache_jar_uri("com.example.a", "a-lib", "1.0.0");
+    let b_uri = gradle_cache_jar_uri("com.example.b", "b-lib", "1.0.0");
+    let c_uri = gradle_cache_jar_uri("com.example.c", "c-lib", "1.0.0");
+    idx.jar_definitions.insert(
+        "Foo".to_owned(),
+        vec![
+            tower_lsp::lsp_types::Location {
+                uri: a_uri.clone(),
+                range: Default::default(),
+            },
+            tower_lsp::lsp_types::Location {
+                uri: b_uri.clone(),
+                range: Default::default(),
+            },
+            tower_lsp::lsp_types::Location {
+                uri: c_uri.clone(),
+                range: Default::default(),
+            },
+        ],
+    );
+    // A lives in a real Kotlin default-import package — normally the
+    // strongest possible signal — but real dependency data below proves A
+    // is NOT a dependency of the calling module at all.
+    idx.jar_files.insert(
+        a_uri.to_string(),
+        std::sync::Arc::new(crate::types::FileData {
+            package: Some("kotlin".to_owned()),
+            ..Default::default()
+        }),
+    );
+    idx.jar_files.insert(
+        b_uri.to_string(),
+        std::sync::Arc::new(crate::types::FileData {
+            package: Some("com.example.blib".to_owned()),
+            ..Default::default()
+        }),
+    );
+    idx.jar_files.insert(
+        c_uri.to_string(),
+        std::sync::Arc::new(crate::types::FileData {
+            package: Some("com.example.clib".to_owned()),
+            ..Default::default()
+        }),
+    );
+
+    // Real Gradle dependency data for the calling file's own module: {B, C}
+    // are real dependencies, A is NOT.
+    let mut dependencies_by_content_root: std::collections::HashMap<
+        std::path::PathBuf,
+        std::collections::HashSet<crate::cli::extract_sources::GradleMeta>,
+    > = std::collections::HashMap::new();
+    dependencies_by_content_root.insert(
+        std::path::PathBuf::from("/test"),
+        std::collections::HashSet::from([
+            crate::cli::extract_sources::GradleMeta {
+                group: "com.example.b".to_owned(),
+                artifact: "b-lib".to_owned(),
+                version: "1.0.0".to_owned(),
+            },
+            crate::cli::extract_sources::GradleMeta {
+                group: "com.example.c".to_owned(),
+                artifact: "c-lib".to_owned(),
+                version: "1.0.0".to_owned(),
+            },
+        ]),
+    );
+    *idx.module_dependencies.write().unwrap() = dependencies_by_content_root;
+
+    let host_uri = uri("/Host.kt");
+    idx.index_content(&host_uri, "package com.pkg\n");
+
+    let locs = resolve_symbol_index_only(&idx, "Foo", None, &host_uri);
+    assert!(
+        !locs.iter().any(|l| l.uri == a_uri),
+        "must never resolve to A: module-scoped narrowing already proved \
+         A is not a real dependency of the calling module, so \
+         default_kotlin_import_tie_break must not be allowed to pick it \
+         back up just because its package is a Kotlin default import, \
+         got {locs:?}"
+    );
+}
+
 /// Same guarantee as `resolve_symbol_index_only_never_spawns_rg_or_fd`, but
 /// for a qualified lookup (`resolve_qualified`'s uppercase branch) — Copilot
 /// review on PR #274: `resolve_qualified` resolved its qualifier root via the
@@ -5905,6 +5998,84 @@ fn find_definition_qualified_falls_back_to_bare_lookup_for_scope_functions() {
         locs.iter().any(|l| l.uri.as_str() == jar_uri),
         "receiver-typed `apply` must fall back to the bare stdlib declaration when \
          the receiver type has no member named `apply`; got {:?}",
+        locs.iter().map(|l| l.uri.as_str()).collect::<Vec<_>>()
+    );
+}
+
+/// Real, measured Moneta collision: `apply`/`run` (Kotlin's own scope
+/// functions) collide with hundreds of unrelated same-named JVM/Android
+/// methods across a real dependency graph (`java.util.function.Function
+/// .apply`, `Runnable.run`, countless builder `.apply()` methods) — none of
+/// which are ever reachable without an explicit import, unlike `kotlin.apply`
+/// which needs none (Kotlin's own default-import list). Unlike the sibling
+/// test above (which explicitly writes `import kotlin.apply` — not
+/// representative of real code, which almost never spells out an import for
+/// an implicitly-available stdlib scope function), this reproduces the REAL
+/// shape: multiple same-named candidates, no `workspace.json` module data
+/// (Moneta's own real corpus state — confirmed no `libraries`/`dependencies`
+/// section), and no explicit import of anything relevant at all.
+#[test]
+fn find_definition_qualified_prefers_kotlin_default_import_when_ambiguous_and_unimported() {
+    use crate::types::FileData;
+    use std::sync::Arc;
+
+    let idx = Indexer::new();
+    let kotlin_jar_uri = "jar:file:///kotlin-stdlib.jar!/kotlin/StandardKt.class";
+    let decoy_jar_uri = "jar:file:///decoy-lib.jar!/com/example/Decoy.class";
+    idx.jar_definitions
+        .entry("apply".to_string())
+        .or_default()
+        .extend([
+            tower_lsp::lsp_types::Location {
+                uri: Url::parse(kotlin_jar_uri).unwrap(),
+                range: tower_lsp::lsp_types::Range::default(),
+            },
+            tower_lsp::lsp_types::Location {
+                uri: Url::parse(decoy_jar_uri).unwrap(),
+                range: tower_lsp::lsp_types::Range::default(),
+            },
+        ]);
+    idx.jar_files.insert(
+        kotlin_jar_uri.to_string(),
+        Arc::new(FileData {
+            package: Some("kotlin".to_string()),
+            ..Default::default()
+        }),
+    );
+    idx.jar_files.insert(
+        decoy_jar_uri.to_string(),
+        Arc::new(FileData {
+            package: Some("com.example".to_string()),
+            ..Default::default()
+        }),
+    );
+
+    let use_uri = Url::parse("file:///app/Show.kt").unwrap();
+    // Deliberately NO `import kotlin.apply` and no other import that would
+    // help the sibling-import-package tie-break either — matching real code,
+    // which never spells out an import for an implicit default-import.
+    idx.index_content(
+        &use_uri,
+        concat!(
+            "package app\n",
+            "class SomeBuilderResult\n",
+            "class Builder { fun build(): SomeBuilderResult = SomeBuilderResult() }\n",
+            "fun show() {\n",
+            "    Builder().build().apply { show() }\n",
+            "}\n",
+        ),
+    );
+
+    let locs = idx.find_definition_qualified("apply", Some("SomeBuilderResult"), &use_uri);
+    assert!(
+        locs.iter().any(|l| l.uri.as_str() == kotlin_jar_uri),
+        "must prefer the kotlin default-import candidate over the decoy when \
+         ambiguous and nothing is explicitly imported; got {:?}",
+        locs.iter().map(|l| l.uri.as_str()).collect::<Vec<_>>()
+    );
+    assert!(
+        !locs.iter().any(|l| l.uri.as_str() == decoy_jar_uri),
+        "must not include the decoy candidate; got {:?}",
         locs.iter().map(|l| l.uri.as_str()).collect::<Vec<_>>()
     );
 }


### PR DESCRIPTION
## Summary

- Extends `ambiguity_safe_tail_with_denylist`'s tie-break sequence with a new step between module-scoped and import-package narrowing: when an ambiguous bare-name lookup has a candidate in a package Kotlin implicitly imports for every file (`kotlin`, `kotlin.collections`, `kotlin.text`, `java.lang`, etc. — the language's own fixed default-import list), prefer it.
- Stronger, more certain evidence than the existing import-package tie-break (a coincidental sibling import, not the ambiguous name itself) — it's a language-level guarantee, not project-specific data that could be stale or absent.
- Concrete real-world case: `apply`/`run` (Kotlin's own scope functions) collide with hundreds of unrelated same-named JVM/Android members (`java.util.function.Function.apply`, `Runnable.run`, countless builder `.apply()` methods) across a real dependency graph. Real code virtually never writes `import kotlin.apply` (it's an implicit default import, never spelled out) — unlike the earlier `Deferred`/`kotlinx.coroutines.async` case that PR #302's import-package tie-break was built for, there was no sibling-import evidence here to work with. This is the more general fix the `apply`/`run` investigation should have landed on the first time.
- Ordering: after module-scoped narrowing (real Gradle dependency data, most precise when available), before import-package narrowing (weakest of the three). Threads the narrowed set forward exactly like module-scoped narrowing already had to (PR #308's fix) — a candidate an earlier, stronger tie-break already ruled out must never be resurrected by this weaker, language-level heuristic.

## Real corpus measurement

Full before/after on the same Moneta corpus state (13,247 files):

| | Before | After | Delta |
|---|---|---|---|
| member-ref recall | 88.7% | 89.6% | +0.9pp |
| bare-ref recall | 71.5% | 73.3% | **+1.8pp** |
| Gap total (member+bare) | 239,669 | 224,112 | **−15,557** |
| combined resolved count | 717,959 | 733,582 | **+15,623** |

The single largest swing of any fix this session except PR #302's import-sibling tie-break, and for the same underlying reason: the mechanism generalizes far beyond the one name (`apply`) that motivated it. `apply` itself drops completely out of the top-20 gap list (was 558-622 occurrences).

## Test plan

- [x] New regression test proving the core fix, RED-verified (temporarily no-op'd the new tie-break, confirmed "declined as ambiguous", restored)
- [x] New regression test proving the ordering discipline (module-scoped narrowing survives into this tie-break, same as PR #308's own guarantee) — verified meaningful by reintroducing the exact threading bug by hand and confirming it fails
- [x] `cargo test` — 1894 pass, 0 failed
- [x] `cargo fmt --check`, `cargo clippy --tests -- -D warnings` — clean
- [x] Full before/after resolution-accuracy measurement on real Moneta corpus (above)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01CXHAR25HwqxCjg33D38NTV