### PR TITLE
fix(resolve): count star imports as evidence in import_package_tie_break

### DIFF
--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -700,10 +700,10 @@ fn module_scoped_tie_break(
 
 /// Third tie-break for [`ambiguity_safe_tail_with_denylist`]: when the
 /// denylist and module-scoped narrowing still leave more than one candidate,
-/// narrow using `origin_uri`'s own explicit (non-star) imports — not of the
-/// ambiguous name itself (`resolve_via_imports` already tried that, earlier
-/// in the chain, and failed, or this tail would never have been reached) but
-/// of any OTHER symbol from the same package. A file that writes `import
+/// narrow using `origin_uri`'s own imports — not of the ambiguous name
+/// itself (`resolve_via_imports` already tried that, earlier in the chain,
+/// and failed, or this tail would never have been reached) but of any OTHER
+/// symbol from the same package. A file that writes `import
 /// kotlinx.coroutines.async` but never spells out `Deferred` (used only
 /// through inference, e.g. `scope.async { }.await()`) still tells us
 /// `kotlinx.coroutines` is a real, in-use package for this file — evidence
@@ -714,7 +714,15 @@ fn module_scoped_tie_break(
 /// needs no `workspace.json` data at all — narrows real cases that
 /// module-scoping can't when a workspace has no module-dependency data
 /// loaded (e.g. a `workspace.json` with only `sourcePaths`, no `libraries`).
-fn import_package_tie_break(
+///
+/// A star import (`import com.foo.bar.*`) counts too, as evidence for its
+/// own exact package only: `ImportEntry::full_path` for a star import is
+/// already the bare package (there's no trailing symbol segment to strip,
+/// unlike a non-star import's `full_path`), so it's used as-is rather than
+/// through [`import_package_prefix`] — passing a star import's `full_path`
+/// through that helper would wrongly strip its own last segment as if it
+/// were an imported symbol, over-widening `com.foo.bar` to `com.foo`.
+pub(super) fn import_package_tie_break(
     indexer: &Indexer,
     origin_uri: &Url,
     locations: Vec<Location>,
@@ -725,8 +733,13 @@ fn import_package_tie_break(
     let imported_packages: std::collections::HashSet<String> = file_data
         .imports
         .iter()
-        .filter(|i| !i.is_star)
-        .map(|i| import_package_prefix(&i.full_path))
+        .map(|i| {
+            if i.is_star {
+                i.full_path.clone()
+            } else {
+                import_package_prefix(&i.full_path)
+            }
+        })
         .collect();
     if imported_packages.is_empty() {
         return vec![];

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -649,6 +649,71 @@ fn module_scoped_narrowing_survives_into_default_kotlin_import_tie_break() {
     );
 }
 
+/// `import_package_tie_break` must treat a star import (`import
+/// com.example.blib.*`) as real narrowing evidence for its own exact
+/// package, same as an explicit non-star sibling import — a wildcard import
+/// is just as much proof the calling file has visibility into that package.
+/// Before this fix the function filtered `is_star` imports out entirely, so
+/// a file relying only on a wildcard import contributed zero evidence and
+/// this tie-break declined outright (`vec![]`), losing an otherwise-unique
+/// answer.
+///
+/// Calls `import_package_tie_break` directly rather than going through
+/// `resolve_symbol_index_only` end-to-end (the pattern the sibling tests
+/// above use): `resolve_chain`'s own earlier star-import step (step 4,
+/// `find_in_star_imports`) already resolves any candidate whose *own* name
+/// is directly found by scanning a star-imported package, before the
+/// ambiguity tail is ever reached — so a same-name candidate set staged via
+/// `jar_definitions` would be resolved by that earlier step regardless of
+/// this fix, making the outer test a false positive. Calling the tie-break
+/// directly isolates the exact narrowing logic under test.
+#[test]
+fn star_import_narrows_import_package_tie_break() {
+    let idx = Indexer::new();
+    let a_uri = gradle_cache_jar_uri("com.example.a", "a-lib", "1.0.0");
+    let b_uri = gradle_cache_jar_uri("com.example.b", "b-lib", "1.0.0");
+    idx.jar_files.insert(
+        a_uri.to_string(),
+        std::sync::Arc::new(crate::types::FileData {
+            package: Some("com.example.alib".to_owned()),
+            ..Default::default()
+        }),
+    );
+    idx.jar_files.insert(
+        b_uri.to_string(),
+        std::sync::Arc::new(crate::types::FileData {
+            package: Some("com.example.blib".to_owned()),
+            ..Default::default()
+        }),
+    );
+
+    // The calling file has ONLY a wildcard import of B's exact package — no
+    // explicit sibling import at all.
+    let host_uri = uri("/Host.kt");
+    idx.index_content(&host_uri, "package com.pkg\nimport com.example.blib.*\n");
+
+    let locations = vec![
+        tower_lsp::lsp_types::Location {
+            uri: a_uri,
+            range: Default::default(),
+        },
+        tower_lsp::lsp_types::Location {
+            uri: b_uri.clone(),
+            range: Default::default(),
+        },
+    ];
+    let narrowed = resolve::import_package_tie_break(&idx, &host_uri, locations);
+    assert_eq!(
+        narrowed,
+        vec![tower_lsp::lsp_types::Location {
+            uri: b_uri,
+            range: Default::default(),
+        }],
+        "a wildcard import of B's exact package should narrow the ambiguity \
+         to B, same as an explicit non-star sibling import would, got {narrowed:?}"
+    );
+}
+
 /// Same guarantee as `resolve_symbol_index_only_never_spawns_rg_or_fd`, but
 /// for a qualified lookup (`resolve_qualified`'s uppercase branch) — Copilot
 /// review on PR #274: `resolve_qualified` resolved its qualifier root via the


### PR DESCRIPTION
## Summary
- `import_package_tie_break` (the weakest/last tie-break in `ambiguity_safe_tail_with_denylist`, `src/resolver/resolve.rs`) filtered out star imports (`.filter(|i| !i.is_star)`) when building its narrowing-evidence set, so a file relying only on a wildcard import (`import com.foo.bar.*`) contributed zero evidence — even though a wildcard import is real, unambiguous proof the file has visibility into that exact package.
- Fix extends the evidence set to include star-imported packages, matched exactly (a star import of `com.foo.bar.*` only counts as evidence for package `com.foo.bar`, never a prefix/suffix of it). Star imports' `ImportEntry::full_path` is already the bare package (no trailing symbol to strip), so it's used as-is rather than through `import_package_prefix` (which assumes a trailing symbol segment and would otherwise wrongly widen `com.foo.bar` to `com.foo`).
- This function is empirically the workhorse of the whole tie-break chain on the real Moneta corpus (decides ~62% of cases the chain resolves at all), so even this small addition is worth having, though the measured net effect on Moneta's recall was flat (see below) — Moneta leans on explicit imports.

## Test plan
- [x] New RED→GREEN unit test `star_import_narrows_import_package_tie_break` (`src/resolver/tests.rs`) calls `import_package_tie_break` directly (bumped to `pub(super)`) rather than through `resolve_symbol_index_only` end-to-end like its sibling tests — `resolve_chain`'s earlier star-import step already resolves same-name candidates directly from a star-imported package before the ambiguity tail is ever reached, so an end-to-end test with jar_definitions-staged candidates would pass even without this fix (verified this concretely before writing the direct test).
- [x] `cargo fmt`
- [x] `cargo clippy --tests -- -D warnings` — clean
- [x] `cargo test --bin kmp-lsp` — 1895 passed, 0 failed, 3 ignored
- [x] `cargo build --release --bin kmp-lsp` + `resolution-accuracy` against `~/Work/Moneta/android`: bare recall held at 73.3% across 3 runs (before + 2 after); member recall bounced 89.2%–89.8% across identical-code reruns due to corpus-scan noise (total ref counts vary by hundreds run-to-run) — no signal distinguishable from that noise band. Consistent with the expectation that Moneta leans on explicit (non-star) imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ