### PR TITLE
fix(resolve): give JAR-derived Java methods real arity and every overload

### DIFF
--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
@@ -480,7 +480,23 @@ private class JavaClassVisitor(private val entries: MutableList<SymbolEntry>, pr
         val isBridge = (access and Opcodes.ACC_BRIDGE) != 0
         if (!isPublic || isSynthetic || isBridge || name == "<init>" || name == "<clinit>") return null
         if (name.contains('$')) return null
-        entries += SymbolEntry(name, "fun", className, "fun $name(...)", pkg = pkg, topLevel = false)
+        // Real per-param types from the descriptor -- NOT a "(...)" placeholder.
+        // Rust's `params_from_detail` parses this `detail` text to compute each
+        // symbol's `(required, total)` arity for call-site shape filtering; a
+        // literal "..." (no comma) always parsed as exactly one required param,
+        // so every plain-Java (non-Kotlin-metadata) method -- 0-arg, 2-arg,
+        // overloaded, whatever its real signature -- silently reported arity
+        // (1, 1). A real 0-arg or 2+-arg call site (e.g. `Assert.fail()`,
+        // `Assert.assertEquals(a, b)`) then failed arity-based shape filtering
+        // and fell through to a Gap/FilteredCandidate resolution outcome.
+        val isVarargs = (access and Opcodes.ACC_VARARGS) != 0
+        val argTypes = org.objectweb.asm.Type.getArgumentTypes(descriptor)
+        val paramsText = argTypes.mapIndexed { i, t ->
+            val typeName = t.className.substringAfterLast('.')
+            val prefix = if (isVarargs && i == argTypes.size - 1) "vararg " else ""
+            "$prefix p$i: $typeName"
+        }.joinToString(", ")
+        entries += SymbolEntry(name, "fun", className, "fun $name($paramsText)", pkg = pkg, topLevel = false)
         return null
     }
 

--- a/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
+++ b/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
@@ -120,6 +120,60 @@ class IndexerTest {
     }
 
     @Test
+    @DisplayName("indexClassBytes encodes a Java method's real parameter count, not a placeholder (Assert.fail-shaped bug)")
+    fun testJavaMethodParameterCountExtraction() {
+        // Real-world motivating case: org.junit.Assert.fail()/assertEquals(String, String)
+        // -- static, Java-only methods (no Kotlin metadata). The Java fallback path
+        // used to emit a literal "fun fail(...)" placeholder for EVERY method regardless
+        // of real arity, which Rust's `params_from_detail` parses as exactly one
+        // required param ("..." has no comma) -- every JAR-derived Java method appeared
+        // to always take exactly 1 argument, so a real 0-arg or 2-arg call site was
+        // wrongly arity-filtered out downstream (`shape_filter_locations`).
+        val cw = org.objectweb.asm.ClassWriter(0)
+        cw.visit(
+            org.objectweb.asm.Opcodes.V1_8,
+            org.objectweb.asm.Opcodes.ACC_PUBLIC,
+            "org/junit/Assert",
+            null,
+            "java/lang/Object",
+            null
+        )
+        val zeroArg = cw.visitMethod(
+            org.objectweb.asm.Opcodes.ACC_PUBLIC or org.objectweb.asm.Opcodes.ACC_STATIC,
+            "fail", "()V", null, null
+        )
+        zeroArg.visitCode()
+        zeroArg.visitInsn(org.objectweb.asm.Opcodes.RETURN)
+        zeroArg.visitMaxs(0, 0)
+        zeroArg.visitEnd()
+
+        val twoArg = cw.visitMethod(
+            org.objectweb.asm.Opcodes.ACC_PUBLIC or org.objectweb.asm.Opcodes.ACC_STATIC,
+            "assertEquals", "(Ljava/lang/String;Ljava/lang/String;)V", null, null
+        )
+        twoArg.visitCode()
+        twoArg.visitInsn(org.objectweb.asm.Opcodes.RETURN)
+        twoArg.visitMaxs(0, 0)
+        twoArg.visitEnd()
+        cw.visitEnd()
+
+        val result = indexClassBytes(cw.toByteArray())
+
+        val failEntry = result.firstOrNull { it.name == "fail" && it.kind == "fun" }
+        assertTrue(failEntry != null, "should find the fail() overload; got: ${result.map { it.name }}")
+        assertFalse(
+            failEntry!!.detail.contains("..."),
+            "0-arg fail() must not encode a '...' placeholder that always parses as 1 required param; got detail=${failEntry.detail}"
+        )
+
+        val assertEqualsEntry = result.firstOrNull { it.name == "assertEquals" && it.kind == "fun" }
+        assertTrue(assertEqualsEntry != null, "should find the assertEquals overload; got: ${result.map { it.name }}")
+        val paramCount = assertEqualsEntry!!.detail.substringAfter('(').substringBeforeLast(')')
+            .split(',').count { it.isNotBlank() }
+        assertEquals(2, paramCount, "2-arg assertEquals must encode 2 real params; got detail=${assertEqualsEntry.detail}")
+    }
+
+    @Test
     @DisplayName("indexClassBytes extracts a public static final field via the Java fallback path (no Kotlin metadata)")
     fun testJavaPublicFieldExtraction() {
         // Mirrors android.jar's own motivating example: Activity.RESULT_OK is a

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -59,7 +59,14 @@ use crate::sidecar::SidecarSymbol;
 ///      compiled enum class's own constants (`BufferOverflow.DROP_OLDEST`) —
 ///      a cached pre-v17 JAR's entries lack them, so older caches must be
 ///      rejected and rescanned.
-const JAR_CACHE_VERSION: u32 = 18;
+/// v18 → v19: `JavaClassVisitor.visitMethod` (pure-Java, no-Kotlin-metadata
+///            fallback path) now emits each method's real per-parameter types
+///            instead of a literal `"(...)"` placeholder — a pre-v19 cache's
+///            Java-only-library methods (e.g. `org.junit.Assert.fail`/
+///            `assertEquals`) all carry the wrong `(1, 1)` arity (parsed from
+///            the placeholder's single `...` "parameter"), so older caches
+///            must be rejected and rescanned.
+const JAR_CACHE_VERSION: u32 = 19;
 
 #[derive(Serialize, Deserialize)]
 struct JarCache {

--- a/src/resolver/find.rs
+++ b/src/resolver/find.rs
@@ -152,12 +152,16 @@ pub(crate) fn find_name_scoped_to_container(
 /// failed arity-based shape filtering for nearly every real call site, since
 /// callers overwhelmingly use the OTHER overloads.
 ///
-/// Only widens the primary range-containment path — the degenerate-range
-/// (JAR stub) fallback still returns at most one candidate, same as before;
-/// broadening overload support there needs sidecar-side changes (the JAR
-/// indexer would need to preserve each overload as a distinct symbol
-/// candidate), a separate, larger effort not needed for the real-world
-/// pure-Java-source case this was measured against.
+/// Widens both the primary range-containment path AND the degenerate-range
+/// (JAR stub) fallback — a JAR-derived class's synthetic `FileData` is flat
+/// (every symbol gets its own single-line `range == selection_range`), so a
+/// class's own range never truly *encloses* its members and the
+/// range-containment path always misses for it, falling through to the
+/// `container`-field match below. Real, measured bug this fixes: JUnit's
+/// `org.junit.Assert.fail()`/`.assertEquals(a, b)` (0-arg and 2-arg calls)
+/// resolved to nothing — the old fallback (`find_name_in_uri_after_line`)
+/// returned only the ONE closest same-named entry after the class's own
+/// synthetic line, silently dropping every other real overload.
 pub(crate) fn find_all_names_scoped_to_container(
     idx: &Indexer,
     name: &str,
@@ -195,6 +199,27 @@ pub(crate) fn find_all_names_scoped_to_container(
         .collect();
     if !contained.is_empty() {
         return contained;
+    }
+
+    // Degenerate-range (JAR stub) container: match every same-named symbol
+    // whose own `container` field (the sidecar's recorded immediate enclosing
+    // class, e.g. "Assert") names this container's bare symbol name — the
+    // one linkage JAR-derived symbols DO carry, in place of a real enclosing
+    // range.
+    let by_container: Vec<Location> = file_data
+        .symbols
+        .iter()
+        .filter(|symbol| {
+            symbol.name == name
+                && symbol.container.as_deref() == Some(container_symbol.name.as_str())
+        })
+        .map(|found| Location {
+            uri: container.uri.clone(),
+            range: found.selection_range,
+        })
+        .collect();
+    if !by_container.is_empty() {
+        return by_container;
     }
 
     find_name_in_uri_after_line(

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -6216,6 +6216,100 @@ fn find_definition_qualified_returns_all_overload_candidates() {
     );
 }
 
+/// Same bug class as [`find_definition_qualified_returns_all_overload_candidates`],
+/// but for a JAR-derived (compiled) class -- real, measured Moneta gap:
+/// `org.junit.Assert.fail()`/`.assertEquals(a, b)` (0-arg and 2-arg calls)
+/// resolved to nothing.
+///
+/// A JAR-derived class's synthetic `FileData` is flat: every symbol gets its
+/// own single-line `range == selection_range`, so a class's own "container"
+/// symbol range never truly *encloses* its members the way a real parsed
+/// source file's does. `find_all_names_scoped_to_container`'s primary
+/// range-containment path therefore always misses for a JAR class, falling
+/// through to `find_name_in_uri_after_line` -- which, before this fix,
+/// returned only the ONE closest same-named entry after the class's own
+/// line, silently dropping every other overload. A real call site to any
+/// overload OTHER than that one arbitrary pick always failed arity-based
+/// shape filtering downstream.
+#[test]
+fn find_definition_qualified_returns_all_jar_overload_candidates() {
+    let idx = Indexer::new();
+    let compiled = vec![
+        jar_sidecar_symbol(
+            "Assert",
+            "class",
+            "",
+            "class org.junit.Assert",
+            "org.junit",
+            false,
+        ),
+        // Deliberately list the 1-arg overload FIRST, matching real JUnit
+        // source order (`fail(String)` declared before `fail()`) -- the old
+        // "closest line after the class" fallback would pick this one and
+        // permanently shadow the 0-arg overload.
+        jar_sidecar_symbol(
+            "fail",
+            "fun",
+            "Assert",
+            "fun fail(p0: String)",
+            "org.junit",
+            false,
+        ),
+        jar_sidecar_symbol("fail", "fun", "Assert", "fun fail()", "org.junit", false),
+        jar_sidecar_symbol(
+            "assertEquals",
+            "fun",
+            "Assert",
+            "fun assertEquals(p0: Object, p1: Object, p2: Object)",
+            "org.junit",
+            false,
+        ),
+        jar_sidecar_symbol(
+            "assertEquals",
+            "fun",
+            "Assert",
+            "fun assertEquals(p0: Object, p1: Object)",
+            "org.junit",
+            false,
+        ),
+    ];
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        "/home/test/.gradle/caches/junit-4.13.2.jar".as_ref(),
+        &compiled,
+    );
+
+    let use_uri = Url::parse("file:///app/SomeTest.kt").unwrap();
+    idx.index_content(
+        &use_uri,
+        concat!(
+            "package app\n",
+            "import org.junit.Assert\n",
+            "class SomeTest {\n",
+            "    fun t() { Assert.fail() }\n",
+            "}\n",
+        ),
+    );
+
+    let fail_locs = idx.find_definition_qualified_index_only("fail", Some("Assert"), &use_uri);
+    assert_eq!(
+        fail_locs.len(),
+        2,
+        "must return both fail() overloads from the JAR class, not collapse \
+         to the single closest-line pick; got {:?}",
+        fail_locs
+    );
+
+    let assert_eq_locs =
+        idx.find_definition_qualified_index_only("assertEquals", Some("Assert"), &use_uri);
+    assert_eq!(
+        assert_eq_locs.len(),
+        2,
+        "must return both assertEquals overloads from the JAR class; got {:?}",
+        assert_eq_locs
+    );
+}
+
 /// Primitive D (member-extension visibility): `fun Modifier.weight(...)`
 /// declared as a MEMBER of `interface ColumnScope` — the real Compose
 /// `ColumnScope`/`Modifier.weight` shape — must resolve via goto-definition


### PR DESCRIPTION
## Summary

Scout follow-up on the resolution-accuracy benchmark's `Assert.fail()`/`Assert.assertEquals()`
Gap cluster (393 combined hits on the Moneta corpus). Root-caused to two compounding bugs,
both in the JAR-derived (compiled, no source) resolution path for plain-Java classes:

1. **`java-sidecar`'s `JavaClassVisitor.visitMethod`** (the ASM fallback used for classes with
   no Kotlin `@Metadata`, e.g. JUnit's `org.junit.Assert`) rendered every method's signature as
   a literal `"fun name(...)"` placeholder — real param types were never extracted. Rust's
   `params_from_detail` parses that literal `"..."` as exactly one required parameter, so
   **every** plain-Java library method appeared to always take exactly 1 argument, regardless
   of its real signature. A real 0-arg call (`Assert.fail()`) or 2-arg call
   (`Assert.assertEquals(a, b)`) then failed arity-based shape filtering and resolved to
   nothing. Fixed by emitting each parameter's real type from the ASM method descriptor
   (marking a trailing varargs param so the existing "unbounded arity" escape hatch applies).
   Bumped `JAR_CACHE_VERSION` 18 → 19 to force a rescan.

2. Even with correct arity, `find_all_names_scoped_to_container`'s degenerate-range (JAR stub)
   fallback only ever returned **one** arbitrary overload — a JAR-derived class's synthetic
   `FileData` is flat (every symbol gets its own single-line range), so the class's own range
   never truly *encloses* its members and the primary range-containment path (PR #304's
   overload-collapse fix) always misses for it, falling through to a single-candidate line
   scan. A real call to any overload other than that one arbitrary pick still failed. Fixed by
   also matching every same-named symbol whose sidecar-recorded `container` field names the
   class, before falling back to the line-scan.

Neither bug is the same issue as the sibling `fix/nested-type-leaf-chain` work (a receiver/
qualifier chain-walking gap for `Outer.Inner.leaf`-shaped access) — this is purely a
sidecar-signature-completeness + JAR-overload-candidate-collection gap. Also confirmed
distinct from PR #304 (overload `.find()` → `find_all` collapse, which this extends rather
than duplicates) and PR #307 (hover ambiguity decline).

## Real-corpus measurement

Moneta (13,247 files), both fixes combined vs. main tip (post #309):

| metric | before | after |
|---|---|---|
| member recall | 89.5% (146,878/164,068) | 90.2% (147,540/163,563) |
| FilteredCandidate | ~7,000 | 6,834 |
| Gap (member) | ~10,000 | 9,189 |

`assertEquals` fully disappeared from the Gap top-20 (was 287 hits). `fail`'s only remaining
Gap hit is an unrelated field access (`liveApiProperty.fail`), not `Assert.fail()`. The fix is
systemic — it applies to every JAR-derived, no-Kotlin-metadata Java class with an overloaded
method, not just JUnit's `Assert`.

## Test plan

- [x] Sidecar RED test (`testJavaMethodParameterCountExtraction`, ASM-built fixture class)
      confirmed failing for the right reason, then GREEN after the `visitMethod` fix.
- [x] Rust RED test (`find_definition_qualified_returns_all_jar_overload_candidates`, using
      `populate_from_symbols` to build a JAR-shaped `Assert`-like fixture) confirmed failing
      for the right reason, then GREEN after the `find_all_names_scoped_to_container` fix.
- [x] `cargo fmt --check`, `cargo clippy --tests -- -D warnings` clean.
- [x] Full `cargo test --release`: 1895/1895 passing.
- [x] Real-corpus before/after measurement (table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ