### PR TITLE
fix(resolve): resolve Outer.Nested.leaf chains through a nested-type receiver

### DIFF
--- a/src/indexer/infer/expr_type_tests.rs
+++ b/src/indexer/infer/expr_type_tests.rs
@@ -554,6 +554,72 @@ fn infer_navigation_expr_type_reanchors_reachability_on_receiver_declaring_file(
 }
 
 #[test]
+fn nested_type_receiver_chain_resolves_end_to_end() {
+    // `R.drawable.ic_account`: `R` is a top-level (JAR-indexed) class,
+    // `drawable` a nested class of `R` (not a field), `ic_account` a
+    // property of `drawable`. Full CST-to-type-inference path, not just the
+    // underlying `find_field_type_in_class` unit — see
+    // `indexer::jar_tests::nested_type_member_access_resolves_through_outer_type`
+    // for the isolated resolver-level test.
+    use crate::indexer::jar::populate_from_symbols;
+    use crate::indexer::Indexer;
+    use crate::queries::KIND_NAV_EXPR;
+    use crate::sidecar::SidecarSymbol;
+
+    fn find_outermost_nav_expr(node: tree_sitter::Node) -> Option<tree_sitter::Node> {
+        if node.kind() == KIND_NAV_EXPR {
+            return Some(node);
+        }
+        let mut cursor = node.walk();
+        let found = node.children(&mut cursor).find_map(find_outermost_nav_expr);
+        found
+    }
+
+    fn sidecar_symbol(name: &str, kind: &str, detail: &str, container: &str) -> SidecarSymbol {
+        SidecarSymbol {
+            name: name.to_owned(),
+            kind: kind.to_owned(),
+            container: container.to_owned(),
+            detail: detail.to_owned(),
+            doc: String::new(),
+            type_params: Vec::new(),
+            extension_receiver_type: String::new(),
+            trailing_lambda: false,
+            deprecated: false,
+            pkg: String::new(),
+            top_level: container.is_empty(),
+            supers: vec![],
+        }
+    }
+
+    let idx = Indexer::new();
+    let symbols = vec![
+        sidecar_symbol("R", "class", "class com.example.R", ""),
+        sidecar_symbol("drawable", "class", "class com.example.R.drawable", "R"),
+        // Matches the sidecar's real Java-fallback output for a plain
+        // `public static int` field: lowercase JVM primitive name, not the
+        // Kotlin-visible "Int" (see `kotlin_primitive_type_name`).
+        sidecar_symbol("ic_account", "val", "val ic_account: int", "drawable"),
+    ];
+    populate_from_symbols(
+        &idx,
+        "/home/test/.gradle/caches/app-r-jar/R.jar".as_ref(),
+        &symbols,
+    );
+
+    let caller_uri = test_url();
+    let caller_src = "fun f() = R.drawable.ic_account\n";
+    let (tree, bytes) = fun_body_expr_node(caller_src);
+    let expr = find_outermost_nav_expr(tree.root_node()).expect("R.drawable.ic_account not parsed");
+
+    assert_eq!(
+        infer_expr_type(expr, &bytes, &idx, &caller_uri).as_deref(),
+        Some("Int"),
+        "R.drawable.ic_account must resolve through the nested type R.drawable"
+    );
+}
+
+#[test]
 fn unknown_identifier_returns_none() {
     // An unregistered variable → no type known
     assert_eq!(

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -1709,6 +1709,50 @@ fn jar_nested_class_fqn_in_qualified_index() {
 }
 
 #[test]
+fn nested_type_member_access_resolves_through_outer_type() {
+    // `R.drawable.ic_account`: `R` is a top-level class, `drawable` a nested
+    // CLASS of `R` (not a field), `ic_account` a property of `drawable`.
+    // Regression for the #1 concentrated member-ref Gap in the
+    // resolution-accuracy benchmark (Android's generated `R` class, but the
+    // shape is general: any `Outer.Nested.leaf` chain where `Nested` is
+    // itself a nested type, not a value).
+    let indexer = idx();
+    let jar_path = "/home/test/.gradle/caches/app-r-jar/R.jar";
+
+    let symbols = vec![
+        make_sidecar_symbol("R", "class", "class com.example.R", ""),
+        make_sidecar_symbol("drawable", "class", "class com.example.R.drawable", "R"),
+        // Matches the sidecar's real Java-fallback output for a plain
+        // `public static int` field: the JVM primitive name is lowercase
+        // ("int"), not the Kotlin-visible "Int" — see
+        // `kotlin_primitive_type_name` in `resolver::infer_lines`.
+        make_sidecar_symbol("ic_account", "val", "val ic_account: int", "drawable"),
+    ];
+    populate_from_symbols(&indexer, jar_path.as_ref(), &symbols);
+
+    let uri = Url::parse("file:///src/Caller.kt").unwrap();
+
+    // `drawable` is a nested TYPE of `R`, not a field — `field_type("R",
+    // "drawable", ...)` must resolve to that nested type, not None.
+    let nested_type = crate::resolver::Resolver::field_type(&indexer, "R", "drawable", &uri);
+    assert!(
+        nested_type.is_some(),
+        "R.drawable must resolve as a nested-type receiver, got None"
+    );
+    let (nested_type_name, _) = nested_type.unwrap();
+
+    // And the final hop, `.ic_account` on that nested type, must resolve too
+    // — to "Int", the Kotlin-visible name for the field's raw Java "int".
+    let leaf_type =
+        crate::resolver::Resolver::field_type(&indexer, &nested_type_name, "ic_account", &uri);
+    assert_eq!(
+        leaf_type.map(|(t, _)| t).as_deref(),
+        Some("Int"),
+        "R.drawable.ic_account must resolve through the nested type {nested_type_name:?}, got None"
+    );
+}
+
+#[test]
 fn jar_enum_constant_resolves_with_enum_member_kind() {
     // The sidecar now emits an "enum_member" SymbolEntry for each of a
     // JAR-compiled enum class's own constants (see KotlinClassIndexer.kt's

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -1173,6 +1173,51 @@ fn find_field_type_in_class_impl(
             return Some((field_type, location.uri.clone()));
         }
     }
+    // Fallback: JAR-indexed classes carry ALL their members (including
+    // compiled properties like `R.drawable`'s resource constants) as flat
+    // symbol-table entries rather than real source text, so the two
+    // text-scanning loops above never see them (`infer_field_type_raw` reads
+    // `indexer.files`/disk, never `indexer.jar_files`). Read the symbol table
+    // directly, scoped to `field_name` entries whose own `container` is
+    // `class_name`'s bare (last-segment) name — `s.container` is only
+    // populated by the JAR sidecar, so this is a no-op for real source files
+    // (already covered by the loops above).
+    //
+    // This also covers `field_name` naming a nested TYPE of `class_name`, not
+    // a field — e.g. `R.drawable` where `drawable` is a nested class of `R`
+    // (Android's generated resource class; the same shape applies to any
+    // user-defined `Outer.Nested` reference, not just `R`). Mirrors
+    // `infer_ident_type`'s bare-uppercase-resolves-to-itself trick one level
+    // up the chain: the member's "type" becomes the nested type itself, so
+    // the next hop in the chain (`.leaf`) can search inside it.
+    let class_base = class_name.rsplit('.').next().unwrap_or(class_name);
+    for location in &candidates {
+        let Some(file_data) = ensure_file_data(indexer, &location.uri) else {
+            continue;
+        };
+        let Some(sym) = file_data
+            .symbols
+            .iter()
+            .find(|s| s.name == field_name && s.container.as_deref() == Some(class_base))
+        else {
+            continue;
+        };
+        if matches!(
+            sym.kind,
+            SymbolKind::CLASS
+                | SymbolKind::INTERFACE
+                | SymbolKind::ENUM
+                | SymbolKind::OBJECT
+                | SymbolKind::STRUCT
+        ) {
+            return Some((format!("{class_name}.{field_name}"), location.uri.clone()));
+        }
+        if matches!(sym.kind, SymbolKind::PROPERTY | SymbolKind::VARIABLE) {
+            if let Some(type_name) = extract_property_type_from_detail(&sym.detail) {
+                return Some((type_name, location.uri.clone()));
+            }
+        }
+    }
     None
 }
 

--- a/src/resolver/infer_lines.rs
+++ b/src/resolver/infer_lines.rs
@@ -423,11 +423,36 @@ pub(super) fn has_dot_after_first_call(rhs: &str, paren_pos: usize) -> bool {
     false
 }
 
+/// Map a JVM primitive type's Java-spelled name to the name Kotlin code
+/// actually uses for it. The sidecar's pure-Java fallback (`JavaClassVisitor`
+/// in `KotlinClassIndexer.kt`) reads a field's type straight off its ASM
+/// `Type.className` — lowercase for a primitive (`"int"`, `"boolean"`, …) —
+/// so a plain Java field like `public static int ic_account` (Android's
+/// generated `R$drawable`, but any Java class's own `int`/`boolean`/…
+/// field hits the same shape) would otherwise never pass
+/// [`extract_property_type_from_detail`]'s uppercase check below.
+fn kotlin_primitive_type_name(java_name: &str) -> Option<&'static str> {
+    Some(match java_name {
+        "int" => "Int",
+        "boolean" => "Boolean",
+        "long" => "Long",
+        "float" => "Float",
+        "double" => "Double",
+        "byte" => "Byte",
+        "short" => "Short",
+        "char" => "Char",
+        "void" => "Unit",
+        _ => return None,
+    })
+}
+
 /// Parse the declared type from a property `SymbolEntry.detail` string.
 ///
 /// `"val ViewModel.viewModelScope: CoroutineScope get() = ..."` → `"CoroutineScope"`
 /// `"val items: List<Product>"` → `"List<Product>"`
 /// `"var count: Int"` → `"Int"`
+/// `"val ic_account: int"` → `"Int"` (Java primitive field, see
+/// [`kotlin_primitive_type_name`])
 ///
 /// Finds the first `:` after the property name (skipping any receiver `Receiver.`)
 /// then uses [`extract_type_with_generics`] to grab the type token.
@@ -458,6 +483,9 @@ pub(crate) fn extract_property_type_from_detail(detail: &str) -> Option<String> 
     })?;
     let type_part = after_kw[colon_pos + 1..].trim_start();
     let type_name = extract_type_with_generics(type_part);
+    if let Some(primitive) = kotlin_primitive_type_name(&type_name) {
+        return Some(primitive.to_owned());
+    }
     if !type_name.is_empty() && type_name.starts_with_uppercase() {
         Some(type_name)
     } else {

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -373,6 +373,27 @@ fn property_type_simple() {
     );
 }
 
+// Regression: the sidecar's pure-Java fallback (`JavaClassVisitor` in
+// `KotlinClassIndexer.kt`) reads a field's type off ASM's `Type.className`,
+// which is lowercase for a JVM primitive ("int", not "Int") — e.g. Android's
+// generated `R$drawable.ic_account: int`. Without `kotlin_primitive_type_name`
+// this fails the uppercase check and silently drops the field's type.
+#[test]
+fn property_type_java_int_primitive_maps_to_kotlin_int() {
+    assert_eq!(
+        extract_property_type_from_detail("val ic_account: int"),
+        Some("Int".into()),
+    );
+}
+
+#[test]
+fn property_type_java_boolean_primitive_maps_to_kotlin_boolean() {
+    assert_eq!(
+        extract_property_type_from_detail("var enabled: boolean"),
+        Some("Boolean".into()),
+    );
+}
+
 #[test]
 fn property_type_no_keyword_returns_none() {
     assert_eq!(

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -2080,10 +2080,17 @@ fn resolve_same_package(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Locatio
     crate::indexer::jar::ensure_jar_definitions_for(indexer, name, &mut cache_backed_only);
     if let Some(locs) = indexer.jar_definitions.get(name) {
         for loc in locs.iter() {
-            if let Some(f) = indexer.jar_files.get(loc.uri.as_str()) {
-                if f.package.as_ref() == Some(&pkg) {
-                    return vec![loc.clone()];
-                }
+            // `jar_symbol_package` (the sidecar's real per-symbol package)
+            // first, NOT `indexer.jar_files.get(...).package` — that whole-JAR
+            // fallback is `build_jar_file_data`'s guess from the FIRST
+            // class-like symbol's `detail` text, which the sidecar's
+            // pure-Java fallback (`JavaClassVisitor`, e.g. Android's
+            // AAPT-generated `R.jar`) never includes a package in (`"class
+            // R"`, not `"class pkg.R"`) — so for a jar like that, this same-
+            // package check could never fire at all without the per-symbol
+            // table, regardless of how many symbols really live in `pkg`.
+            if location_package(indexer, loc).as_ref() == Some(&pkg) {
+                return vec![loc.clone()];
             }
         }
     }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -864,6 +864,71 @@ fn resolve_does_not_cross_packages_without_import() {
     );
 }
 
+/// Regression: `resolve_same_package`'s JAR branch used to check
+/// `indexer.jar_files.get(loc.uri).package` — the whole-JAR fallback package
+/// `build_jar_file_data` infers from the FIRST class-like symbol's `detail`
+/// text. The sidecar's pure-Java fallback (`JavaClassVisitor` in
+/// `KotlinClassIndexer.kt`, used for AAPT-generated classes like Android's
+/// `R` — no Kotlin metadata) emits a *bare* class detail (`"class R"`, not
+/// `"class pkg.R"` the way the Kotlin-metadata path does) — so that
+/// whole-JAR inference always fails (no dot to split on) and the same-package
+/// JAR check could never fire for an `R.jar`-shaped compiled JAR, no matter
+/// how many symbols shared its real package. The fix reads each symbol's own
+/// *real* package via `jar_symbol_package` (the sidecar's per-symbol `pkg`
+/// side table — see `location_package`) instead.
+#[test]
+fn resolve_same_package_finds_jar_symbol_with_bare_class_detail() {
+    use crate::sidecar::SidecarSymbol;
+
+    let sym = |name: &str, kind: &str, container: &str, detail: &str, pkg: &str| SidecarSymbol {
+        name: name.to_owned(),
+        kind: kind.to_owned(),
+        container: container.to_owned(),
+        detail: detail.to_owned(),
+        doc: String::new(),
+        type_params: vec![],
+        extension_receiver_type: String::new(),
+        trailing_lambda: false,
+        deprecated: false,
+        pkg: pkg.to_owned(),
+        top_level: container.is_empty(),
+        supers: vec![],
+    };
+    let idx = Indexer::new();
+    // Two Android modules, each with its own AAPT-generated `R.jar` in its
+    // own package — the real-world shape (a real workspace has one such JAR
+    // per module). Bare `detail` text throughout, exactly as
+    // `JavaClassVisitor.visit()`/`visitField()` emit it for a pure-Java class
+    // (no package prefix) — unlike the Kotlin-metadata path's `"class pkg.Name"`.
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/commonui-R.jar"),
+        &[sym("R", "class", "", "class R", "cz.moneta.commonui")],
+    );
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/other-R.jar"),
+        &[sym("R", "class", "", "class R", "com.other.app")],
+    );
+
+    let caller_uri = uri("/cz/moneta/commonui/DrawableMap.kt");
+    idx.index_content(&caller_uri, "package cz.moneta.commonui\nval x = R\n");
+
+    let locs = resolve_symbol(&idx, "R", None, &caller_uri);
+    assert!(
+        !locs.is_empty(),
+        "same-package resolution must find the JAR-indexed R even though \
+         its whole-JAR fallback package is unknown (bare class detail)"
+    );
+    assert!(
+        locs[0].uri.as_str().contains("commonui-R.jar"),
+        "must resolve to the caller's OWN module's R (matching its real \
+         per-symbol package), not an unrelated same-named R from another \
+         module's jar — got {:?}",
+        locs[0]
+    );
+}
+
 // ── resolve_qualified (dot accessor) ────────────────────────────────────
 
 #[test]
@@ -1223,12 +1288,13 @@ fn resolve_qualified_uppercase_root_hierarchy_fallback_reaches_jar_superclass() 
 /// is JAR-promotion-aware the same way `resolve_from_class_hierarchy` is
 /// above, so it can walk into a JAR-derived superclass whose stub symbols
 /// carry the same degenerate `.range == .selection_range` (no real body
-/// span). Unlike a member *function* (found via the container-scoped
-/// `find_in_workspace_defs` check), a JAR class's own member *property* has
-/// no indexed-detail resolution path yet (`infer_field_type_raw` never reads
-/// `jar_files`, only workspace `files`) — the point of this test is that the
-/// walk still terminates with a clean `None` instead of panicking on the
-/// JAR stub's degenerate range, not that the property resolves.
+/// span). `find_field_type_in_class_impl`'s symbol-table fallback (added
+/// alongside the nested-type receiver fix, see
+/// `indexer::jar_tests::nested_type_member_access_resolves_through_outer_type`)
+/// now reads a JAR class's own member *property* straight from its indexed
+/// `detail` text — the point of this test is now that the walk resolves the
+/// inherited property AND still terminates cleanly instead of panicking on
+/// the JAR stub's degenerate range.
 #[test]
 fn catalog_field_type_supertype_walk_reaches_jar_superclass_without_panicking() {
     use crate::sidecar::SidecarSymbol;
@@ -1265,12 +1331,12 @@ fn catalog_field_type_supertype_walk_reaches_jar_superclass_without_panicking() 
 
     let result =
         crate::resolver::Resolver::field_type(&idx, "ConcreteViewModel", "uiState", &host_uri);
-    assert!(
-        result.is_none(),
-        "a JAR class's own member property has no indexed-detail resolution \
-         path today (unlike an extension property); the walk must return \
-         None gracefully instead of panicking on the JAR stub's degenerate \
-         range, got {result:?}"
+    assert_eq!(
+        result.map(|(type_name, _)| type_name).as_deref(),
+        Some("String"),
+        "walk into the JAR-derived superclass must resolve uiState's type \
+         from its indexed detail text without panicking on the JAR stub's \
+         degenerate range"
     );
 }
 


### PR DESCRIPTION
## Summary
- `R.drawable.ic_account`-shaped 3-segment member chains never resolved: `infer_navigation_expr_type`/`find_field_type_in_class_impl` had no fallback for a `.` receiver that is itself a reference to a nested TYPE (`R.drawable`, a nested class of `R`), not a field-typed value. Added a fallback that mirrors `infer_ident_type`'s existing bare-uppercase-resolves-to-itself trick one hop up the chain, and reads a JAR class's own member property straight from its indexed detail text.
- Fixed two more bugs surfaced while making the real `R.drawable.ic_account` case actually resolve end-to-end (neither is R-specific, both are general sidecar/resolver bugs):
  - The sidecar's pure-Java fallback (`JavaClassVisitor`, used for classes with no Kotlin metadata, e.g. AAPT-generated `R.jar`) emits a field's type as the raw lowercase JVM primitive name (`"int"`), which `extract_property_type_from_detail` silently dropped. Added a primitive-name map.
  - `resolve_same_package`'s JAR branch compared against the whole-JAR fallback package (guessed from only the first class-like symbol's detail text, which the same pure-Java fallback never populates with a package prefix) instead of the already-existing per-symbol `jar_symbol_package` lookup — so same-package JAR resolution could never fire for a JAR like `R.jar` at all, at any scale beyond a single unambiguous candidate.
- None of these are `R`-specific: the fix is general for any `Outer.Nested.leaf` chain, any Java-fallback JAR-indexed primitive field, and any same-package JAR resolution.

## Real-corpus measurement
Moneta (13,247 files), identical corpus state before/after:
- member-ref recall: 89.5% (146,878/164,068) → 89.8% (147,416/164,090)
- bare-ref recall: 73.3% (586,674/800,668) → 73.5% (588,122/800,646)
- `drawable` fully gone from the Gap top-20 (was #1 at 623 occurrences, concentrated in `DrawableMap.kt`)

## Test plan
- [x] RED tests written first, confirmed failing for the right reason, then implementation added
- [x] `cargo fmt`
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo test --release`: 1899 passed, 0 failed, 3 ignored (no regressions)
- [x] Real-corpus resolution-accuracy benchmark run before/after (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CAuS1A7Z2CehoZ2nMKFHZ