### PR TITLE
fix(resolve): fall back to a supertype-walk extension when a same-named member has the wrong arity

### DIFF
--- a/src/features/definition.rs
+++ b/src/features/definition.rs
@@ -324,7 +324,13 @@ pub(crate) async fn find_definition(
             return None;
         }
     }
-    let locs = index.find_definition_qualified(&ctx.word, ctx.qualifier.as_deref(), uri);
+    let mut locs = index.find_definition_qualified(&ctx.word, ctx.qualifier.as_deref(), uri);
+    // `resolve_qualified` can now return a wrong-arity member alongside its
+    // correct-arity extension fallback (`with_supertype_extension_fallback`)
+    // — shape-filter here too, same as the branches above.
+    if let Some(shape) = call_shape_at_callee(index, uri, position) {
+        locs = crate::indexer::shape_filter_locations(index, shape, locs).resolved();
+    }
     if !locs.is_empty() {
         return locs_to_opt_response(locs);
     }

--- a/src/features/definition_tests.rs
+++ b/src/features/definition_tests.rs
@@ -301,3 +301,49 @@ async fn goto_definition_resolves_explicit_receiver_call_to_jar_member_not_self(
          collect(scope, block) self-declaration, got: {loc:?}"
     );
 }
+
+/// Real Moneta bug (`navController.navigate(route = ...)`, `NavHostController`
+/// extends `NavController`): the receiver's CONCRETE type declares its own
+/// same-named member with a DIFFERENT, incompatible arity (`act()`, no args —
+/// standing in for `NavController.navigate(Uri)`/`navigate(NavDirections)`),
+/// while the call actually wants a same-named extension declared on an
+/// ancestor type (`Base.act(label: String)`, standing in for the Kotlin KTX
+/// `NavController.navigate(route: String, ...)` extension). Before the fix,
+/// `resolve_qualified` returned the wrong-arity member alone and never even
+/// looked at the supertype-walk extension fallback, so — once the caller's
+/// arity filter (correctly) rejected that member — resolution came up empty
+/// entirely instead of falling through to the extension. The receiver here is
+/// a plain lowercase local parameter (`d: Derived`), exercising both the
+/// CST-resolved path (`classify_cursor`/`resolve_identity`) AND `find_definition`'s
+/// own final string-qualifier fallback, since both now need the appended
+/// extension candidate to pick the right one via shape filtering.
+#[tokio::test]
+async fn goto_definition_prefers_supertype_extension_over_wrong_arity_concrete_member() {
+    let idx = Indexer::new();
+    let uri = Url::parse("file:///t/Nav.kt").unwrap();
+    let src = "open class Base\n\
+               fun Base.act(label: String): Unit = TODO()\n\
+               class Derived : Base() {\n\
+                   fun act(): Unit = TODO()\n\
+               }\n\
+               fun f(d: Derived) {\n\
+                   d.act(\"x\")\n\
+               }\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+
+    let col = src.lines().nth(6).unwrap().find("act").unwrap() as u32;
+    let position = Position::new(6, col);
+    let ctx = CursorContext::build(&idx, &uri, position).unwrap();
+    let response = find_definition(&ctx, &idx, &uri, position).await;
+    let loc = match response {
+        Some(GotoDefinitionResponse::Scalar(loc)) => loc,
+        Some(GotoDefinitionResponse::Array(mut locs)) if locs.len() == 1 => locs.remove(0),
+        other => panic!("expected exactly one resolved location, got: {other:?}"),
+    };
+    assert_eq!(
+        loc.range.start.line, 1,
+        "d.act(\"x\") (1 arg) must resolve to Base's extension act(label: \
+         String) on line 1, not Derived's own 0-arg act() on line 3, got: {loc:?}"
+    );
+}

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -1534,7 +1534,14 @@ fn resolve_qualified(
             // nothing (see `find_all_names_scoped_to_container`'s doc).
             let member_locs = find_all_names_scoped_to_container(indexer, name, &anchor);
             if !member_locs.is_empty() {
-                return member_locs;
+                return with_supertype_extension_fallback(
+                    indexer,
+                    member_locs,
+                    anchor_class_name,
+                    &anchor.uri,
+                    name,
+                    from_uri,
+                );
             }
 
             // `anchor`'s own body doesn't declare `name` — it may live on a
@@ -1669,7 +1676,17 @@ fn resolve_qualified(
     if let Some(ref resolved_uri) = current_file {
         let locs = find_name_in_uri(indexer, name, resolved_uri);
         if !locs.is_empty() {
-            return locs;
+            return match Url::parse(resolved_uri) {
+                Ok(parsed_uri) => with_supertype_extension_fallback(
+                    indexer,
+                    locs,
+                    &current_type_base,
+                    &parsed_uri,
+                    name,
+                    from_uri,
+                ),
+                Err(_) => locs,
+            };
         }
         if let Ok(parsed_uri) = Url::parse(resolved_uri) {
             let hierarchy_locs = resolve_from_class_hierarchy(indexer, name, &parsed_uri);
@@ -2267,6 +2284,36 @@ fn resolve_from_class_hierarchy_scoped(
             ))
         })
         .collect()
+}
+
+/// A same-named real member doesn't always satisfy the actual call's arity
+/// (e.g. `navController.navigate(route = ...)`: a wrong-arity JVM member
+/// `NavController.navigate(Uri)` vs. the wanted KTX extension
+/// `NavController.navigate(route: String, ...)`). Appends the supertype-walk
+/// extension after `member_locs` rather than replacing it — members still
+/// win when arity-compatible (Kotlin's own precedence), but a shape-aware
+/// caller now has the extension to fall back to instead of an empty result.
+fn with_supertype_extension_fallback(
+    indexer: &Indexer,
+    member_locs: Vec<Location>,
+    anchor_class_name: &str,
+    anchor_uri: &Url,
+    name: &str,
+    from_uri: &Url,
+) -> Vec<Location> {
+    let supertype_ext_locs = resolve_extension_via_supertype_hierarchy(
+        indexer,
+        anchor_class_name,
+        anchor_uri,
+        name,
+        from_uri,
+    );
+    if supertype_ext_locs.is_empty() {
+        return member_locs;
+    }
+    let mut combined = member_locs;
+    combined.extend(supertype_ext_locs);
+    combined
 }
 
 /// Extension-lookup counterpart to [`resolve_from_class_hierarchy_scoped`]:

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -1662,6 +1662,61 @@ fn resolve_qualified_member_on_concrete_type_still_shadows_supertype_extension()
 }
 
 #[test]
+fn resolve_qualified_appends_supertype_extension_alongside_a_wrong_arity_concrete_member() {
+    // Real Moneta bug: `navController.navigate(route = ...)` where
+    // `NavHostController`/`NavController` (the concrete receiver type and its
+    // hierarchy) also declare a same-named member with a DIFFERENT arity
+    // (real JVM overloads like `navigate(Uri)`), and the call actually wants
+    // a same-named extension declared on an ancestor (the KTX
+    // `NavController.navigate(route: String, ...)` extension). Before this
+    // fix, `resolve_qualified` returned the wrong-arity member alone and
+    // never tried the supertype-walk extension fallback at all -- once a
+    // shape-aware caller correctly rejected that member, resolution came up
+    // completely empty instead of falling through to the extension. This
+    // test is the unshaped `resolve_symbol` layer: it must now return BOTH
+    // candidates (member first, extension appended after) so a shape-aware
+    // caller has something to pick from.
+    let host_uri = uri("/Host.kt");
+    let base_uri = uri("/Base.kt");
+    let derived_uri = uri("/Derived.kt");
+    let ext_uri = uri("/BaseExtensions.kt");
+    let idx = Indexer::new();
+    idx.index_content(&base_uri, "package com.pkg\nopen class Base\n");
+    idx.index_content(
+        &derived_uri,
+        "package com.pkg\nclass Derived : Base() {\n  fun act(): String = \"member\"\n}\n",
+    );
+    idx.index_content(
+        &ext_uri,
+        "package com.pkg\nfun Base.act(label: String): String = TODO()\n",
+    );
+    idx.index_content(
+        &host_uri,
+        "package com.pkg\nfun foo(receiver: Derived) { receiver.act(\"x\") }\n",
+    );
+
+    let locs = resolve_symbol(&idx, "act", Some("Derived"), &host_uri);
+    assert_eq!(
+        locs.len(),
+        2,
+        "expected both the wrong-arity concrete member and the supertype \
+         extension as candidates, got {locs:?}"
+    );
+    assert_eq!(
+        locs[0].uri, derived_uri,
+        "the concrete member must still come first (real Kotlin member-over-\
+         extension precedence when arity isn't in question), got {:?}",
+        locs[0].uri
+    );
+    assert_eq!(
+        locs[1].uri, ext_uri,
+        "the supertype extension must be appended as the second candidate, \
+         got {:?}",
+        locs[1].uri
+    );
+}
+
+#[test]
 fn resolve_qualified_supertype_extension_fallback_threads_the_real_origin_uri() {
     // Copilot review finding on PR #289: the new supertype-extension-fallback
     // `walk_hierarchy` call passed `CallerContext::default()`, so its


### PR DESCRIPTION
## Summary
- `resolve_qualified` returned the first same-named member on a receiver type and stopped, even when the member's arity couldn't satisfy the call — e.g. `navController.navigate(route = "...")`, where `NavHostController`/`NavController` also declare unrelated-arity JVM `navigate` overloads, shadowing the wanted `NavController.navigate(route: String, ...)` extension.
- `with_supertype_extension_fallback` now appends the supertype-walk extension candidates after the member (member still wins first, matching Kotlin's own precedence), so a shape-aware caller can pick the correct-arity one instead of getting nothing back.
- `find_definition`'s own final qualified-lookup fallback previously applied no shape filtering at all — fixed to match the shape-aware branches above it.

## Test plan
- [x] 2 new regression tests: `resolve_qualified_appends_supertype_extension_alongside_a_wrong_arity_concrete_member`, `goto_definition_prefers_supertype_extension_over_wrong_arity_concrete_member`
- [x] Full suite: 1903/1903 passing, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7ZonwYUh94VsuQphiHykF